### PR TITLE
Wire refunds to the gateway, restock, and order state machine

### DIFF
--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -215,6 +215,11 @@ class CheckoutController extends Controller
             }
         }
 
+        // Persist the gateway charge id so a later refund has something to void.
+        if (isset($paymentResult['transaction_id'])) {
+            $order->update(['transaction_id' => $paymentResult['transaction_id']]);
+        }
+
         $order->transitionTo(Order::STATUS_PAID, notes: 'Payment captured');
 
         // Send order confirmation email

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -74,6 +74,10 @@ class Order extends Model
         'supplier_order_reference',
         'supplier_tracking_number',
         'supplier_response',
+        'transaction_id',
+        'refund_total',
+        'partially_refunded',
+        'fully_refunded',
     ];
 
     protected $casts = [
@@ -83,6 +87,9 @@ class Order extends Model
         'tax_amount' => 'decimal:2',
         'discount_amount' => 'decimal:2',
         'total_amount' => 'decimal:2',
+        'refund_total' => 'decimal:2',
+        'partially_refunded' => 'boolean',
+        'fully_refunded' => 'boolean',
     ];
 
     public function customer()

--- a/app/Models/Refund.php
+++ b/app/Models/Refund.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Services\PaymentGatewayService;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -54,26 +55,52 @@ class Refund extends Model
             return false;
         }
 
+        $order = $this->order;
+
+        // Void the payment with the gateway FIRST. If it has a charge to refund and
+        // the gateway declines, nothing changes — no restock, no state move.
+        $result = [];
+        if ($order->transaction_id) {
+            $result = app(PaymentGatewayService::class)->refundPayment(
+                $order->payment_method,
+                $order->transaction_id,
+                (float) $this->amount,
+            );
+
+            if (! ($result['success'] ?? false)) {
+                return false;
+            }
+        }
+
         $this->update([
             'status' => 'processed',
             'processed_by' => $userId,
             'processed_at' => now(),
+            'transaction_id' => $result['refund_id'] ?? $this->transaction_id,
         ]);
 
-        // Update order refund totals
-        $this->order->increment('refund_total', $this->amount);
-        $this->order->update([
-            'partially_refunded' => $this->order->refund_total < $this->order->total,
-            'fully_refunded' => $this->order->refund_total >= $this->order->total,
-        ]);
-
-        // Restock items if needed
+        // Restock refunded items if requested.
         if ($this->restock_items) {
             foreach ($this->items as $item) {
-                if ($item->restock) {
+                if ($item->restock && $item->orderItem && $item->orderItem->product) {
                     $item->orderItem->product->increment('inventory_count', $item->quantity);
                 }
             }
+        }
+
+        // Update refund totals + move the order through the state machine.
+        $order->increment('refund_total', $this->amount);
+        $order->refresh();
+
+        $fully = (float) $order->refund_total >= (float) $order->total_amount;
+        $order->update([
+            'partially_refunded' => ! $fully,
+            'fully_refunded' => $fully,
+        ]);
+
+        $target = $fully ? Order::STATUS_REFUNDED : Order::STATUS_PARTIALLY_REFUNDED;
+        if ($order->status !== $target && in_array($target, Order::TRANSITIONS[$order->status] ?? [], true)) {
+            $order->transitionTo($target, $userId, 'Refund processed');
         }
 
         return true;

--- a/database/migrations/2026_07_13_000005_add_transaction_id_to_orders_table.php
+++ b/database/migrations/2026_07_13_000005_add_transaction_id_to_orders_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Persist the payment gateway's transaction/charge id on the order so refunds
+     * have something to refund against. The gateways return it from processPayment
+     * but checkout never stored it, leaving Refund::process with no charge to void.
+     */
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            if (! Schema::hasColumn('orders', 'transaction_id')) {
+                $table->string('transaction_id')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn('transaction_id');
+        });
+    }
+};

--- a/tests/Feature/CheckoutInventoryTest.php
+++ b/tests/Feature/CheckoutInventoryTest.php
@@ -76,7 +76,7 @@ class CheckoutInventoryTest extends TestCase
     public function test_successful_checkout_marks_order_paid_and_decrements_inventory(): void
     {
         Notification::fake();
-        $this->bindGateway(fn () => ['success' => true]);
+        $this->bindGateway(fn () => ['success' => true, 'transaction_id' => 'ch_persist']);
 
         $product = Product::factory()->create(['inventory_count' => 5, 'is_downloadable' => true]);
 
@@ -87,6 +87,8 @@ class CheckoutInventoryTest extends TestCase
         $this->assertNotNull($order, 'Order was not created');
         $this->assertSame('paid', $order->status);
         $this->assertSame(4, $product->fresh()->inventory_count);
+        // The gateway charge id must be persisted so a later refund has something to void.
+        $this->assertSame('ch_persist', $order->transaction_id);
     }
 
     public function test_inventory_is_reserved_before_payment_is_charged(): void

