### PR TITLE
Fix checkout money bugs + latent fatals; add order state machine

### DIFF
--- a/app/Exceptions/InvalidOrderTransitionException.php
+++ b/app/Exceptions/InvalidOrderTransitionException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class InvalidOrderTransitionException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $from,
+        public readonly string $to,
+    ) {
+        parent::__construct("Invalid order status transition: {$from} -> {$to}");
+    }
+}

--- a/app/Factories/PaymentGatewayFactory.php
+++ b/app/Factories/PaymentGatewayFactory.php
@@ -11,13 +11,12 @@ class PaymentGatewayFactory
 {
     public static function create(string $gateway): PaymentGatewayInterface
     {
-        switch ($gateway) {
-            case 'stripe':
-                return new StripeGateway();
-            case 'paypal':
-                return new PayPalGateway();
-            default:
-                throw new InvalidArgumentException("Unsupported payment gateway: {$gateway}");
-        }
+        // Resolve through the container so gateways are injectable (tests can bind
+        // a fake) and their own dependencies are wired.
+        return match ($gateway) {
+            'stripe' => app(StripeGateway::class),
+            'paypal' => app(PayPalGateway::class),
+            default => throw new InvalidArgumentException("Unsupported payment gateway: {$gateway}"),
+        };
     }
 }

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -202,20 +202,20 @@ class CheckoutController extends Controller
                 $paymentResult = $this->processPayPalPayment($order, $request->paypal_payment_id);
             } else {
                 $this->releaseInventory($order, $cart);
-                $order->update(['status' => 'failed']);
+                $order->transitionTo(Order::STATUS_FAILED, notes: 'Invalid payment information');
                 return redirect()->back()
                     ->with('error', 'Invalid payment information. Please try again.');
             }
 
             if (!$paymentResult['success']) {
                 $this->releaseInventory($order, $cart);
-                $order->update(['status' => 'failed']);
+                $order->transitionTo(Order::STATUS_FAILED, notes: 'Payment failed: ' . ($paymentResult['error'] ?? 'unknown'));
                 return redirect()->back()
                     ->with('error', 'Payment failed: ' . ($paymentResult['error'] ?? 'Please try again.'));
             }
         }
 
-        $order->update(['status' => 'paid']);
+        $order->transitionTo(Order::STATUS_PAID, notes: 'Payment captured');
 
         // Send order confirmation email
         Notification::route('mail', $order->customer_email)
@@ -232,11 +232,11 @@ class CheckoutController extends Controller
                 \App\Jobs\DispatchDropshippingOrder::dispatch($order->id, $supplierId);
 
                 // set temporary status indicating background placement
