### PR TITLE
Fix 17 pre-existing schema/view drift test failures → suite fully green

### DIFF
--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Spatie\Permission\Models\Permission as SpatiePermission;
+
+class Permission extends SpatiePermission
+{
+    //
+}

--- a/database/migrations/2026_07_13_000001_make_refunds_reason_nullable.php
+++ b/database/migrations/2026_07_13_000001_make_refunds_reason_nullable.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// A refund can be created (pending) before a reason is recorded, so `reason`
+// must be nullable — the original migration made it NOT NULL with no default.
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('refunds', function (Blueprint $table) {
+            $table->string('reason')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('refunds', function (Blueprint $table) {
+            $table->string('reason')->nullable(false)->change();
+        });
+    }
+};

--- a/database/migrations/2026_07_13_000002_add_detailed_ratings_to_ratings_table.php
+++ b/database/migrations/2026_07_13_000002_add_detailed_ratings_to_ratings_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// Rating model/controller write these breakdown columns; the original table only had `rating`.
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('ratings', function (Blueprint $table) {
+            foreach (['overall_rating', 'quality_rating', 'value_rating', 'price_rating'] as $col) {
+                if (!Schema::hasColumn('ratings', $col)) {
+                    $table->integer($col)->nullable()->after('rating');
+                }
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ratings', function (Blueprint $table) {
+            $table->dropColumn(['overall_rating', 'quality_rating', 'value_rating', 'price_rating']);
+        });
+    }
+};

--- a/database/migrations/2026_07_13_000003_add_votes_to_reviews_table.php
+++ b/database/migrations/2026_07_13_000003_add_votes_to_reviews_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// ReviewController::vote() increments these; the original table never had them.
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            foreach (['helpful_votes', 'unhelpful_votes'] as $col) {
+                if (!Schema::hasColumn('reviews', $col)) {
+                    $table->unsignedInteger($col)->default(0)->after('approved');
+                }
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->dropColumn(['helpful_votes', 'unhelpful_votes']);
+        });
+    }
+};

--- a/database/migrations/2026_07_13_000004_create_invoice_product_table.php
+++ b/database/migrations/2026_07_13_000004_create_invoice_product_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// Pivot for Invoice::products() belongsToMany(...)->withPivot('quantity', 'price').
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('invoice_product')) {
+            return;
+        }
+
+        Schema::create('invoice_product', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('invoice_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->integer('quantity')->default(1);
+            $table->decimal('price', 10, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('invoice_product');
+    }
+};

--- a/resources/views/orders/show.blade.php
+++ b/resources/views/orders/show.blade.php
@@ -1,0 +1,14 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Order #{{ $order->id }}</h1>
+    <p>Date: {{ $order->created_at->format('Y-m-d H:i') }}</p>
+    <p>Status: {{ ucfirst($order->status) }}</p>
+    <p>Payment: {{ ucfirst($order->payment_status) }}</p>
+    <p>Shipping: {{ ucfirst($order->shipping_status) }}</p>
+    <p>Total: ${{ number_format($order->total_amount, 2) }}</p>
+
+    <a href="{{ route('orders.index') }}" class="btn btn-secondary">Back to orders</a>
+</div>
+@endsection

--- a/resources/views/sitemap/index.blade.php
+++ b/resources/views/sitemap/index.blade.php
@@ -1,0 +1,17 @@
+<?php echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n"; ?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>{{ url('/') }}</loc>
+    </url>
+    @foreach($products as $product)
+    <url>
+        <loc>{{ route('products.show', $product) }}</loc>
+        <lastmod>{{ optional($product->updated_at)->toAtomString() }}</lastmod>
+    </url>
+    @endforeach
+    @foreach($categories as $category)
+    <url>
+        <loc>{{ url('/products?category=' . $category->slug) }}</loc>
+    </url>
+    @endforeach
+</urlset>


### PR DESCRIPTION
The test suite carried **17 failing tests** from long-standing model↔schema and missing-view drift (unrelated to any single feature — they predate recent work). This fixes all of them **additively**: no test, config, factory, or assertion changes, and no weakened guards (verified: only new files, zero modifications to tracked files).

**Suite: 712 passed / 0 failed** (was 695 / 17). New migrations verified on sqlite **and** MySQL 8.4.

## Fixes

| Failing tests | Root cause | Fix |
|---|---|---|
| JetstreamActionsTest (5) | `App\Models\Permission` referenced by `config/permission.php` + `AppServiceProvider` but the model never existed | Created `app/Models/Permission.php` mirroring `App\Models\Role` |
| RefundItemModelTest (3) | `refunds.reason` `NOT NULL`, but the pending-refund create flow doesn't set it | Made `reason` nullable |
| RatingControllerTest (2) | `ratings` lacked `overall_rating`/`quality_rating`/`value_rating`/`price_rating` (in `Rating::$fillable`, written by controller) | Added columns |
| ReviewControllerTest (2) | `reviews` lacked `helpful_votes`/`unhelpful_votes` (incremented by `ReviewController::vote`) | Added columns |
| InvoiceControllerTest (1) | `invoice_product` pivot (backing `Invoice::products()`, iterated by the blade) never existed | Created pivot table |
| SitemapControllerTest (3) + OrderHistoryControllerTest (1) | `sitemap.index` + `orders.show` views referenced by controllers but missing | Created both blade views |

## Notes
- All migrations are additive and guarded (`Schema::hasColumn` / `hasTable`), using Laravel 11+ native `->change()` (no doctrine/dbal).
- `orders/show` renders order header fields; line-items table deliberately skipped (no test exercises it, and it would guess `OrderItem` column names).

## Test plan
`php artisan test` → 712 passed / 0 failed.