### PR TITLE
Repair drift/fatal/logic bugs across segmentation, analytics, chat (+ Carbon 3 sweep)

### DIFF
--- a/app/Models/CustomerMetric.php
+++ b/app/Models/CustomerMetric.php
@@ -64,7 +64,7 @@ class CustomerMetric extends Model
             'first_purchase_at' => $orders->min('created_at'),
             'last_purchase_at' => $orders->max('created_at'),
             'days_since_last_purchase' => $orders->max('created_at')
-                ? now()->diffInDays($orders->max('created_at'))
+                ? $orders->max('created_at')->diffInDays(now())
                 : null,
             'customer_segment' => $this->calculateSegment($orders),
             'retention_score' => $this->calculateRetentionScore($orders),

--- a/app/Models/CustomerSegment.php
+++ b/app/Models/CustomerSegment.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class CustomerSegment extends Model
@@ -45,9 +44,15 @@ class CustomerSegment extends Model
         }
 
         $query = User::query();
-        
+
+        // match_type 'any' => OR the conditions, 'all' => AND them.
+        // Each condition is its own nested group so whereHas/has clauses combine correctly.
+        $boolean = $this->match_type === 'any' ? 'orWhere' : 'where';
+
         foreach ($this->conditions as $condition) {
-            $this->applyCondition($query, $condition);
+            $query->{$boolean}(function ($q) use ($condition) {
+                $this->applyCondition($q, $condition);
+            });
         }
 
         $userIds = $query->pluck('id');