-                $order->update(['status' => 'supplier_queued']);
+                $order->transitionTo(Order::STATUS_SUPPLIER_QUEUED, notes: "Supplier order queued ({$supplierId})");
 
             } catch (Exception $e) {
                 \Log::error('Dropshipping dispatch error: ' . $e->getMessage());
-                $order->update(['status' => 'supplier_failed']);
+                $order->transitionTo(Order::STATUS_SUPPLIER_FAILED, notes: 'Dropshipping dispatch error: ' . $e->getMessage());
 
                 Notification::route('mail', config('mail.from.address'))
                     ->notify(new \App\Notifications\SupplierFailureNotification("Error queuing dropshipping order for order {$order->id}: " . $e->getMessage()));

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use App\Models\ShippingMethod;
 use App\Services\ShippingService;
-use App\Services\PaymentGatewayService;
 use App\Models\Order;
 use App\Models\Coupon;
 use App\Models\InventoryLog;

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
@@ -16,11 +17,16 @@ use App\Models\User;
 use Illuminate\Support\Facades\Notification;
 use App\Factories\PaymentGatewayFactory;
 use App\Models\Product;
+use App\Notifications\OrderConfirmationNotification;
 use App\Services\TaxService;
 use App\Services\CouponService;
+use Exception;
 
 class CheckoutController extends Controller
 {
+    /** Sentinel thrown inside the reservation transaction to roll it back on insufficient stock. */
+    private const OUT_OF_STOCK = 'OUT_OF_STOCK';
+
     protected $shippingService;
     protected $taxService;
     protected $couponService;
@@ -124,46 +130,86 @@ class CheckoutController extends Controller
 
         $totalAmount = $subtotal - $discountAmount + $shippingCost + $taxAmount;
 
-        // Create order
-        $order = Order::create([
-            'customer_email' => $request->email,
-            'shipping_address' => $request->shipping_address,
-            'shipping_method_id' => $request->shipping_method_id,
-            'payment_method' => $request->payment_method,
-            'total_amount' => $totalAmount,
-            'shipping_cost' => $shippingCost,
-            'tax_amount' => $taxAmount,
-            'discount_amount' => $discountAmount,
-            'coupon_code' => $couponCode,
-            'status' => 'pending',
-            'is_dropshipped' => $request->has('dropship'),
-            'recipient_name' => $request->recipient_name,
-            'recipient_email' => $request->recipient_email,
-            'gift_message' => $request->gift_message,
-        ]);
+        // Create the order and RESERVE stock atomically, before charging.
+        // If any line can't be reserved (e.g. a concurrent buyer took the last
+        // unit), the whole transaction rolls back and no payment is taken — this
+        // is what prevents charging a customer for stock we can't fulfil.
+        $order = null;
+        try {
+            DB::transaction(function () use (&$order, $cart, $request, $totalAmount, $shippingCost, $taxAmount, $discountAmount, $couponCode) {
+                $order = Order::create([
+                    'customer_email' => $request->email,
+                    'shipping_address' => $request->shipping_address,
+                    'shipping_method_id' => $request->shipping_method_id,
+                    'payment_method' => $request->payment_method,
+                    'total_amount' => $totalAmount,
+                    'shipping_cost' => $shippingCost,
+                    'tax_amount' => $taxAmount,
+                    'discount_amount' => $discountAmount,
+                    'coupon_code' => $couponCode,
+                    'status' => 'pending',
+                    'is_dropshipped' => $request->has('dropship'),
+                    'recipient_name' => $request->recipient_name,
+                    'recipient_email' => $request->recipient_email,
+                    'gift_message' => $request->gift_message,
+                ]);
 
-        // Create order items
-        foreach ($cart as $productId => $item) {
-            $order->items()->create([
-                'product_id' => $productId,
-                'quantity' => $item['quantity'],
-                'price' => $item['price'],
-            ]);
+                foreach ($cart as $productId => $item) {
+                    $order->items()->create([
+                        'product_id' => $productId,
+                        'quantity' => $item['quantity'],
+                        'price' => $item['price'],
+                    ]);
+
+                    $before = Product::where('id', $productId)->value('inventory_count');
+
+                    // Atomic, guarded decrement: only succeeds while enough stock remains.
+                    $affected = Product::where('id', $productId)
+                        ->where('inventory_count', '>=', $item['quantity'])
+                        ->decrement('inventory_count', $item['quantity']);
+
+                    if ($affected === 0) {
+                        // Not enough stock (or product gone) — abort the whole order.
+                        throw new \RuntimeException(self::OUT_OF_STOCK);
+                    }
+
+                    InventoryLog::create([
+                        'product_id' => $productId,
+                        'quantity_change' => -$item['quantity'],
+                        'old_quantity' => $before,
+                        'new_quantity' => $before - $item['quantity'],
+                        'reason' => 'order',
+                        'reference_id' => $order->id,
+                        'reference_type' => Order::class,
+                    ]);
+                }
+            });
+        } catch (\RuntimeException $e) {
+            if ($e->getMessage() === self::OUT_OF_STOCK) {
+                return redirect()->back()
+                    ->with('error', 'Some items in your cart are no longer available in the requested quantity.');
+            }
+            throw $e;
         }
 
-        // Process payment based on selected method
+        /** @var Order $order */
+
+        // Charge payment. Stock is already reserved, so we never charge for stock
+        // we can't fulfil. If the charge fails, release the reservation.
         if ($totalAmount > 0) {
             if ($request->payment_method === 'stripe' && $request->has('stripeToken')) {
                 $paymentResult = $this->processStripePayment($order, $request->stripeToken);
             } else if ($request->payment_method === 'paypal' && $request->has('paypal_payment_id')) {
                 $paymentResult = $this->processPayPalPayment($order, $request->paypal_payment_id);
             } else {
+                $this->releaseInventory($order, $cart);
                 $order->update(['status' => 'failed']);
                 return redirect()->back()
                     ->with('error', 'Invalid payment information. Please try again.');
             }
 
             if (!$paymentResult['success']) {
+                $this->releaseInventory($order, $cart);
                 $order->update(['status' => 'failed']);
                 return redirect()->back()
                     ->with('error', 'Payment failed: ' . ($paymentResult['error'] ?? 'Please try again.'));
@@ -204,13 +250,13 @@ class CheckoutController extends Controller
         // Generate download links for downloadable products
         foreach ($cart as $productId => $item) {
             if ($item['is_downloadable']) {
-                $product = Product::with('productCategory')->find($productId);
+                $product = Product::with('category')->find($productId);
                 $orderItem = $order->items()->where('product_id', $productId)->first();
-                
+
                 if ($orderItem && $product) {
                     // Generate secure download link with expiration (30 days)
                     $token = Str::random(64);
-                    $categoryId = $product->productCategory ? $product->productCategory->id : 'general';
+                    $categoryId = $product->category ? $product->category->id : 'general';
                     $downloadLink = route('download.serve-file', [
                         'category' => $categoryId,
                         'product' => $product->id,
@@ -224,38 +270,6 @@ class CheckoutController extends Controller
                     ]);
                 }
             }
-        }
-        
-        // Update inventory after successful payment (with atomic operations)
-        foreach ($cart as $productId => $item) {
-            $product = Product::find($productId);
-            $oldInventory = $product->inventory_count;
-            
-            // Atomic decrement with check to prevent negative inventory
-            $affected = Product::where('id', $productId)
-                ->where('inventory_count', '>=', $item['quantity'])
-                ->decrement('inventory_count', $item['quantity']);
-            
-            if ($affected === 0) {
-                // Inventory insufficient - this shouldn't happen as we checked earlier
-                // Log the issue but don't fail the order
-                \Log::warning("Inventory insufficient for product {$productId} during order {$order->id}");
-                continue;
-            }
-            
-            // Reload to get the new inventory count
-            $product->refresh();
-            
-            // Log inventory change
-            InventoryLog::create([
-                'product_id' => $productId,
-                'quantity_change' => -$item['quantity'],
-                'old_quantity' => $oldInventory,
-                'new_quantity' => $product->inventory_count,
-                'reason' => 'order',
-                'reference_id' => $order->id,
-                'reference_type' => 'App\Models\Order',
-            ]);
         }
 
         // Clear cart and coupon
@@ -291,6 +305,32 @@ class CheckoutController extends Controller
             'order_id' => $order->id,
             'customer_email' => $order->customer_email
         ]);
+    }
+
+    /**
+     * Return reserved stock to inventory when a payment fails after the order was
+     * created. Keeps an audit row so the reserve/release pair is traceable.
+     */
+    private function releaseInventory($order, array $cart): void
+    {
+        foreach ($cart as $productId => $item) {
+            $before = Product::where('id', $productId)->value('inventory_count');
+            if ($before === null) {
+                continue;
+            }
+
+            Product::where('id', $productId)->increment('inventory_count', $item['quantity']);
+
+            InventoryLog::create([
+                'product_id' => $productId,
+                'quantity_change' => $item['quantity'],
+                'old_quantity' => $before,
+                'new_quantity' => $before + $item['quantity'],
+                'reason' => 'payment_failed_release',
+                'reference_id' => $order->id,
+                'reference_type' => Order::class,
+            ]);
+        }
     }
 
     private function hasPhysicalProducts($cart)

--- a/app/Http/Controllers/PaypalPaymentController.php
+++ b/app/Http/Controllers/PaypalPaymentController.php
@@ -22,7 +22,9 @@ class PaypalPaymentController extends Controller
         $paymentMethodId = $request->input('paymentMethodId');
         $amount = $request->input('amount');
 
-        $result = $this->paymentGatewayService->processPaypalPayment($paymentMethodId, $amount);
+        $result = $this->paymentGatewayService->processPayment('paypal', (float) $amount, [
+            'payment_id' => $paymentMethodId,
+        ]);
 
         return response()->json($result);
     }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -2,14 +2,52 @@
 
 namespace App\Models;
 
+use App\Exceptions\InvalidOrderTransitionException;
 use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Order extends Model
 {
     use HasFactory;
     use IsTenantModel;
+
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_PAID = 'paid';
+    public const STATUS_FAILED = 'failed';
+    public const STATUS_PROCESSING = 'processing';
+    public const STATUS_SUPPLIER_QUEUED = 'supplier_queued';
+    public const STATUS_SUPPLIER_FAILED = 'supplier_failed';
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_CANCELLED = 'cancelled';
+    public const STATUS_REFUNDED = 'refunded';
+    public const STATUS_PARTIALLY_REFUNDED = 'partially_refunded';
+
+    /**
+     * Allowed status transitions. A status maps to the set it may move to;
+     * anything else is rejected by transitionTo(). Terminal states map to [].
+     */
+    public const TRANSITIONS = [
+        self::STATUS_PENDING => [self::STATUS_PAID, self::STATUS_FAILED, self::STATUS_CANCELLED],
+        self::STATUS_PAID => [
+            self::STATUS_PROCESSING, self::STATUS_SUPPLIER_QUEUED, self::STATUS_SUPPLIER_FAILED,
+            self::STATUS_COMPLETED, self::STATUS_CANCELLED, self::STATUS_REFUNDED, self::STATUS_PARTIALLY_REFUNDED,
+        ],
+        self::STATUS_PROCESSING => [
+            self::STATUS_COMPLETED, self::STATUS_SUPPLIER_QUEUED, self::STATUS_CANCELLED,
+            self::STATUS_REFUNDED, self::STATUS_PARTIALLY_REFUNDED,
+        ],
+        self::STATUS_SUPPLIER_QUEUED => [
+            self::STATUS_SUPPLIER_FAILED, self::STATUS_PROCESSING, self::STATUS_COMPLETED, self::STATUS_REFUNDED,
+        ],
+        self::STATUS_SUPPLIER_FAILED => [self::STATUS_SUPPLIER_QUEUED, self::STATUS_CANCELLED],
+        self::STATUS_COMPLETED => [self::STATUS_REFUNDED, self::STATUS_PARTIALLY_REFUNDED],
+        self::STATUS_PARTIALLY_REFUNDED => [self::STATUS_REFUNDED],
+        self::STATUS_FAILED => [],
+        self::STATUS_CANCELLED => [],
+        self::STATUS_REFUNDED => [],
+    ];
 
     protected $table = 'orders';
 
@@ -60,5 +98,32 @@ class Order extends Model
     public function items()
     {
         return $this->hasMany(OrderItem::class);
+    }
+
+    public function statusHistory(): HasMany
+    {
+        return $this->hasMany(OrderStatusHistory::class);
+    }
+
+    /**
+     * Move the order to a new status, enforcing the allowed-transition map and
+     * recording an audit row. Throws on an illegal transition (nothing changes).
+     */
+    public function transitionTo(string $status, ?int $changedBy = null, ?string $notes = null): void
+    {
+        $from = $this->status;
+
+        if (! in_array($status, self::TRANSITIONS[$from] ?? [], true)) {
+            throw new InvalidOrderTransitionException($from, $status);
+        }
+
+        $this->update(['status' => $status]);
+
+        $this->statusHistory()->create([
+            'from_status' => $from,
+            'to_status' => $status,
+            'changed_by' => $changedBy,
+            'notes' => $notes,
+        ]);
     }
 }

--- a/app/Services/PaymentGatewayService.php
+++ b/app/Services/PaymentGatewayService.php
@@ -3,41 +3,26 @@
 namespace App\Services;
 
 use App\Factories\PaymentGatewayFactory;
-use App\Interfaces\PaymentGatewayInterface;
-use App\Models\PaymentMethod;
-use InvalidArgumentException;
 
 class PaymentGatewayService
 {
-    protected $paymentGateway;
-
-    public function __construct()
+    /**
+     * Thin wrapper over PaymentGatewayFactory: resolve the named gateway per call
+     * and delegate. (Previously this held a $paymentGateway that was never set, so
+     * every method fataled on a null dereference.)
+     */
+    public function processPayment(string $gateway, float $amount, array $paymentDetails): array
     {
-        // $this->paymentGateway = PaymentGatewayFactory::create($gateway);
+        return PaymentGatewayFactory::create($gateway)->processPayment($amount, $paymentDetails);
     }
 
-    // public function __construct()
-    // {
-    //     $this->stripeClient = new StripeClient(Config::get('services.stripe.secret'));
-    //     $this->paypalContext = new ApiContext(new OAuthTokenCredential(
-    //         Config::get('services.paypal.client_id'),
-    //         Config::get('services.paypal.secret')
-    //     ));
-    //     $this->paypalContext->setConfig(Config::get('services.paypal.settings'));
-    // }
-
-    public function processPayment(float $amount, array $paymentDetails): array
+    public function processSubscription(string $gateway, string $planId, array $subscriptionDetails): array
     {
-        return $this->paymentGateway->processPayment($amount, $paymentDetails);
+        return PaymentGatewayFactory::create($gateway)->processSubscription($planId, $subscriptionDetails);
     }
 
-    public function processSubscription(string $planId, array $subscriptionDetails): array
+    public function refundPayment(string $gateway, string $transactionId, float $amount): array
     {
-        return $this->paymentGateway->processSubscription($planId, $subscriptionDetails);
-    }
-
-    public function refundPayment(string $transactionId, float $amount): array
-    {
-        return $this->paymentGateway->refundPayment($transactionId, $amount);
+        return PaymentGatewayFactory::create($gateway)->refundPayment($transactionId, $amount);
     }
 }

--- a/database/migrations/2026_07_12_000000_add_recipient_fields_to_orders_table.php
+++ b/database/migrations/2026_07_12_000000_add_recipient_fields_to_orders_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Fix the orders table so guest / gift checkout can create an order:
+     *  - recipient_name / recipient_email / gift_message are written by the
+     *    Order model + CheckoutController but were never migrated (every
+     *    checkout fataled at order creation).
+     *  - customer_id was NOT NULL (foreignId()->constrained()), but guest
+     *    checkout creates email-only orders with no customer, so it must be
+     *    nullable or guest orders violate the constraint.
+     */
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            if (! Schema::hasColumn('orders', 'recipient_name')) {
+                $table->string('recipient_name')->nullable();
+            }
+            if (! Schema::hasColumn('orders', 'recipient_email')) {
+                $table->string('recipient_email')->nullable();
+            }
+            if (! Schema::hasColumn('orders', 'gift_message')) {
+                $table->text('gift_message')->nullable();
+            }
+        });
+
+        // Legacy NOT-NULL columns from the original create_orders_table that the
+        // checkout flow never populates (it uses customer_email + status instead).
+        // Left required, they block every order insert.
+        Schema::table('orders', function (Blueprint $table) {
+            $table->unsignedBigInteger('customer_id')->nullable()->change();
+            $table->string('order_date')->nullable()->change();
+            $table->string('payment_status')->nullable()->change();
+            $table->string('shipping_status')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn(['recipient_name', 'recipient_email', 'gift_message']);
+        });
+    }
+};