--- a/tests/Feature/RefundProcessTest.php
+++ b/tests/Feature/RefundProcessTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Interfaces\PaymentGatewayInterface;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\Refund;
+use App\Services\PaymentGateways\StripeGateway;
+use Closure;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RefundProcessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function bindGateway(Closure $refundResult): object
+    {
+        $spy = new class($refundResult) implements PaymentGatewayInterface {
+            public array $refundCalls = [];
+
+            public function __construct(private Closure $refundResult) {}
+
+            public function processPayment(float $amount, array $paymentDetails): array
+            {
+                return ['success' => true];
+            }
+
+            public function processSubscription(string $planId, array $subscriptionDetails): array
+            {
+                return ['success' => true];
+            }
+
+            public function refundPayment(string $transactionId, float $amount): array
+            {
+                $this->refundCalls[] = ['transaction_id' => $transactionId, 'amount' => $amount];
+
+                return ($this->refundResult)();
+            }
+        };
+
+        $this->app->instance(StripeGateway::class, $spy);
+
+        return $spy;
+    }
+
+    private function makeRefund(int $stock, float $orderTotal, float $refundAmount, int $qty): Refund
+    {
+        $product = Product::factory()->create(['inventory_count' => $stock]);
+
+        $order = Order::create([
+            'customer_email' => 'buyer@example.com',
+            'payment_method' => 'stripe',
+            'transaction_id' => 'ch_test',
+            'total_amount' => $orderTotal,
+            'status' => Order::STATUS_PAID,
+        ]);
+
+        $orderItem = $order->items()->create([
+            'product_id' => $product->id,
+            'quantity' => $qty,
+            'price' => 50,
+        ]);
+
+        $refund = Refund::create([
+            'order_id' => $order->id,
+            'amount' => $refundAmount,
+            'reason' => 'customer request',
+            'status' => 'pending',
+            'restock_items' => true,
+        ]);
+
+        $refund->items()->create([
+            'order_item_id' => $orderItem->id,
+            'quantity' => $qty,
+            'amount' => $refundAmount,
+            'restock' => true,
+        ]);
+
+        return $refund;
+    }
+
+    public function test_processing_refund_calls_gateway_restocks_and_refunds_order(): void
+    {
+        $spy = $this->bindGateway(fn () => ['success' => true, 'refund_id' => 're_1']);
+        $refund = $this->makeRefund(stock: 3, orderTotal: 100, refundAmount: 100, qty: 2);
+
+        $result = $refund->process();
+
+        $this->assertTrue($result);
+        // Gateway was called with the order's charge id.
+        $this->assertCount(1, $spy->refundCalls);
+        $this->assertSame('ch_test', $spy->refundCalls[0]['transaction_id']);
+        // Refund recorded, stock returned.
+        $this->assertSame('processed', $refund->fresh()->status);
+        $this->assertSame(5, $refund->order->items->first()->product->fresh()->inventory_count);
+        // Order fully refunded and moved through the state machine.
+        $order = $refund->order->fresh();
+        $this->assertTrue((bool) $order->fully_refunded);
+        $this->assertSame(Order::STATUS_REFUNDED, $order->status);
+        $this->assertNotNull(
+            $order->statusHistory()->where('to_status', Order::STATUS_REFUNDED)->first(),
+            'Refund did not record an order status transition'
+        );
+    }
+
+    public function test_gateway_failure_does_not_refund_restock_or_transition(): void
+    {
+        $this->bindGateway(fn () => ['success' => false, 'error' => 'gateway declined']);
+        $refund = $this->makeRefund(stock: 3, orderTotal: 100, refundAmount: 100, qty: 2);
+
+        $result = $refund->process();
+
+        $this->assertFalse($result);
+        $this->assertSame('pending', $refund->fresh()->status);
+        $this->assertSame(3, $refund->order->items->first()->product->fresh()->inventory_count);
+        $this->assertSame(Order::STATUS_PAID, $refund->order->fresh()->status);
+    }
+
+    public function test_partial_refund_marks_order_partially_refunded(): void
+    {
+        $this->bindGateway(fn () => ['success' => true]);
+        $refund = $this->makeRefund(stock: 3, orderTotal: 100, refundAmount: 40, qty: 1);
+
+        $refund->process();
+
+        $order = $refund->order->fresh();
+        $this->assertTrue((bool) $order->partially_refunded);
+        $this->assertFalse((bool) $order->fully_refunded);
+        $this->assertSame(Order::STATUS_PARTIALLY_REFUNDED, $order->status);
+    }
+}


### PR DESCRIPTION
`Refund::process()` looked like it worked but did nothing real. This makes refunds actually refund money, restock, and move the order lifecycle — building on the state machine from #693.

**Suite: 715 passed / 0 failed.**

## The bugs
`Refund::process()`:
- **never called the payment gateway** → no money was ever returned;
- computed refund totals against `$order->total` — a **column that doesn't exist** (it's `total_amount`), so `fully_refunded` was always set true;
- wrote `refund_total`/`partially_refunded`/`fully_refunded` which **weren't in `Order::$fillable`** → silently dropped;
- **never moved the order's lifecycle status** (the `OrderStatusHistory` audit added in #693 was bypassed).

And orders **never persisted the gateway charge id**, so even a correct `process()` would have had nothing to refund against.

## The fix
- Add `orders.transaction_id`; `CheckoutController` stores the gateway's charge id at capture.
- Add `transaction_id` + the refund flag columns to `Order::$fillable` and casts.
- Rewrite `Refund::process()`:
  1. **Gateway first** — `PaymentGatewayService::refundPayment(gateway, chargeId, amount)`. If it declines, return `false` and change nothing (no restock, no state move).
  2. On success: mark the refund processed, restock requested items, update `refund_total` against `total_amount`, set the refund flags, and `transitionTo(REFUNDED | PARTIALLY_REFUNDED)` — validated + audited.

## Tests (`RefundProcessTest`)
- Full refund → gateway called with the order's charge id, items restocked, order → `refunded` with a status-history row.
- Gateway failure → nothing refunded, restocked, or transitioned; refund stays `pending`.
- Partial refund → order `partially_refunded`, flags correct.
- `CheckoutInventoryTest` now asserts the charge id is persisted at checkout.

## Not in this PR
- A trigger surface (admin Filament action / API endpoint) to *initiate* a refund — `process()` is now correct and unit-covered; wiring a button is a small follow-up.
- `ReturnRequest::approve()` → spawn a refund (still orphaned).

## Test plan
`php artisan test` → 715 passed / 0 failed.