@@ -77,9 +82,9 @@ class CustomerSegment extends Model
 
         // Handle different condition types
         match($field) {
-            'total_orders' => $query->whereHas('orders', function($q) use ($operator, $value) {
-                $q->havingRaw("COUNT(*) {$operator} ?", [$value]);
-            }),
+            // has() builds a correlated `(select count(*) ...) <op> <value>` predicate.
+            // The old havingRaw()-in-whereHas produced invalid SQL ("HAVING on a non-aggregate query").
+            'total_orders' => $query->has('orders', $operator, (int) $value),
             'lifetime_value' => $query->whereHas('customerMetric', function($q) use ($operator, $value) {
                 $q->where('lifetime_value', $operator, $value);
             }),

--- a/app/Models/ProductPerformance.php
+++ b/app/Models/ProductPerformance.php
@@ -11,6 +11,10 @@ class ProductPerformance extends Model
 {
     use HasFactory, IsTenantModel;
 
+    // Migration creates `product_performance`; without this, Eloquent would
+    // pluralise to the non-existent `product_performances` and every query fatals.
+    protected $table = 'product_performance';
+
     protected $fillable = [
         'product_id',
         'date',
@@ -24,7 +28,10 @@ class ProductPerformance extends Model
     ];
 
     protected $casts = [
-        'date' => 'date',
+        // No date cast: the record* helpers store/query the date as a plain
+        // 'Y-m-d' string. A Carbon cast serialises to 'Y-m-d 00:00:00', which
+        // updateOrCreate's raw lookup then never matches -> duplicate INSERT
+        // and a unique(product_id, date) violation on the second call of a day.
         'views' => 'integer',
         'add_to_cart' => 'integer',
         'purchases' => 'integer',

--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -75,7 +75,7 @@ class ChatService
         // Calculate response time
         $analytics = $conversation->analytics;
         if ($analytics && !$analytics->response_time_seconds) {
-            $responseTime = now()->diffInSeconds($conversation->created_at);
+            $responseTime = $conversation->created_at->diffInSeconds(now());
             $analytics->update(['response_time_seconds' => $responseTime]);
         }
 
@@ -103,7 +103,7 @@ class ChatService
         // Update resolution time
         $analytics = $conversation->analytics;
         if ($analytics && $conversation->started_at) {
-            $resolutionTime = now()->diffInSeconds($conversation->started_at);
+            $resolutionTime = $conversation->started_at->diffInSeconds(now());
             $analytics->update(['resolution_time_seconds' => $resolutionTime]);
         }
 

--- a/tests/Feature/OrderUserLinkageTest.php
+++ b/tests/Feature/OrderUserLinkageTest.php
@@ -72,4 +72,18 @@ class OrderUserLinkageTest extends TestCase
         $this->assertSame(2, $metric->fresh()->total_orders);
         $this->assertEquals(150.0, (float) $metric->fresh()->lifetime_value);
     }
+
+    public function test_customer_metric_days_since_last_purchase_is_not_negative(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create();
+        $order = $this->paidOrderFor($user, $product, 100);
+        $order->forceFill(['created_at' => now()->subDays(5)])->save();
+
+        $metric = CustomerMetric::create(['user_id' => $user->id]);
+        $metric->recalculate();
+
+        // Carbon 3's now()->diffInDays($past) is negative; days elapsed must be >= 0.
+        $this->assertGreaterThanOrEqual(0, (int) $metric->fresh()->days_since_last_purchase);
+    }
 }

--- a/tests/Unit/AnalyticsServiceTest.php
+++ b/tests/Unit/AnalyticsServiceTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use App\Models\Customer;
 use App\Models\Order;
+use App\Models\OrderItem;
 use App\Models\Product;
 use App\Models\ProductCategory;
 use App\Services\AnalyticsService;
@@ -182,5 +183,88 @@ class AnalyticsServiceTest extends TestCase
         $demographics = $this->service->getCustomerDemographics();
 
         $this->assertEquals(2, $demographics['total_customers']);
+    }
+
+    public function test_get_sales_metrics_computes_aov_and_growth(): void
+    {
+        Carbon::setTestNow('2026-07-12 12:00:00');
+        $customer = $this->makeCustomer(20);
+
+        $start = Carbon::parse('2026-07-03');
+        $end = Carbon::parse('2026-07-12 12:00:00');
+
+        // Current window: two paid orders -> revenue 300, count 2, AOV 150.
+        $this->makeOrder($customer, ['order_date' => '2026-07-05', 'total_amount' => 200]);
+        $this->makeOrder($customer, ['order_date' => '2026-07-06', 'total_amount' => 100]);
+        // Previous window (before $start): one paid order -> revenue 150.
+        $this->makeOrder($customer, ['order_date' => '2026-06-27', 'total_amount' => 150]);
+
+        $metrics = $this->service->getSalesMetrics($start, $end);
+
+        $this->assertEquals(2, $metrics['order_count']);
+        $this->assertEquals(300, $metrics['total_revenue']);
+        $this->assertEquals(150, $metrics['avg_order_value']);
+        $this->assertEquals(100.0, $metrics['revenue_growth']); // (300-150)/150*100
+        $this->assertEquals(100.0, $metrics['order_growth']);   // (2-1)/1*100
+    }
+
+    public function test_get_sales_metrics_excludes_orders_outside_range(): void
+    {
+        Carbon::setTestNow('2026-07-12 12:00:00');
+        $customer = $this->makeCustomer(21);
+
+        $this->makeOrder($customer, ['order_date' => '2026-07-10', 'total_amount' => 80]);
+        // Way outside the default 30-day window.
+        $this->makeOrder($customer, ['order_date' => '2026-01-01', 'total_amount' => 999]);
+
+        $metrics = $this->service->getSalesMetrics();
+
+        $this->assertEquals(1, $metrics['order_count']);
+        $this->assertEquals(80, $metrics['total_revenue']);
+    }
+
+    public function test_get_sales_trends_daily_groups_and_aggregates(): void
+    {
+        Carbon::setTestNow('2026-07-12 12:00:00');
+        $customer = $this->makeCustomer(22);
+
+        $this->makeOrder($customer, ['order_date' => '2026-07-10', 'total_amount' => 100]);
+        $this->makeOrder($customer, ['order_date' => '2026-07-10', 'total_amount' => 300]);
+        $this->makeOrder($customer, ['order_date' => '2026-07-11', 'total_amount' => 50]);
+        // Unpaid must be ignored.
+        $this->makeOrder($customer, ['order_date' => '2026-07-10', 'total_amount' => 500, 'payment_status' => 'pending']);
+
+        $trends = $this->service->getSalesTrends('daily');
+
+        $this->assertCount(2, $trends);
+        $byPeriod = collect($trends)->keyBy('period');
+        $this->assertEquals(2, $byPeriod['2026-07-10']['order_count']);
+        $this->assertEquals(400, $byPeriod['2026-07-10']['total_revenue']);
+        $this->assertEquals(200, $byPeriod['2026-07-10']['avg_order_value']);
+        $this->assertEquals(50, $byPeriod['2026-07-11']['total_revenue']);
+    }
+
+    public function test_get_top_products_ranks_by_revenue_and_ignores_unpaid(): void
+    {
+        Carbon::setTestNow('2026-07-12 12:00:00');
+        $customer = $this->makeCustomer(23);
+        $cheap = $this->makeProduct(['name' => 'Cheap']);
+        $pricey = $this->makeProduct(['name' => 'Pricey']);
+
+        $paid = $this->makeOrder($customer, ['order_date' => '2026-07-10', 'total_amount' => 100]);
+        OrderItem::create(['order_id' => $paid->id, 'product_id' => $cheap->id, 'quantity' => 10, 'price' => 1.00]);   // rev 10
+        OrderItem::create(['order_id' => $paid->id, 'product_id' => $pricey->id, 'quantity' => 2, 'price' => 50.00]);  // rev 100
+
+        $unpaid = $this->makeOrder($customer, ['order_date' => '2026-07-10', 'total_amount' => 999, 'payment_status' => 'pending']);
+        OrderItem::create(['order_id' => $unpaid->id, 'product_id' => $cheap->id, 'quantity' => 1000, 'price' => 1.00]);
+
+        $top = json_decode(json_encode($this->service->getTopProducts(10)), true);
+
+        $this->assertCount(2, $top);
+        $this->assertEquals('Pricey', $top[0]['name']);
+        $this->assertEquals(100, $top[0]['total_revenue']);
+        $this->assertEquals('Cheap', $top[1]['name']);
+        $this->assertEquals(10, $top[1]['total_revenue']);   // unpaid 1000 units excluded
+        $this->assertEquals(10, $top[1]['total_quantity']);
     }
 }

