### PR TITLE
Tax the discounted amount, not the full subtotal

### DIFF
--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -123,9 +123,8 @@ class CheckoutController extends Controller
             $couponCode = $couponData['code'] ?? null;
         }
 
-        // Calculate tax based on shipping address (after discount)
-        $taxableAmount = max(0, $subtotal - $discountAmount);
-        $taxAmount = $this->taxService->calculateTaxForCart($cart, $request->shipping_address);
+        // Calculate tax on the amount after discount.
+        $taxAmount = $this->taxService->calculateTaxForCart($cart, $request->shipping_address, $discountAmount);
 
         $totalAmount = $subtotal - $discountAmount + $shippingCost + $taxAmount;
 

--- a/app/Services/TaxService.php
+++ b/app/Services/TaxService.php
@@ -9,7 +9,7 @@ class TaxService
     /**
      * Calculate tax for a cart based on shipping address
      */
-    public function calculateTaxForCart(array $cart, ?string $shippingAddress = null): float
+    public function calculateTaxForCart(array $cart, ?string $shippingAddress = null, float $discount = 0): float
     {
         if (!$shippingAddress) {
             return 0;
@@ -30,15 +30,16 @@ class TaxService
             return 0;
         }
 
-        // Calculate subtotal
+        // Calculate subtotal, then tax the amount left AFTER any discount.
         $subtotal = collect($cart)->sum(function ($item) {
             return $item['price'] * $item['quantity'];
         });
+        $taxable = max(0, $subtotal - $discount);
 
         // Calculate tax
         $totalTax = 0;
         foreach ($taxRates as $rate) {
-            $totalTax += $rate->calculateTax($subtotal);
+            $totalTax += $rate->calculateTax($taxable);
         }
 
         return round($totalTax, 2);

--- a/tests/Unit/TaxServiceTest.php
+++ b/tests/Unit/TaxServiceTest.php
@@ -124,4 +124,15 @@ class TaxServiceTest extends TestCase
 
         $this->assertEquals(8.00, $tax);
     }
+
+    public function test_tax_for_cart_is_calculated_on_the_amount_after_discount(): void
+    {
+        $this->makeRate(['rate' => 10.00]);
+        $cart = [['price' => 100, 'quantity' => 1]];
+
+        // subtotal 100, discount 20 => taxable 80 => 10% = 8 (not 10 on the full subtotal)
+        $tax = $this->service->calculateTaxForCart($cart, '123 Main St, CA 90210', 20);
+
+        $this->assertEquals(8.00, $tax);
+    }
 }


### PR DESCRIPTION
Checkout computed `$taxableAmount = subtotal - discount` and then **discarded it**, taxing the full pre-discount subtotal. Every order with a coupon was over-taxed.

`TaxService::calculateTaxForCart` now takes an optional `$discount` and taxes `max(0, subtotal - discount)`; `CheckoutController` passes the coupon discount, and the dead `$taxableAmount` is removed.

**Test:** a 100 cart with a 10% rate and a 20 discount is taxed **8** (on 80), not 10.
**Suite: 716 passed / 0 failed.**

## Scope note
This fixes only the pre-discount over-tax. The deeper `TaxService` issues remain (task 1.5): the address is regex-parsed with country hard-forced to `US`, `tax_class`/`tax_status` ignored, no inclusive/exclusive handling — the structured `TaxCalculator` that supports those exists but is orphaned. Separate PR.

## Test plan
`php artisan test tests/Unit/TaxServiceTest.php` → 10 passed.