### PR TITLE
Repair drift/fatal/money bugs across cart-recovery, gift-registry, currency

### DIFF
--- a/app/Models/AbandonedCart.php
+++ b/app/Models/AbandonedCart.php
@@ -29,6 +29,7 @@ class AbandonedCart extends Model
         'customer_locale',
         'billing_address',
         'shipping_address',
+        'recovery_order_id',
     ];
 
     protected $casts = [
@@ -49,7 +50,7 @@ class AbandonedCart extends Model
 
     public function recoveryEmails(): HasMany
     {
-        return $this->hasMany(AbandonedCartEmail::class);
+        return $this->hasMany(CartRecoveryAttempt::class);
     }
 
     public function isRecovered(): bool
@@ -72,7 +73,7 @@ class AbandonedCart extends Model
         return $this->recovery_email_count < 3;
     }
 
-    public function markAsRecovered(Order $order = null): void
+    public function markAsRecovered(?Order $order = null): void
     {
         $this->recovered_at = now();
         if ($order) {

--- a/app/Models/Currency.php
+++ b/app/Models/Currency.php
@@ -69,10 +69,16 @@ class Currency extends Model
      */
     public function convertToBase(float $amount): float
     {
-        if ($this->exchange_rate === 0.0 || $this->exchange_rate < 0.000001) {
+        // exchange_rate is a decimal-cast string; cast to float so 0 / tiny / negative all guard.
+        if ((float) $this->exchange_rate < 0.000001) {
             return 0;
         }
-        return round($amount / $this->exchange_rate, 2);
+
+        // Result is expressed in the base currency, so round to the base currency's precision
+        // (mirrors convertFromBase rounding to this currency's decimal_places). Fall back to 2.
+        $baseDecimals = static::getDefault()->decimal_places ?? 2;
+
+        return round($amount / $this->exchange_rate, $baseDecimals);
     }
 
     /**

--- a/app/Models/GiftRegistry.php
+++ b/app/Models/GiftRegistry.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Support\Str;
 
 class GiftRegistry extends Model
@@ -59,7 +60,7 @@ class GiftRegistry extends Model
         return $this->hasMany(GiftRegistryItem::class, 'registry_id');
     }
 
-    public function purchases(): HasMany
+    public function purchases(): HasManyThrough
     {
         return $this->hasManyThrough(
             GiftRegistryPurchase::class,

--- a/app/Models/GiftRegistryItem.php
+++ b/app/Models/GiftRegistryItem.php
@@ -45,7 +45,7 @@ class GiftRegistryItem extends Model
 
     public function purchases(): HasMany
     {
-        return $this->hasMany(GiftRegistryPurchase::class);
+        return $this->hasMany(GiftRegistryPurchase::class, 'registry_item_id');
     }
 
     /**
@@ -69,9 +69,17 @@ class GiftRegistryItem extends Model
      */
     public function markPurchased(int $quantity, int $orderId, ?string $purchaserName = null, ?string $purchaserEmail = null, bool $anonymous = false): GiftRegistryPurchase
     {
-        $this->increment('quantity_purchased', $quantity);
+        if ($quantity < 1) {
+            throw new \InvalidArgumentException('Purchase quantity must be at least 1.');
+        }
 
-        return $this->purchases()->create([
+        $remaining = $this->getRemainingQuantity();
+        if ($quantity > $remaining) {
+            throw new \InvalidArgumentException("Cannot purchase {$quantity}; only {$remaining} remaining for this item.");
+        }
+
+        // Record the purchase first: a failed insert must not bump the count.
+        $purchase = $this->purchases()->create([
             'order_id' => $orderId,
             'quantity' => $quantity,
             'purchaser_name' => $purchaserName,
@@ -79,5 +87,9 @@ class GiftRegistryItem extends Model
             'anonymous' => $anonymous,
             'purchased_at' => now(),
         ]);
+
+        $this->increment('quantity_purchased', $quantity);
+
+        return $purchase;
     }
 }

--- a/app/Models/GiftRegistryPurchase.php
+++ b/app/Models/GiftRegistryPurchase.php
@@ -31,7 +31,7 @@ class GiftRegistryPurchase extends Model
 
     public function registryItem(): BelongsTo
     {
-        return $this->belongsTo(GiftRegistryItem::class);
+        return $this->belongsTo(GiftRegistryItem::class, 'registry_item_id');
     }
 
     public function order(): BelongsTo

--- a/database/migrations/2026_07_14_001201_widen_exchange_rate_columns.php
+++ b/database/migrations/2026_07_14_001201_widen_exchange_rate_columns.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * exchange_rate was decimal(10,6): only 4 integer digits (max 9999.999999).
+     * Real FX rates overflow that (IDR ~16,500, VND ~25,000, LBP ~89,000) and MySQL
+     * rejects the insert with error 1264 "Out of range value". SQLite ignores decimal
+     * precision, so the test suite never sees it. Widen to decimal(20,10).
+     *
+     * NOTE (MySQL verification required): uses ->change() on money columns.
+     */
+    public function up(): void
+    {
+        if (Schema::hasColumn('currencies', 'exchange_rate')) {
+            Schema::table('currencies', function (Blueprint $table) {
+                $table->decimal('exchange_rate', 20, 10)->default(1.0)->change();
+            });
+        }
+
+        if (Schema::hasColumn('orders', 'exchange_rate')) {
+            Schema::table('orders', function (Blueprint $table) {
+                $table->decimal('exchange_rate', 20, 10)->default(1.0)->change();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('currencies', 'exchange_rate')) {
+            Schema::table('currencies', function (Blueprint $table) {
+                $table->decimal('exchange_rate', 10, 6)->default(1.0)->change();
+            });
+        }
+
+        if (Schema::hasColumn('orders', 'exchange_rate')) {
+            Schema::table('orders', function (Blueprint $table) {
+                $table->decimal('exchange_rate', 10, 6)->default(1.0)->change();
+            });
+        }
+    }
+};

--- a/database/migrations/2026_07_14_001301_add_recovery_order_id_to_abandoned_carts_table.php
+++ b/database/migrations/2026_07_14_001301_add_recovery_order_id_to_abandoned_carts_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * AbandonedCart::markAsRecovered($order) writes recovery_order_id, but no
+     * migration ever created the column -> the method fatals whenever a recovering
+     * order is passed. Add it (nullable FK to orders).
+     */
+    public function up(): void
+    {
+        Schema::table('abandoned_carts', function (Blueprint $table) {
+            if (! Schema::hasColumn('abandoned_carts', 'recovery_order_id')) {
+                $table->foreignId('recovery_order_id')->nullable()->constrained('orders')->nullOnDelete();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('abandoned_carts', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('recovery_order_id');
+        });
+    }
+};

--- a/tests/Unit/AbandonedCartRecoveryTest.php
+++ b/tests/Unit/AbandonedCartRecoveryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\AbandonedCart;
+use App\Models\Order;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AbandonedCartRecoveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function cart(): AbandonedCart
+    {
+        return AbandonedCart::create([
+            'customer_email' => 'buyer@example.com',
+            'session_id' => 'sess-'.uniqid(),
+            'cart_token' => 'tok-'.uniqid(),
+            'total_amount' => 50,
+            'abandoned_at' => now(),
+            'line_items' => [['product_id' => 1, 'quantity' => 2]],
+        ]);
+    }
+
+    public function test_recovery_attempts_relation_resolves(): void
+    {
+        $cart = $this->cart();
+
+        // Relation pointed at a nonexistent AbandonedCartEmail model -> fatal.
+        $this->assertCount(0, $cart->recoveryEmails);
+    }
+
+    public function test_mark_as_recovered_records_recovered_at_and_order(): void
+    {
+        $cart = $this->cart();
+        $order = Order::create([
+            'customer_email' => 'buyer@example.com',
+            'total_amount' => 50,
+            'status' => Order::STATUS_PAID,
+        ]);
+
+        $cart->markAsRecovered($order);
+
+        $fresh = $cart->fresh();
+        $this->assertNotNull($fresh->recovered_at);
+        $this->assertSame($order->id, $fresh->recovery_order_id);
+        $this->assertTrue($fresh->isRecovered());
+    }
+}

--- a/tests/Unit/CurrencyModelTest.php
+++ b/tests/Unit/CurrencyModelTest.php
@@ -75,10 +75,45 @@ class CurrencyModelTest extends TestCase
         $this->assertEquals(0.0, $result);
     }
 
+    public function test_convert_to_base_returns_zero_for_negative_rate(): void
+    {
+        $currency = $this->makeCurrency(['code' => 'NEG', 'exchange_rate' => -0.5]);
+
+        $this->assertEquals(0.0, $currency->convertToBase(100.0));
+    }
+
+    public function test_convert_to_base_rounds_to_base_currency_decimal_places(): void
+    {
+        // Base currency has 0 decimal places (e.g. JPY): a base amount must be whole.
+        $this->makeCurrency([
+            'code' => 'JPY',
+            'decimal_places' => 0,
+            'exchange_rate' => 1.0,
+            'is_default' => true,
+            'is_active' => true,
+        ]);
+
+        // 100 / 1.5 = 66.6667 -> must round to 67 in a 0-decimal base currency.
+        $currency = $this->makeCurrency(['code' => 'FOO', 'exchange_rate' => 1.5]);
+
+        $this->assertEquals(67.0, $currency->convertToBase(100.0));
+    }
+
+    public function test_convert_round_trip_preserves_amount(): void
+    {
+        // No default currency -> convertToBase falls back to 2 decimals.
+        $currency = $this->makeCurrency(['code' => 'RTP', 'exchange_rate' => 0.8654, 'decimal_places' => 2]);
+
+        $inTarget = $currency->convertFromBase(50.0);           // base -> target
+        $backToBase = $currency->convertToBase($inTarget);       // target -> base
+
+        $this->assertEqualsWithDelta(50.0, $backToBase, 0.01);
+    }
+
     public function test_get_default_returns_default_currency(): void
     {
-        $default = $this->makeCurrency(['code' => 'DEF', 'is_default' => true, 'is_active' => true]);
-        $other = $this->makeCurrency(['code' => 'OTH', 'is_default' => false]);
+        $this->makeCurrency(['code' => 'DEF', 'is_default' => true, 'is_active' => true]);
+        $this->makeCurrency(['code' => 'OTH', 'is_default' => false]);
 
         $result = Currency::getDefault();
 
@@ -105,6 +140,16 @@ class CurrencyModelTest extends TestCase
         $codes = $result->pluck('code')->toArray();
         $this->assertContains('ACT', $codes);
         $this->assertNotContains('INA', $codes);
+    }
+
+    public function test_exchange_rate_holds_real_world_fx_values(): void
+    {
+        // IDR-class rate (>9999) overflows decimal(10,6) on MySQL; column must be widened.
+        // SQLite ignores precision, so this only truly guards after the widening migration
+        // runs on MySQL. It locks that exchange_rate stays decimal and round-trips.
+        $currency = $this->makeCurrency(['code' => 'IDR', 'exchange_rate' => 16500.123456]);
+
+        $this->assertEqualsWithDelta(16500.123456, (float) $currency->fresh()->exchange_rate, 0.000001);
     }
 
     public function test_format_price_uses_thousand_separator(): void

--- a/tests/Unit/GiftRegistryTest.php
+++ b/tests/Unit/GiftRegistryTest.php
@@ -4,6 +4,8 @@ namespace Tests\Unit;
 
 use App\Models\GiftRegistry;
 use App\Models\GiftRegistryItem;
+use App\Models\GiftRegistryPurchase;
+use App\Models\Order;
 use App\Models\Product;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -12,6 +14,105 @@ use Tests\TestCase;
 class GiftRegistryTest extends TestCase
 {
     use RefreshDatabase;
+
+    private function makeOrder(): Order
+    {
+        return Order::create([
+            'customer_email' => 'buyer@example.com',
+            'total_amount' => 100,
+            'status' => 'pending',
+        ]);
+    }
+
+    private function makeItem(int $requested = 3): GiftRegistryItem
+    {
+        $registry = GiftRegistry::factory()->create();
+        $product = Product::factory()->create();
+
+        return $registry->items()->create([
+            'product_id' => $product->id,
+            'quantity_requested' => $requested,
+            'quantity_purchased' => 0,
+        ]);
+    }
+
+    public function test_mark_purchased_records_purchase_and_updates_count()
+    {
+        $item = $this->makeItem(3);
+        $order = $this->makeOrder();
+
+        $purchase = $item->markPurchased(2, $order->id, 'Alice', 'alice@example.com');
+
+        $this->assertInstanceOf(GiftRegistryPurchase::class, $purchase);
+        $this->assertDatabaseHas('gift_registry_purchases', [
+            'registry_item_id' => $item->id,
+            'order_id' => $order->id,
+            'quantity' => 2,
+            'purchaser_name' => 'Alice',
+        ]);
+
+        $item->refresh();
+        $this->assertEquals(2, $item->quantity_purchased);
+        $this->assertEquals(1, $item->getRemainingQuantity());
+        $this->assertFalse($item->isFullyPurchased());
+    }
+
+    public function test_purchases_relation_and_inverse_resolve()
+    {
+        $item = $this->makeItem(3);
+        $order = $this->makeOrder();
+
+        $purchase = $item->markPurchased(1, $order->id);
+
+        $this->assertCount(1, $item->purchases()->get());
+        $this->assertEquals($item->id, $purchase->registryItem->id);
+    }
+
+    public function test_registry_purchases_through_relation()
+    {
+        $item = $this->makeItem(3);
+        $order = $this->makeOrder();
+
+        $item->markPurchased(1, $order->id);
+
+        $this->assertCount(1, $item->registry->purchases()->get());
+    }
+
+    public function test_mark_purchased_rejects_over_purchase()
+    {
+        $item = $this->makeItem(1);
+        $order = $this->makeOrder();
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        try {
+            $item->markPurchased(2, $order->id);
+        } finally {
+            $this->assertEquals(0, $item->fresh()->quantity_purchased);
+            $this->assertEquals(0, GiftRegistryPurchase::count());
+        }
+    }
+
+    public function test_mark_purchased_rejects_non_positive_quantity()
+    {
+        $item = $this->makeItem(3);
+        $order = $this->makeOrder();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $item->markPurchased(0, $order->id);
+    }
+
+    public function test_mark_purchased_to_capacity_marks_fully_purchased()
+    {
+        $item = $this->makeItem(2);
+        $order = $this->makeOrder();
+
+        $item->markPurchased(2, $order->id);
+        $item->refresh();
+
+        $this->assertTrue($item->isFullyPurchased());
+        $this->assertEquals(0, $item->getRemainingQuantity());
+    }
 
     public function test_gift_registry_can_be_created()
     {


### PR DESCRIPTION
Fourth parallel subsystem audit. **Nine bugs** the green suite never exercised — additive/root-cause with tests, nothing weakened.

**Suite: 775 passed / 0 failed** (deterministic). Migrations verified on MySQL 8.4.

## Abandoned-cart recovery
- **Fatal:** `recoveryEmails()` was `hasMany(AbandonedCartEmail::class)` — a model that **doesn't exist** → `Class not found`. The real model is `CartRecoveryAttempt` (keyed `abandoned_cart_id`). Repointed.
- **Fatal:** `markAsRecovered($order)` wrote `recovery_order_id`, a column **no migration created** → fatal on save. Added the nullable FK + fillable.
- PHP 8.5 implicit-nullable param → `?Order`.

## Gift registry
- **Fatal FK drift:** `GiftRegistryItem::purchases()` derived `gift_registry_item_id` but the column is `registry_item_id` → `markPurchased()` fataled. Fixed FK + the broken inverse relation.
- **Fatal TypeError:** `GiftRegistry::purchases()` declared `: HasMany` but returns `hasManyThrough`. Fixed return type + import.
- **Logic:** `markPurchased()` had no over-purchase / non-positive guard → completion could exceed 100% and `qty<=0` corrupted counts. Added guards; record purchase before incrementing.

## Multi-currency (money)
- `convertToBase` rounded to a hardcoded 2 decimals — wrong for non-2-decimal bases (JPY). Now rounds to the base currency's `decimal_places`.
- Dead zero-guard (`=== 0.0` on a string-cast decimal was always false) → one correct guard, also covers negative rates.
- **`exchange_rate` was `decimal(10,6)`** — only 4 integer digits, so real FX rates (IDR ~16,500, VND ~25,000) **overflow with MySQL error 1264** (sqlite-masked). Widened `currencies.exchange_rate` + `orders.exchange_rate` to `decimal(20,10)`.

## MySQL verification (`->change()` on money columns)
```
SHOW COLUMNS FROM currencies LIKE 'exchange_rate';  -> decimal(20,10)
INSERT ... exchange_rate = 16500.123456;  SELECT ...;  -> 16500.1234560000  (was an overflow)
```

## Reported, not fixed (out of scope)
- Multi-currency is orphaned — `Product`/`Order`/`CheckoutController` never call the conversion methods (wiring missing if multi-currency checkout is intended).
- `getDefault()` filters `is_active`: marking the base currency inactive makes it null → conversions silently lose base precision. A decision, not fixed.

## Test plan
`php artisan test` → 775 passed / 0 failed.