--- a/tests/Unit/ChatServiceTest.php
+++ b/tests/Unit/ChatServiceTest.php
@@ -208,4 +208,33 @@ class ChatServiceTest extends TestCase
         $this->assertCount(1, $results);
         $this->assertEquals($conversation->id, $results->first()->id);
     }
+
+    public function test_assign_agent_records_positive_response_time(): void
+    {
+        $agent = User::factory()->create();
+        $this->freezeTime();
+        $conversation = $this->service->createConversation(['session_id' => 'sess_rt']);
+
+        $this->travel(30)->seconds();
+        $this->service->assignAgent($conversation->id, $agent->id);
+
+        $analytics = ChatAnalytics::where('conversation_id', $conversation->id)->first();
+        $this->assertGreaterThanOrEqual(0, $analytics->response_time_seconds);
+        $this->assertEqualsWithDelta(30, $analytics->response_time_seconds, 1);
+    }
+
+    public function test_close_conversation_records_positive_resolution_time(): void
+    {
+        $agent = User::factory()->create();
+        $this->freezeTime();
+        $conversation = $this->service->createConversation(['session_id' => 'sess_res']);
+        $this->service->assignAgent($conversation->id, $agent->id);
+
+        $this->travel(60)->seconds();
+        $this->service->closeConversation($conversation->id);
+
+        $analytics = ChatAnalytics::where('conversation_id', $conversation->id)->first();
+        $this->assertGreaterThanOrEqual(0, $analytics->resolution_time_seconds);
+        $this->assertEqualsWithDelta(60, $analytics->resolution_time_seconds, 1);
+    }
 }

--- a/tests/Unit/CustomerSegmentTest.php
+++ b/tests/Unit/CustomerSegmentTest.php
@@ -2,7 +2,10 @@
 
 namespace Tests\Unit;
 
+use App\Models\Customer;
+use App\Models\CustomerMetric;
 use App\Models\CustomerSegment;
