### PR TITLE
Update 2022_09_26_113708_create_products_table.php

### DIFF
--- a/database/migrations/2022_09_26_113708_create_products_table.php
+++ b/database/migrations/2022_09_26_113708_create_products_table.php
@@ -23,6 +23,7 @@ return new class extends Migration
                 $table->boolean('is_variable')->default(0);
                 $table->boolean('is_grouped')->default(0);
                 $table->boolean('is_simple')->default(1);
+                $table->boolean('is_featured')->default(0);
                 $table->string('featured_image');
                 $table->timestamps();
             });


### PR DESCRIPTION
is_featured column missing and causing error:

SQLSTATE[42S22]: Column not found: 1054 Unknown column 'is_featured' in 'where clause' 

App\Http\Controllers\HomeController:
`$featuredProducts = Product::where('is_featured', true)->get();`