### PR TITLE
Repair drift/fatal/pricing bugs across inventory, wholesale, and recommendations

### DIFF
--- a/app/Models/ABTest.php
+++ b/app/Models/ABTest.php
@@ -42,10 +42,17 @@ class ABTest extends Model
      */
     public function assignVariant(?int $userId, string $sessionId): ABTestAssignment
     {
-        // Check if already assigned
-        $existing = $this->assignments()
-            ->where('session_id', $sessionId)
-            ->first();
+        // Stable assignment: a known user keeps the same variant across sessions
+        // (new device, cleared cookies). Guests fall back to their session id.
+        // When a user is known we also match their prior guest row on this
+        // session to avoid a duplicate (test_id, session_id) insert.
+        $existing = $userId !== null
+            ? $this->assignments()
+                ->where(fn ($q) => $q->where('user_id', $userId)->orWhere('session_id', $sessionId))
+                ->first()
+            : $this->assignments()
+                ->where('session_id', $sessionId)
+                ->first();
 
         if ($existing) {
             return $existing;

--- a/app/Models/InventoryItem.php
+++ b/app/Models/InventoryItem.php
@@ -80,7 +80,7 @@ class InventoryItem extends Model
                     ->value('available') ?? 0;
     }
 
-    public function adjustInventory(InventoryLocation $location, int $quantity, string $reason = null): void
+    public function adjustInventory(InventoryLocation $location, int $quantity, ?string $reason = null): void
     {
         $level = $this->inventoryLevels()->firstOrCreate([
             'location_id' => $location->id,

--- a/app/Models/InventoryLevel.php
+++ b/app/Models/InventoryLevel.php
@@ -41,15 +41,17 @@ class InventoryLevel extends Model
         return $this->belongsTo(InventoryLocation::class);
     }
 
-    public function adjustQuantity(int $quantity, string $reason = null): void
+    public function adjustQuantity(int $quantity, ?string $reason = null): void
     {
         $this->available += $quantity;
         $this->on_hand += $quantity;
         $this->save();
 
-        // Log the adjustment
+        // Log the adjustment. inventory_item_id is NOT NULL in the schema, so it
+        // must be set here or every adjustment insert fatals.
         InventoryAdjustment::create([
             'inventory_level_id' => $this->id,
+            'inventory_item_id' => $this->inventory_item_id,
             'quantity_delta' => $quantity,
             'reason' => $reason,
             'available_after' => $this->available,

--- a/app/Models/WholesalePriceTier.php
+++ b/app/Models/WholesalePriceTier.php
@@ -66,8 +66,25 @@ class WholesalePriceTier extends Model
             $query->where('wholesale_group_id', $wholesaleGroupId);
         }
 
-        $tier = $query->orderBy('min_quantity', 'desc')->first();
+        $tiers = $query->get();
 
-        return $tier ? (float) $tier->price : null;
+        if ($tiers->isEmpty()) {
+            return null;
+        }
+
+        // Percentage tiers price off the product's retail price; load it once only if needed.
+        $basePrice = $tiers->contains(fn ($t) => $t->discount_percentage !== null)
+            ? Product::find($productId)?->price
+            : null;
+
+        // Overlapping ranges can both qualify — charge the cheapest effective price, not
+        // whichever tier happens to have the highest min_quantity.
+        return $tiers->map(function ($tier) use ($basePrice) {
+            if ($tier->discount_percentage !== null && $basePrice !== null) {
+                return round((float) $basePrice * (1 - (float) $tier->discount_percentage / 100), 2);
+            }
+
+            return (float) $tier->price;
+        })->min();
     }
 }

--- a/app/Services/ABTestingService.php
+++ b/app/Services/ABTestingService.php
@@ -52,9 +52,12 @@ class ABTestingService
 
         $sessionId = $this->getSessionId();
 
-        $assignment = ABTestAssignment::where('test_id', $test->id)
-            ->where('session_id', $sessionId)
-            ->first();
+        // Match the same way assignments are made: by user when known
+        // (conversion may happen in a different session), else by session.
+        $query = ABTestAssignment::where('test_id', $test->id);
+        $assignment = $userId !== null
+            ? $query->where(fn ($q) => $q->where('user_id', $userId)->orWhere('session_id', $sessionId))->first()
+            : $query->where('session_id', $sessionId)->first();
 
         if ($assignment && !$assignment->converted) {
             $assignment->markConverted($value);

--- a/app/Services/ProductRecommendationService.php
+++ b/app/Services/ProductRecommendationService.php
@@ -44,12 +44,27 @@ class ProductRecommendationService
             return $this->getTrendingProducts($limit);
         }
 
-        // Get recommended products based on what user viewed
+        // Don't recommend products the user already bought.
+        $purchasedProductIds = ProductInteraction::where('user_id', $userId)
+            ->byType('purchase')
+            ->pluck('product_id')
+            ->unique();
+
+        // Highest score first, then dedup by product and cap at $limit
+        // (a product can be recommended by several viewed products).
         return ProductRecommendation::whereIn('product_id', $viewedProductIds)
+            ->when(
+                $purchasedProductIds->isNotEmpty(),
+                fn ($q) => $q->whereNotIn('recommended_product_id', $purchasedProductIds)
+            )
             ->with('recommendedProduct')
-            ->topRecommendations($limit)
+            ->orderByDesc('score')
             ->get()
-            ->pluck('recommendedProduct');
+            ->pluck('recommendedProduct')
+            ->filter()
+            ->unique('id')
+            ->take($limit)
+            ->values();
     }
 
     /**
@@ -68,9 +83,13 @@ class ProductRecommendationService
 
         return ProductRecommendation::whereIn('product_id', $viewedProductIds)
             ->with('recommendedProduct')
-            ->topRecommendations($limit)
+            ->orderByDesc('score')
             ->get()
-            ->pluck('recommendedProduct');
+            ->pluck('recommendedProduct')
+            ->filter()
+            ->unique('id')
+            ->take($limit)
+            ->values();
     }
 
     /**

--- a/app/Services/RecommendationService.php
+++ b/app/Services/RecommendationService.php
@@ -4,9 +4,6 @@ namespace App\Services;
 
 use App\Models\User;
 use App\Models\Product;
-use App\Models\Order;
-use App\Models\Rating;
-use App\Models\BrowsingHistory;
 
 class RecommendationService
 {
@@ -27,19 +24,26 @@ class RecommendationService
         // Recommend based on highly rated products
         $recommendedProducts = $recommendedProducts->merge($this->getHighlyRatedProducts($ratedProducts));
 
-        // Remove duplicates and products already purchased or browsed
-        $recommendedProducts = $recommendedProducts->unique('id')
-            ->diff($purchasedProducts)
-            ->diff($browsedProducts)
-            ->sortByDesc('rating')
-            ->take($limit);
+        // Remove duplicates and products already purchased or browsed.
+        // NB: this is a base Collection of models, so exclude by id — a
+        // Collection::diff() here would string-cast the models and fatal.
+        $excludeIds = $purchasedProducts->pluck('id')
+            ->merge($browsedProducts->pluck('id'))
+            ->unique();
 
-        return $recommendedProducts;
+        return $recommendedProducts->unique('id')
+            ->reject(fn ($product) => $excludeIds->contains($product->id))
+            ->sortByDesc('rating')
+            ->take($limit)
+            ->values();
     }
 
     private function getPurchasedProducts(User $user)
     {
-        return $user->orders()->with('products')->get()->pluck('products')->flatten()->unique('id');
+        // Order has no `products` relation; go through its line items.
+        return $user->orders()->with('items.product')->get()
+            ->pluck('items')->flatten()
+            ->pluck('product')->filter()->unique('id');
     }
 
     private function getBrowsedProducts(User $user)
@@ -54,15 +58,24 @@ class RecommendationService
 
     private function getRelatedProducts($products)
     {
-        return Product::whereHas('categories', function ($query) use ($products) {
-            $query->whereIn('id', $products->pluck('categories.*.id')->flatten());
-        })->get();
+        // Product belongs to a single category (category_id), not a `categories`
+        // relation. Recommend same-category products, excluding the seeds.
+        $categoryIds = $products->pluck('category_id')->filter()->unique();
+
+        if ($categoryIds->isEmpty()) {
+            return collect();
+        }
+
+        return Product::whereIn('category_id', $categoryIds)
+            ->whereNotIn('id', $products->pluck('id')->filter())
+            ->get();
     }
 
     private function getHighlyRatedProducts($products)
     {
+        // Product exposes `rating()` (ProductRating), which has a `rating` column.
         return Product::whereIn('id', $products->pluck('id'))
-            ->withAvg('ratings as rating', 'rating')
+            ->withAvg('rating as rating', 'rating')
             ->orderByDesc('rating')
             ->take(10)
             ->get();

--- a/database/migrations/2026_07_14_000601_create_browsing_histories_table.php
+++ b/database/migrations/2026_07_14_000601_create_browsing_histories_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('browsing_histories')) {
+            return;
+        }
+
+        Schema::create('browsing_histories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('product_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+
+            $table->index(['user_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('browsing_histories');
+    }
+};

--- a/tests/Unit/ABTestModelTest.php
+++ b/tests/Unit/ABTestModelTest.php
@@ -92,6 +92,23 @@ class ABTestModelTest extends TestCase
         $this->assertEquals($user->id, $assignment->user_id);
     }
 
+    public function test_assign_variant_is_stable_per_user_across_sessions(): void
+    {
+        $test = $this->makeTest();
+        $user = User::factory()->create();
+
+        // Same user, two different sessions (e.g. new device / cleared cookies)
+        $first = $test->assignVariant($user->id, 'session_one');
+        $second = $test->assignVariant($user->id, 'session_two');
+
+        $this->assertEquals($first->id, $second->id);
+        $this->assertEquals($first->variant_name, $second->variant_name);
+        $this->assertEquals(
+            1,
+            ABTestAssignment::where('test_id', $test->id)->where('user_id', $user->id)->count()
+        );
+    }
+
     public function test_get_conversion_rates_returns_stats_per_variant(): void
     {
         $test = $this->makeTest();

--- a/tests/Unit/ABTestingServiceTest.php
+++ b/tests/Unit/ABTestingServiceTest.php
@@ -4,10 +4,9 @@ namespace Tests\Unit;
 
 use App\Models\ABTest;
 use App\Models\ABTestAssignment;
+use App\Models\User;
 use App\Services\ABTestingService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Cookie;
-use Illuminate\Support\Facades\Session;
 use Tests\TestCase;
 
 class ABTestingServiceTest extends TestCase
@@ -127,6 +126,26 @@ class ABTestingServiceTest extends TestCase
         } else {
             $this->markTestSkipped('No assignment created (session ID mismatch)');
         }
+    }
+
+    public function test_track_conversion_finds_assignment_by_user_across_sessions(): void
+    {
+        $test = $this->makeActiveTest();
+        $user = User::factory()->create();
+
+        // User assigned under one session id...
+        $test->assignVariant($user->id, 'assigned_session');
+
+        // ...converts later when the active session id differs, but user is known.
+        $this->service->trackConversion('button_test', 42.00, $user->id);
+
+        $assignment = ABTestAssignment::where('test_id', $test->id)
+            ->where('user_id', $user->id)
+            ->first();
+
+        $this->assertNotNull($assignment);
+        $this->assertTrue($assignment->fresh()->converted);
+        $this->assertEquals(42.00, $assignment->fresh()->conversion_value);
     }
 
     public function test_create_test_creates_draft_test(): void

--- a/tests/Unit/InventoryAdjustmentModelTest.php
+++ b/tests/Unit/InventoryAdjustmentModelTest.php
@@ -101,4 +101,23 @@ class InventoryAdjustmentModelTest extends TestCase
 
         $this->assertIsInt($adj->fresh()->quantity_delta);
     }
+
+    public function test_adjust_quantity_updates_level_and_logs_adjustment(): void
+    {
+        $item = $this->makeInventoryItem();
+        $level = $this->makeLevel($item); // available 100
+
+        $level->adjustQuantity(10, 'restock');
+
+        $level->refresh();
+        $this->assertSame(110, $level->available);
+        $this->assertSame(10, $level->on_hand);
+
+        $adj = InventoryAdjustment::latest('id')->first();
+        $this->assertNotNull($adj);
+        // inventory_item_id is NOT NULL in the schema; adjustQuantity must set it.
+        $this->assertSame($item->id, $adj->inventory_item_id);
+        $this->assertSame(10, $adj->quantity_delta);
+        $this->assertSame(110, $adj->available_after);
+    }
 }

--- a/tests/Unit/ProductRecommendationServiceTest.php
+++ b/tests/Unit/ProductRecommendationServiceTest.php
@@ -4,8 +4,9 @@ namespace Tests\Unit;
 
 use App\Models\Product;
 use App\Models\ProductCategory;
+use App\Models\ProductInteraction;
 use App\Models\ProductRecommendation;
-use App\Models\RecommendationRule;
+use App\Models\User;
 use App\Services\ProductRecommendationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -57,6 +58,63 @@ class ProductRecommendationServiceTest extends TestCase
 
         $this->assertInstanceOf(ProductRecommendation::class, $rec);
         $this->assertEquals(85.5, $rec->score);
+    }
+
+    public function test_user_recommendations_dedup_and_exclude_purchased(): void
+    {
+        $user = User::factory()->create();
+        $viewedA = $this->makeProduct();
+        $viewedB = $this->makeProduct();
+        $recommended = $this->makeProduct();
+        $purchased = $this->makeProduct();
+
+        // User viewed A and B, and already purchased $purchased.
+        foreach ([$viewedA->id, $viewedB->id] as $pid) {
+            ProductInteraction::create([
+                'user_id' => $user->id,
+                'session_id' => 'sess',
+                'product_id' => $pid,
+                'interaction_type' => 'view',
+                'interacted_at' => now(),
+            ]);
+        }
+        ProductInteraction::create([
+            'user_id' => $user->id,
+            'session_id' => 'sess',
+            'product_id' => $purchased->id,
+            'interaction_type' => 'purchase',
+            'interacted_at' => now(),
+        ]);
+
+        // Both viewed products recommend the SAME product (duplicate),
+        // and A also recommends the already-purchased product.
+        ProductRecommendation::create([
+            'product_id' => $viewedA->id,
+            'recommended_product_id' => $recommended->id,
+            'score' => 0.9,
+            'reason' => 'test',
+        ]);
+        ProductRecommendation::create([
+            'product_id' => $viewedB->id,
+            'recommended_product_id' => $recommended->id,
+            'score' => 0.8,
+            'reason' => 'test',
+        ]);
+        ProductRecommendation::create([
+            'product_id' => $viewedA->id,
+            'recommended_product_id' => $purchased->id,
+            'score' => 0.95,
+            'reason' => 'test',
+        ]);
+
+        $recs = $this->service->getPersonalizedRecommendations($user->id, null, 10);
+        $ids = $recs->pluck('id');
+
+        // Deduplicated: the recommended product appears exactly once.
+        $this->assertEquals(1, $ids->filter(fn ($id) => $id === $recommended->id)->count());
+        // Already-purchased product is excluded.
+        $this->assertFalse($ids->contains($purchased->id));
+        $this->assertTrue($ids->contains($recommended->id));
     }
 
     public function test_top_recommendations_scope_orders_by_score(): void

--- a/tests/Unit/RecommendationServiceTest.php
+++ b/tests/Unit/RecommendationServiceTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit;
 
+use App\Models\Product;
+use App\Models\User;
 use App\Services\RecommendationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -15,5 +17,22 @@ class RecommendationServiceTest extends TestCase
         $service = app(RecommendationService::class);
 
         $this->assertInstanceOf(RecommendationService::class, $service);
+    }
+
+    public function test_browsing_history_can_be_recorded_and_related(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create();
+
+        $user->browsingHistory()->create(['product_id' => $product->id]);
+
+        $this->assertDatabaseHas('browsing_histories', [
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+        ]);
+
+        $history = $user->browsingHistory()->with('product')->first();
+        $this->assertNotNull($history);
+        $this->assertEquals($product->id, $history->product->id);
     }
 }

--- a/tests/Unit/WholesalePriceTierModelTest.php
+++ b/tests/Unit/WholesalePriceTierModelTest.php
@@ -86,4 +86,52 @@ class WholesalePriceTierModelTest extends TestCase
         $this->assertInstanceOf(Product::class, $tier->product);
         $this->assertEquals($this->product->id, $tier->product->id);
     }
+
+    public function test_overlapping_tiers_return_cheapest_qualifying_price(): void
+    {
+        // A wide promo tier (10-100 @ 30) overlaps a bulk tier (50+ @ 35).
+        // At qty 60 both ranges qualify; the customer must get the cheaper 30,
+        // not the higher-min (pricier) tier.
+        $this->makeTier(['min_quantity' => 10, 'max_quantity' => 100, 'price' => 30.00]);
+        $this->makeTier(['min_quantity' => 50, 'max_quantity' => null, 'price' => 35.00]);
+
+        $price = WholesalePriceTier::getPriceForQuantity($this->product->id, 60);
+
+        $this->assertEquals(30.0, $price);
+    }
+
+    public function test_max_quantity_boundary_is_inclusive_and_non_overlapping(): void
+    {
+        $this->makeTier(['min_quantity' => 10, 'max_quantity' => 49, 'price' => 40.00]);
+        $this->makeTier(['min_quantity' => 50, 'max_quantity' => null, 'price' => 35.00]);
+
+        $this->assertEquals(40.0, WholesalePriceTier::getPriceForQuantity($this->product->id, 49));
+        $this->assertEquals(35.0, WholesalePriceTier::getPriceForQuantity($this->product->id, 50));
+    }
+
+    public function test_percentage_tier_computes_discount_off_retail_price(): void
+    {
+        // product retail price is 50.00 (see setUp). A 10% percentage tier must
+        // yield 45.00 regardless of the fixed `price` column value.
+        $this->makeTier([
+            'min_quantity' => 10,
+            'price' => 99.00,
+            'discount_percentage' => 10.00,
+        ]);
+
+        $price = WholesalePriceTier::getPriceForQuantity($this->product->id, 20);
+
+        $this->assertEquals(45.0, $price);
+    }
+
+    public function test_fixed_price_tier_ignores_null_discount_percentage(): void
+    {
+        $this->makeTier([
+            'min_quantity' => 10,
+            'price' => 42.00,
+            'discount_percentage' => null,
+        ]);
+
+        $this->assertEquals(42.0, WholesalePriceTier::getPriceForQuantity($this->product->id, 20));
+    }
 }


### PR DESCRIPTION
Second parallel subsystem audit (follows #697). **Eight bugs** the green suite never exercised, across three more self-contained subsystems — additive/root-cause with tests, nothing weakened.

**Suite: 742 passed / 0 failed** (deterministic). New migration verified on sqlite + MySQL 8.4.

## Inventory
- **Fatal on a live admin path:** `InventoryLevel::adjustQuantity()` logged an `InventoryAdjustment` without the NOT-NULL `inventory_item_id` → every adjustment fataled. It's wired to a **live Filament admin "adjust inventory" action** (`ProductResource`), so the button 500'd in production. Now sets `inventory_item_id`.
- PHP 8.5 deprecation: implicit-nullable `string $reason = null` → `?string` in `adjustQuantity`/`adjustInventory`.

## Wholesale / B2B (money)
- `WholesalePriceTier::getPriceForQuantity()` returned the tier with the highest `min_quantity` among overlapping tiers → **picked the pricier one (overcharge)**, and never consulted `discount_percentage` → percentage tiers mispriced. Now returns the **cheapest qualifying effective price**.

## Recommendations & A/B
- `browsing_histories` table had **no migration** (model + `User` relation + service use it) → fatal `no such table`. Added.
- `ABTest::assignVariant()` matched only by `session_id` → a logged-in user was **re-randomized across sessions/devices**. Now matches by `user_id` when known.
- `ABTestingService::trackConversion()` **ignored its `$userId`** (session-only) → cross-session conversions unrecorded. Fixed.
- `ProductRecommendationService` returned **duplicate** products and re-recommended **already-purchased** items → dedup + exclude purchases.
- `RecommendationService` had multiple **fatal** wrong `Product` refs (`categories`/`ratings` relations, `diff()` on model collections, `Order->products`) → fixed to `category_id` / rating relation / reject-by-id / `items.product`.

## Reported, not built (needs Order/User owner)
`User::orders()` is `hasMany` keyed on a **nonexistent `orders.user_id`** (orders link via `customer_id`) → `$user->orders()` fatals. Blocks a live `RecommendationService::getRecommendations()` path (only called from commented-out code today) and also affects `DownloadController` + `CustomerMetric`. Two agents have now independently confirmed this — it's the next thing to fix, and needs a User-vs-Customer ownership decision.

## Test plan
`php artisan test` → 742 passed / 0 failed.