### PR TITLE
Link orders to users (fix downloads, LTV, recommendations)

### DIFF
--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -136,6 +136,7 @@ class CheckoutController extends Controller
         try {
             DB::transaction(function () use (&$order, $cart, $request, $totalAmount, $shippingCost, $taxAmount, $discountAmount, $couponCode) {
                 $order = Order::create([
+                    'user_id' => auth()->id(),
                     'customer_email' => $request->email,
                     'shipping_address' => $request->shipping_address,
                     'shipping_method_id' => $request->shipping_method_id,

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\DownloadableProduct;
+use App\Models\Order;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -64,7 +65,7 @@ class DownloadController extends Controller
             ->whereHas('items', function ($query) use ($downloadableProduct) {
                 $query->where('product_id', $downloadableProduct->product_id);
             })
-            ->where('status', 'completed')
+            ->whereIn('status', [Order::STATUS_PAID, Order::STATUS_COMPLETED])
             ->exists();
     }
 }

--- a/app/Models/CustomerMetric.php
+++ b/app/Models/CustomerMetric.php
@@ -50,12 +50,14 @@ class CustomerMetric extends Model
     public function recalculate(): void
     {
         $user = $this->user;
-        $orders = $user->orders()->where('status', 'completed')->get();
+        $orders = $user->orders()
+            ->whereIn('status', [Order::STATUS_PAID, Order::STATUS_COMPLETED])
+            ->get();
 
         $this->update([
             'total_orders' => $orders->count(),
-            'lifetime_value' => $orders->sum('total'),
-            'average_order_value' => $orders->avg('total') ?? 0,
+            'lifetime_value' => $orders->sum('total_amount'),
+            'average_order_value' => $orders->avg('total_amount') ?? 0,
             'total_items_purchased' => $orders->sum(function ($order) {
                 return $order->items->sum('quantity');
             }),

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -53,6 +53,7 @@ class Order extends Model
 
     protected $fillable = [
         'customer_id',
+        'user_id',
         'customer_email',
         'order_date',
         'total_amount',

--- a/database/migrations/2026_07_14_000701_add_user_id_to_orders_table.php
+++ b/database/migrations/2026_07_14_000701_add_user_id_to_orders_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * User::orders() is hasMany(Order) keyed on the default `user_id`, but orders
+     * only had `customer_id` (a Customer) and no user_id — so $user->orders()
+     * fataled, breaking downloads, LTV, and recommendations. Add a nullable
+     * user_id (guest orders stay email-only / null).
+     */
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            if (! Schema::hasColumn('orders', 'user_id')) {
+                $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('user_id');
+        });
+    }
+};

--- a/database/migrations/2026_07_14_000702_add_downloads_count_to_downloadable_products_table.php
+++ b/database/migrations/2026_07_14_000702_add_downloads_count_to_downloadable_products_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * DownloadableProduct's $fillable/$casts include downloads_count, but the
+     * table never had the column -> any create with it fatals.
+     */
+    public function up(): void
+    {
+        Schema::table('downloadable_products', function (Blueprint $table) {
+            if (! Schema::hasColumn('downloadable_products', 'downloads_count')) {
+                $table->integer('downloads_count')->default(0);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('downloadable_products', function (Blueprint $table) {
+            $table->dropColumn('downloads_count');
+        });
+    }
+};

--- a/tests/Feature/CheckoutInventoryTest.php
+++ b/tests/Feature/CheckoutInventoryTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Interfaces\PaymentGatewayInterface;
 use App\Models\Order;
 use App\Models\Product;
+use App\Models\User;
 use App\Services\PaymentGateways\StripeGateway;
 use Closure;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -121,5 +122,33 @@ class CheckoutInventoryTest extends TestCase
         $this->assertSame('failed', $order->status);
         // Reserved stock must be released back when the charge fails.
         $this->assertSame(5, $product->fresh()->inventory_count, 'Inventory was lost on a failed payment');
+    }
+
+    public function test_authenticated_checkout_links_the_order_to_the_user(): void
+    {
+        Notification::fake();
+        $this->bindGateway(fn () => ['success' => true, 'transaction_id' => 'ch_1']);
+
+        $user = User::factory()->create();
+        $product = Product::factory()->create(['inventory_count' => 5, 'is_downloadable' => true]);
+
+        $this->actingAs($user)
+            ->withSession(['cart' => $this->cartFor($product, 1)])
+            ->post(route('checkout.process'), $this->payload());
+
+        $this->assertSame($user->id, Order::first()->user_id);
+    }
+
+    public function test_guest_checkout_leaves_the_order_user_id_null(): void
+    {
+        Notification::fake();
+        $this->bindGateway(fn () => ['success' => true, 'transaction_id' => 'ch_1']);
+
+        $product = Product::factory()->create(['inventory_count' => 5, 'is_downloadable' => true]);
+
+        $this->withSession(['cart' => $this->cartFor($product, 1)])
+            ->post(route('checkout.process'), $this->payload());
+
+        $this->assertNull(Order::first()->user_id);
     }
 }

--- a/tests/Feature/OrderUserLinkageTest.php
+++ b/tests/Feature/OrderUserLinkageTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\DownloadController;
+use App\Models\CustomerMetric;
+use App\Models\DownloadableProduct;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OrderUserLinkageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function paidOrderFor(User $user, Product $product, float $total): Order
+    {
+        $order = Order::create([
+            'user_id' => $user->id,
+            'customer_email' => $user->email,
+            'total_amount' => $total,
+            'status' => Order::STATUS_PAID,
+        ]);
+        $order->items()->create(['product_id' => $product->id, 'quantity' => 1, 'price' => $total]);
+
+        return $order;
+    }
+
+    public function test_user_orders_relation_resolves_and_scopes_to_the_user(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create();
+        $mine = $this->paidOrderFor($user, $product, 25);
+        Order::create(['customer_email' => 'guest@example.com', 'total_amount' => 5, 'status' => Order::STATUS_PAID]);
+
+        $orders = $user->orders()->get();
+
+        $this->assertTrue($orders->contains('id', $mine->id));
+        $this->assertCount(1, $orders);
+    }
+
+    public function test_download_is_authorized_for_a_paid_order(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create(['price' => 20]);
+        $this->paidOrderFor($user, $product, 20);
+        $downloadable = DownloadableProduct::create([
+            'product_id' => $product->id,
+            'file_url' => 'files/x.zip',
+            'download_limit' => 5,
+            'downloads_count' => 0,
+        ]);
+
+        $method = new \ReflectionMethod(DownloadController::class, 'authorizeDownload');
+        $granted = $method->invoke(app(DownloadController::class), $user, $downloadable);
+
+        $this->assertTrue($granted, 'A paid order should grant download access');
+    }
+
+    public function test_customer_metric_lifetime_value_sums_paid_orders(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create();
+        $this->paidOrderFor($user, $product, 100);
+        $this->paidOrderFor($user, $product, 50);
+
+        $metric = CustomerMetric::create(['user_id' => $user->id]);
+        $metric->recalculate();
+
+        $this->assertSame(2, $metric->fresh()->total_orders);
+        $this->assertEquals(150.0, (float) $metric->fresh()->lifetime_value);
+    }
+}


### PR DESCRIPTION
`User::orders()` is `hasMany(Order)` keyed on the default `user_id`, but orders only had `customer_id` and **no `user_id` column** → `$user->orders()` threw `no such column: orders.user_id`. Three subsystems call it and were dead-or-fatal: the download purchase gate, CustomerMetric LTV, and RecommendationService's purchase step. (Confirmed independently by two subsystem-audit agents.)

Per the chosen approach: add `orders.user_id`, populate at authenticated checkout, guest orders stay email-only.

**Suite: 738 passed / 0 failed.** Migrations verified on sqlite + MySQL 8.4.

## Changes
- **Migration:** nullable `orders.user_id` (FK to users, `nullOnDelete`).
- **CheckoutController:** `user_id = auth()->id()` at order creation (null for guests).
- **DownloadController gate:** queried `status = 'completed'` — a status the app **never sets** (so no digital order was ever downloadable) → `whereIn('status', [paid, completed])`, and the relation now resolves.
- **CustomerMetric::recalculate:** same status fix, plus it summed `$orders->sum('total')`/`avg('total')` against a **nonexistent column** → `total_amount`.
- **Adjacent drift:** `downloadable_products` had no `downloads_count` column though the model writes it → added.

## Tests
- `user->orders()` scopes to the user (relation + column).
- A paid order grants download access (`authorizeDownload`).
- CustomerMetric LTV sums paid orders' `total_amount`.
- Authenticated checkout links the order to the user; guest checkout leaves `user_id` null.

## Follow-on now unblocked
`RecommendationService::getRecommendations()` purchase step (fixed in #698 but blocked on this) now has a working `$user->orders()`.

## Test plan
`php artisan test` → 738 passed / 0 failed.