--- a/database/migrations/2026_07_12_000001_add_tracking_columns_to_inventory_logs_table.php
+++ b/database/migrations/2026_07_12_000001_add_tracking_columns_to_inventory_logs_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The InventoryLog model's $fillable and every writer (CheckoutController,
+     * InventoryController, ProductResource) record old_quantity, new_quantity and
+     * a polymorphic reference, but the create_inventory_logs_table migration only
+     * created product_id/quantity_change/reason — so every inventory log insert
+     * fatals. This adds the missing columns.
+     */
+    public function up(): void
+    {
+        Schema::table('inventory_logs', function (Blueprint $table) {
+            if (! Schema::hasColumn('inventory_logs', 'old_quantity')) {
+                $table->integer('old_quantity')->nullable();
+            }
+            if (! Schema::hasColumn('inventory_logs', 'new_quantity')) {
+                $table->integer('new_quantity')->nullable();
+            }
+            if (! Schema::hasColumn('inventory_logs', 'reference_id')) {
+                $table->unsignedBigInteger('reference_id')->nullable();
+            }
+            if (! Schema::hasColumn('inventory_logs', 'reference_type')) {
+                $table->string('reference_type')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('inventory_logs', function (Blueprint $table) {
+            $table->dropColumn(['old_quantity', 'new_quantity', 'reference_id', 'reference_type']);
+        });
+    }
+};

--- a/tests/Feature/CheckoutInventoryTest.php
+++ b/tests/Feature/CheckoutInventoryTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Interfaces\PaymentGatewayInterface;
+use App\Models\Order;
+use App\Models\Product;
+use App\Services\PaymentGateways\StripeGateway;
+use Closure;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class CheckoutInventoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Bind a spy payment gateway that records how much inventory existed at the
+     * moment the payment was charged. Returns the spy so tests can inspect it.
+     */
+    private function bindGateway(Closure $result): object
+    {
+        $spy = new class($result) implements PaymentGatewayInterface {
+            public ?int $inventoryAtCharge = null;
+
+            public function __construct(private Closure $result) {}
+
+            public function processPayment(float $amount, array $paymentDetails): array
+            {
+                // Total stock left across all products at the instant of charging.
+                $this->inventoryAtCharge = (int) Product::sum('inventory_count');
+
+                return ($this->result)();
+            }
+
+            public function processSubscription(string $planId, array $subscriptionDetails): array
+            {
+                return ['success' => true];
+            }
+
+            public function refundPayment(string $transactionId, float $amount): array
+            {
+                return ['success' => true];
+            }
+        };
+
+        $this->app->instance(StripeGateway::class, $spy);
+
+        return $spy;
+    }
+
+    private function cartFor(Product $product, int $qty): array
+    {
+        return [
+            $product->id => [
+                'quantity' => $qty,
+                'price' => (float) $product->price,
+                'is_downloadable' => true,
+                'name' => $product->name,
+            ],
+        ];
+    }
+
+    private function payload(): array
+    {
+        return [
+            'email' => 'buyer@example.com',
+            'has_physical_products' => 0,
+            'shipping_address' => '123 Test St, CA 90001',
+            'payment_method' => 'stripe',
+            'stripeToken' => 'tok_test',
+        ];
+    }
+
+    public function test_successful_checkout_marks_order_paid_and_decrements_inventory(): void
+    {
+        Notification::fake();
+        $this->bindGateway(fn () => ['success' => true]);
+
+        $product = Product::factory()->create(['inventory_count' => 5, 'is_downloadable' => true]);
+
+        $this->withSession(['cart' => $this->cartFor($product, 1)])
+            ->post(route('checkout.process'), $this->payload());
+
+        $order = Order::first();
+        $this->assertNotNull($order, 'Order was not created');
+        $this->assertSame('paid', $order->status);
+        $this->assertSame(4, $product->fresh()->inventory_count);
+    }
+
+    public function test_inventory_is_reserved_before_payment_is_charged(): void
+    {
+        Notification::fake();
+        $spy = $this->bindGateway(fn () => ['success' => true]);
+
+        $product = Product::factory()->create(['inventory_count' => 5, 'is_downloadable' => true]);
+
+        $this->withSession(['cart' => $this->cartFor($product, 2)])
+            ->post(route('checkout.process'), $this->payload());
+
+        // Stock must already be reserved (decremented) when payment runs; otherwise a
+        // concurrent buyer can be charged for stock that is already gone (oversell).
+        $this->assertSame(3, $spy->inventoryAtCharge, 'Payment was charged before inventory was reserved');
+    }
+
+    public function test_failed_payment_does_not_lose_inventory_and_marks_order_failed(): void
+    {
+        Notification::fake();
+        $this->bindGateway(fn () => ['success' => false, 'error' => 'card declined']);
+
+        $product = Product::factory()->create(['inventory_count' => 5, 'is_downloadable' => true]);
+
+        $this->withSession(['cart' => $this->cartFor($product, 2)])
+            ->post(route('checkout.process'), $this->payload());
+
+        $order = Order::first();
+        $this->assertNotNull($order);
+        $this->assertSame('failed', $order->status);
+        // Reserved stock must be released back when the charge fails.
+        $this->assertSame(5, $product->fresh()->inventory_count, 'Inventory was lost on a failed payment');
+    }
+}

--- a/tests/Feature/OrderStateMachineTest.php
+++ b/tests/Feature/OrderStateMachineTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Exceptions\InvalidOrderTransitionException;
+use App\Models\Order;
+use App\Models\OrderStatusHistory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OrderStateMachineTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function order(string $status): Order
+    {
+        return Order::create([
+            'customer_email' => 'buyer@example.com',
+            'total_amount' => 100,
+            'status' => $status,
+        ]);
+    }
+
+    public function test_valid_transition_updates_status_and_records_history(): void
+    {
+        $order = $this->order(Order::STATUS_PENDING);
+
+        $order->transitionTo(Order::STATUS_PAID, notes: 'payment captured');
+
+        $this->assertSame(Order::STATUS_PAID, $order->fresh()->status);
+
+        $history = $order->statusHistory()->first();
+        $this->assertNotNull($history, 'No status history was recorded');
+        $this->assertSame(Order::STATUS_PENDING, $history->from_status);
+        $this->assertSame(Order::STATUS_PAID, $history->to_status);
+        $this->assertSame('payment captured', $history->notes);
+    }
+
+    public function test_invalid_transition_throws_and_leaves_state_unchanged(): void
+    {
+        $order = $this->order(Order::STATUS_PENDING);
+
+        try {
+            $order->transitionTo(Order::STATUS_COMPLETED);
+            $this->fail('Expected InvalidOrderTransitionException for pending -> completed');
+        } catch (InvalidOrderTransitionException $e) {
+            // expected: pending cannot jump straight to completed
+        }
+
+        $this->assertSame(Order::STATUS_PENDING, $order->fresh()->status);
+        $this->assertSame(0, OrderStatusHistory::count(), 'A rejected transition must not record history');
+    }
+}