+use App\Models\Order;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -10,6 +13,51 @@ use Tests\TestCase;
 class CustomerSegmentTest extends TestCase
 {
     use RefreshDatabase;
+
+    private function makeSegment(array $conditions, string $matchType): CustomerSegment
+    {
+        return CustomerSegment::create([
+            'name' => 'seg',
+            'conditions' => $conditions,
+            'match_type' => $matchType,
+            'is_active' => true,
+        ]);
+    }
+
+    private function userWithLtv(float $ltv): User
+    {
+        $user = User::factory()->create();
+        CustomerMetric::create([
+            'user_id' => $user->id,
+            'lifetime_value' => $ltv,
+            'total_orders' => 0,
+        ]);
+
+        return $user;
+    }
+
+    private function userWithOrderCount(int $count): User
+    {
+        $user = User::factory()->create();
+        $customer = Customer::create([
+            'first_name' => 'A', 'last_name' => 'B', 'email' => uniqid().'@x.com',
+            'phone_number' => 5551234, 'address' => 'a', 'city' => 'c', 'state' => 's', 'postal_code' => 'z',
+        ]);
+
+        for ($i = 0; $i < $count; $i++) {
+            Order::create([
+                'user_id' => $user->id,
+                'customer_id' => $customer->id,
+                'order_date' => now()->toDateString(),
+                'total_amount' => 100,
+                'payment_status' => 'paid',
+                'shipping_status' => 'pending',
+                'status' => 'paid',
+            ]);
+        }
+
+        return $user;
+    }
 
     public function test_customer_segment_can_be_created()
     {
@@ -49,5 +97,70 @@ class CustomerSegmentTest extends TestCase
         $activeSegments = CustomerSegment::active()->get();
 
         $this->assertEquals(1, $activeSegments->count());
+    }
+
+    public function test_match_type_any_matches_users_satisfying_either_condition(): void
+    {
+        $rich = $this->userWithLtv(2000);
+        $poor = $this->userWithLtv(5);
+        $mid  = $this->userWithLtv(500);
+
+        $segment = $this->makeSegment([
+            ['field' => 'lifetime_value', 'operator' => '>=', 'value' => 1000],
+            ['field' => 'lifetime_value', 'operator' => '<=', 'value' => 10],
+        ], 'any');
+
+        $segment->calculateMembers();
+
+        $ids = $segment->members()->pluck('users.id')->all();
+        $this->assertContains($rich->id, $ids, 'lifetime_value >= 1000 should match under "any"');
+        $this->assertContains($poor->id, $ids, 'lifetime_value <= 10 should match under "any"');
+        $this->assertNotContains($mid->id, $ids, 'user matching neither condition must be excluded');
+        $this->assertEquals(2, $segment->customer_count);
+    }
+
+    public function test_match_type_all_requires_every_condition(): void
+    {
+        $mid  = $this->userWithLtv(500);
+        $rich = $this->userWithLtv(2000);
+        $poor = $this->userWithLtv(5);
+
+        $segment = $this->makeSegment([
+            ['field' => 'lifetime_value', 'operator' => '>=', 'value' => 100],
+            ['field' => 'lifetime_value', 'operator' => '<=', 'value' => 1000],
+        ], 'all');
+
+        $segment->calculateMembers();
+
+        $ids = $segment->members()->pluck('users.id')->all();
+        $this->assertContains($mid->id, $ids, 'user in [100,1000] should match under "all"');
+        $this->assertNotContains($rich->id, $ids, 'user above upper bound must be excluded');
+        $this->assertNotContains($poor->id, $ids, 'user below lower bound must be excluded');
+    }
+
+    public function test_total_orders_condition_matches_at_boundary_without_fataling(): void
+    {
+        $twoOrders = $this->userWithOrderCount(2);
+        $oneOrder  = $this->userWithOrderCount(1);
+
+        $matched = function (string $operator, int $value): array {
+            $segment = $this->makeSegment(
+                [['field' => 'total_orders', 'operator' => $operator, 'value' => $value]],
+                'all'
+            );
+            $segment->calculateMembers();
+
+            return $segment->members()->pluck('users.id')->all();
+        };
+
+        // Boundary: user with exactly 2 orders
+        $this->assertContains($twoOrders->id, $matched('>=', 2));
+        $this->assertNotContains($twoOrders->id, $matched('>=', 3));
+        $this->assertContains($twoOrders->id, $matched('=', 2));
+        $this->assertContains($twoOrders->id, $matched('>', 1));
+        $this->assertNotContains($twoOrders->id, $matched('>', 2));
+
+        // The single-order user must never match a >= 2 threshold
+        $this->assertNotContains($oneOrder->id, $matched('>=', 2));
     }
 }