--- a/tests/Feature/PaymentGatewayServiceTest.php
+++ b/tests/Feature/PaymentGatewayServiceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Interfaces\PaymentGatewayInterface;
+use App\Services\PaymentGatewayService;
+use App\Services\PaymentGateways\PayPalGateway;
+use App\Services\PaymentGateways\StripeGateway;
+use Tests\TestCase;
+
+class PaymentGatewayServiceTest extends TestCase
+{
+    private function fakeGateway(array $return): PaymentGatewayInterface
+    {
+        return new class($return) implements PaymentGatewayInterface {
+            public function __construct(private array $return) {}
+
+            public function processPayment(float $amount, array $paymentDetails): array
+            {
+                return $this->return + ['amount' => $amount];
+            }
+
+            public function processSubscription(string $planId, array $subscriptionDetails): array
+            {
+                return $this->return;
+            }
+
+            public function refundPayment(string $transactionId, float $amount): array
+            {
+                return $this->return + ['amount' => $amount];
+            }
+        };
+    }
+
+    public function test_process_payment_delegates_to_the_named_gateway(): void
+    {
+        $this->app->instance(StripeGateway::class, $this->fakeGateway(['success' => true, 'gateway' => 'stripe']));
+
+        $result = app(PaymentGatewayService::class)->processPayment('stripe', 10.0, ['token' => 'tok']);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('stripe', $result['gateway']);
+        $this->assertSame(10.0, $result['amount']);
+    }
+
+    public function test_refund_payment_delegates_to_the_named_gateway(): void
+    {
+        $this->app->instance(PayPalGateway::class, $this->fakeGateway(['success' => true, 'gateway' => 'paypal']));
+
+        $result = app(PaymentGatewayService::class)->refundPayment('paypal', 'txn_1', 5.0);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('paypal', $result['gateway']);
+        $this->assertSame(5.0, $result['amount']);
+    }
+}

--- a/tests/Feature/PaypalPaymentControllerTest.php
+++ b/tests/Feature/PaypalPaymentControllerTest.php
@@ -2,60 +2,61 @@
 
 namespace Tests\Feature;
 
+use App\Interfaces\PaymentGatewayInterface;
+use App\Services\PaymentGateways\PayPalGateway;
 use Tests\TestCase;
-use Mockery;
-use App\Http\Controllers\PaypalPaymentController;
-use App\Services\PaymentGatewayService;
-use App\Services\SubscriptionService;
-use Illuminate\Http\Request;
-use Illuminate\Http\JsonResponse;
 
 class PaypalPaymentControllerTest extends TestCase
 {
-    public function testCreateOneTimePaymentSuccess()
+    private function bindPaypalGateway(array $return): void
     {
-        $paymentGatewayServiceMock = Mockery::mock(PaymentGatewayService::class);
-        $subscriptionServiceMock = Mockery::mock(SubscriptionService::class);
-        $request = Request::create('/createOneTimePayment', 'POST', [
-            'paymentMethodId' => 'validMethodId',
-            'amount' => 100
-        ]);
+        $this->app->instance(PayPalGateway::class, new class($return) implements PaymentGatewayInterface {
+            public function __construct(private array $return) {}
 
-        $paymentGatewayServiceMock->shouldReceive('processPaypalPayment')
-            ->once()
-            ->with('validMethodId', 100)
-            ->andReturn(['success' => true, 'message' => 'PayPal payment successful']);
+            public function processPayment(float $amount, array $paymentDetails): array
+            {
+                return $this->return + ['payment_id' => $paymentDetails['payment_id'] ?? null];
+            }
 
-        $controller = new PaypalPaymentController($paymentGatewayServiceMock, $subscriptionServiceMock);
-        $response = $controller->createOneTimePayment($request);
+            public function processSubscription(string $planId, array $subscriptionDetails): array
+            {
+                return $this->return;
+            }
 
-        $this->assertInstanceOf(JsonResponse::class, $response);
-        $this->assertEquals(200, $response->status());
-        $this->assertEquals(['success' => true, 'message' => 'PayPal payment successful'], $response->getData(true));
+            public function refundPayment(string $transactionId, float $amount): array
+            {
+                return $this->return;
+            }
+        });
     }
 
-    public function testCreateOneTimePaymentFailure()
+    public function test_one_time_payment_delegates_to_the_paypal_gateway(): void
     {
-        $paymentGatewayServiceMock = Mockery::mock(PaymentGatewayService::class);
-        $subscriptionServiceMock = Mockery::mock(SubscriptionService::class);
-        $request = Request::create('/createOneTimePayment', 'POST', [
-            'paymentMethodId' => 'invalidMethodId',
-            'amount' => 0
+        $this->bindPaypalGateway(['success' => true, 'transaction_id' => 'txn_test']);
+
+        $response = $this->postJson(route('paypal.payment.create'), [
+            'paymentMethodId' => 'pm_123',
+            'amount' => 25,
         ]);
 
-        $paymentGatewayServiceMock->shouldReceive('processPaypalPayment')
-            ->once()
-            ->with('invalidMethodId', 0)
-            ->andReturn(['success' => false, 'message' => 'Payment failed']);
-
-        $controller = new PaypalPaymentController($paymentGatewayServiceMock, $subscriptionServiceMock);
-        $response = $controller->createOneTimePayment($request);
-
-        $this->assertInstanceOf(JsonResponse::class, $response);
-        $this->assertEquals(200, $response->status());
-        $this->assertEquals(['success' => false, 'message' => 'Payment failed'], $response->getData(true));
+        $response->assertOk();
+        $response->assertJson([
+            'success' => true,
+            'transaction_id' => 'txn_test',
+            'payment_id' => 'pm_123',
+        ]);
     }
 
-    // Similar test methods will be created for createSubscription, updateSubscription, and cancelSubscription methods, covering all possible scenarios including success, failure, and edge cases.
+    public function test_one_time_payment_returns_gateway_failure(): void
+    {
+        $this->bindPaypalGateway(['success' => false, 'error' => 'declined']);
 
+        $response = $this->postJson(route('paypal.payment.create'), [
+            'paymentMethodId' => 'pm_bad',
+            'amount' => 10,
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['success' => false, 'error' => 'declined']);
+    }
 }


### PR DESCRIPTION
Fixes a stack of money/data bugs on the checkout path (all previously hidden because `CheckoutControllerTest` was `.disabled`), then adds an enforced order status state machine. Every change is TDD; migrations verified on sqlite **and** MySQL 8.4. Full suite: **695 passed / 17 failed** (the 17 are pre-existing drift failures unrelated to this branch — Jetstream Permission class, RefundItem NOT NULL, ratings/reviews columns, invoice_product table, sitemap/orders.show views).

## Commits

### `91345ec` — reserve stock before charging (+ 6 latent fatals)
Checkout charged the customer, marked the order paid, and only then decremented inventory — with a silent `continue` if the guarded decrement found no stock. Two buyers racing for the last unit could both be charged while only one could be fulfilled, leaving a paid order with no stock and no refund.

- **Reserve-before-charge**: create order + decrement stock (guarded, atomic) inside a `DB::transaction`; if any line can't be reserved the order rolls back and no payment is taken. On charge failure the reserved stock is released.
- Fixed latent fatals uncovered on the (previously untested) path:
  - `OrderConfirmationNotification` and `Exception` referenced unqualified in `App\Http\Controllers` (no import) → class-not-found fatal on every paid order / dropship error.
  - `Product::with('productCategory')` → relation is `category`; every downloadable purchase fataled.
  - `orders` table never had `recipient_name`/`recipient_email`/`gift_message`; `customer_id` + legacy columns were `NOT NULL` → order insert fataled and guest checkout was impossible.
  - `inventory_logs` never had `old_quantity`/`new_quantity`/`reference_*` (written by three call sites) → every inventory log insert fataled.
- `PaymentGatewayFactory` now resolves gateways via the container (injectable).

### `fee2c4b` — make PaymentGatewayService functional; fix PayPal one-time payment
`PaymentGatewayService` held a `$paymentGateway` that was never assigned → every method fataled on a null dereference. `PaypalPaymentController` called a `processPaypalPayment()` that never existed → `/paypal/payment` 500'd every request. Rewrote the service as a stateless factory wrapper; pointed the controller at `processPayment('paypal', ...)`. Replaced the test that mocked the nonexistent method (green while prod was broken) with real-route tests.

### `272c025` — order status state machine with audit history
Status was a free-text string mutated by raw `update()` from anywhere, with no valid-transition concept and no audit (the `OrderStatusHistory` table had zero writers). Added status constants + an allowed-transition map + `Order::transitionTo()` that rejects illegal transitions (`InvalidOrderTransitionException`, nothing changes) and records an `OrderStatusHistory` row on every accepted move. CheckoutController's paid/failed/supplier_* changes routed through it.

## Follow-ups (not in this PR)
- Reader vocab: `DownloadController` + `CustomerMetric` query `status='completed'` which is never set (downloads/LTV silently dead); both depend on the unverified `User->orders()` relation, and `CustomerMetric` has the `total`→`total_amount` column drift.
- Admin `OrderResource` has no status field; it must drive `transitionTo` rather than write status directly.
- Wire `Refund::process()` to the gateway + restock via `transitionTo(REFUNDED)` (now unblocked).

## Test plan
- `php artisan test tests/Feature/CheckoutInventoryTest.php` — reserve-before-charge, release-on-failure, paid+decrement.
- `php artisan test tests/Feature/PaymentGatewayServiceTest.php tests/Feature/PaypalPaymentControllerTest.php` — gateway delegation + real PayPal route.
- `php artisan test tests/Feature/OrderStateMachineTest.php` — valid transition + history, illegal transition rejected.