--- a/tests/Unit/ProductPerformanceTest.php
+++ b/tests/Unit/ProductPerformanceTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Product;
+use App\Models\ProductCategory;
+use App\Models\ProductPerformance;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductPerformanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeProduct(): Product
+    {
+        $category = ProductCategory::create([
+            'name' => 'Perf Cat',
+            'slug' => 'perf-cat-' . uniqid(),
+        ]);
+
+        return Product::create([
+            'name' => 'Perf Product',
+            'slug' => 'perf-prod-' . uniqid(),
+            'price' => 10.00,
+            'category_id' => $category->id,
+            'inventory_count' => 10,
+        ]);
+    }
+
+    /**
+     * Regression: the model must map to the `product_performance` table.
+     * Without an explicit $table, Eloquent pluralises the class to
+     * `product_performances`, which does not exist -> every read/write fatals.
+     */
+    public function test_model_uses_the_migrated_table_name(): void
+    {
+        $this->assertSame('product_performance', (new ProductPerformance())->getTable());
+    }
+
+    public function test_record_view_creates_and_increments_a_single_daily_row(): void
+    {
+        $product = $this->makeProduct();
+
+        ProductPerformance::recordView($product->id, '2026-07-14');
+        ProductPerformance::recordView($product->id, '2026-07-14');
+
+        $rows = ProductPerformance::where('product_id', $product->id)->get();
+
+        $this->assertCount(1, $rows, 'Same product+date must reuse one row');
+        $this->assertEquals(2, $rows->first()->views);
+    }
+
+    public function test_record_purchase_accumulates_and_computes_conversion(): void
+    {
+        $product = $this->makeProduct();
+
+        // 10 views, then 2 purchases -> conversion 20%
+        for ($i = 0; $i < 10; $i++) {
+            ProductPerformance::recordView($product->id, '2026-07-14');
+        }
+        ProductPerformance::recordPurchase($product->id, 25.00, '2026-07-14');
+        ProductPerformance::recordPurchase($product->id, 25.00, '2026-07-14');
+
+        $row = ProductPerformance::where('product_id', $product->id)->first();
+
+        $this->assertEquals(10, $row->views);
+        $this->assertEquals(2, $row->purchases);
+        $this->assertEquals(50.00, $row->revenue);
+        $this->assertEquals(20.00, $row->conversion_rate);
+    }
+
+    public function test_calculate_conversion_rate_is_zero_without_views(): void
+    {
+        $product = $this->makeProduct();
+
+        $row = ProductPerformance::create([
+            'product_id' => $product->id,
+            'date' => '2026-07-14',
+            'views' => 0,
+            'purchases' => 3,
+        ]);
+        $row->calculateConversionRate();
+
+        $this->assertEquals(0, $row->conversion_rate);
+    }
+
+    public function test_calculate_return_rate(): void
+    {
+        $product = $this->makeProduct();
+
+        $row = ProductPerformance::create([
+            'product_id' => $product->id,
+            'date' => '2026-07-14',
+            'purchases' => 4,
+            'returns' => 1,
+        ]);
+        $row->calculateReturnRate();
+
+        $this->assertEquals(25.00, $row->return_rate);
+    }
+}


### PR DESCRIPTION
Third parallel subsystem audit. Bugs the green suite never exercised — additive/root-cause with tests, nothing weakened, **no schema changes**.

**Suite: 762 passed / 0 failed** (deterministic).

## Customer segmentation
- **Fatal SQL:** the `total_orders` criterion used `havingRaw("COUNT(*) ...")` with **no `GROUP BY`** inside a `whereHas` EXISTS subquery → hard-fatal on sqlite **and** MySQL (`HAVING clause on a non-aggregate query`) for the most common segment type. Replaced with the portable correlated-count operator `has('orders', $op, $value)`.
- **Logic:** `match_type` was ignored — `'any'` segments silently used AND. Now applies each condition as OR/AND per `match_type`.

## Analytics
- **Fatal (prod too):** `ProductPerformance` had no `$table`, so Eloquent used `product_performances` but the table is `product_performance` → every read/write fataled. Added `$table`.
- **Duplicate-insert crash:** the `date` cast serialized to a datetime while `updateOrCreate` looked up a date-only string, so the second write per product/day re-INSERTed and hit `unique(product_id, date)` (sqlite-exposed, MySQL-masked). Removed the cast → column round-trips as `Y-m-d` consistently.

## Chat + cross-cutting Carbon 3 sweep
- **Carbon 3 sign regression:** `now()->diffInSeconds($past)` / `diffInDays($past)` is signed & non-absolute in Carbon 3 (was absolute in Carbon 2). Chat stored **negative** response/resolution times (poisoning analytics), and `CustomerMetric::days_since_last_purchase` was negative too. Flipped diff direction in both (`ChatService`, `CustomerMetric`).

## Reported, not fixed (need forbidden/shared files)
- `CustomerSegment` `in_customer_group` references `users.customer_group_id` which doesn't exist (MySQL-fatal, sqlite-masked) → needs a User↔Customer link.
- **`orders.total_amount` is an `integer` column but `Order` casts it `decimal:2`** → order totals with cents are **truncated at the DB**. Real latent money bug in the orders schema; deserves its own PR.

## Test plan
`php artisan test` → 762 passed / 0 failed.