### PR TITLE
Repair drift/fatal/money/status bugs across bundles, shipping, dropshipping

### DIFF
--- a/app/Jobs/DispatchDropshippingOrder.php
+++ b/app/Jobs/DispatchDropshippingOrder.php
@@ -20,6 +20,9 @@ class DispatchDropshippingOrder implements ShouldQueue
     public $orderId;
     public $supplierId;
 
+    /** Number of times the queued job may be attempted. */
+    public int $tries = 3;
+
     /**
      * Create a new job instance.
      */
@@ -27,9 +30,6 @@ class DispatchDropshippingOrder implements ShouldQueue
     {
         $this->orderId = $orderId;
         $this->supplierId = $supplierId;
-
-        // allow a few retries
-        $this->tries = 3;
     }
 
     /**
@@ -74,16 +74,19 @@ class DispatchDropshippingOrder implements ShouldQueue
             $order->supplier_response = $result['data'] ?? ($result['error'] ?? $result);
 
             if ($result['success']) {
-                $order->status = 'supplier_placed';
+                // Supplier accepted the order; it is now being fulfilled.
+                // 'supplier_placed' was not a real Order status (absent from
+                // Order::TRANSITIONS), so nothing downstream understood it.
+                $order->status = Order::STATUS_PROCESSING;
             } else {
-                $order->status = 'supplier_failed';
+                $order->status = Order::STATUS_SUPPLIER_FAILED;
                 Notification::route('mail', config('mail.from.address'))
                     ->notify(new SupplierFailureNotification("Dropshipping order placement failed for order {$order->id}: " . ($result['message'] ?? 'Unknown')));
             }
 
             $order->save();
         } catch (Exception $e) {
-            $order->status = 'supplier_failed';
+            $order->status = Order::STATUS_SUPPLIER_FAILED;
             $order->supplier_response = ['exception' => $e->getMessage()];
             $order->save();
 

--- a/app/Models/ProductBundle.php
+++ b/app/Models/ProductBundle.php
@@ -55,7 +55,7 @@ class ProductBundle extends Model
         $regularPrice = $this->getRegularPrice();
         
         if ($this->discount_percentage > 0) {
-            return $regularPrice * (1 - $this->discount_percentage / 100);
+            return max(0, $regularPrice * (1 - $this->discount_percentage / 100));
         }
         
         if ($this->discount_amount > 0) {
@@ -79,9 +79,11 @@ class ProductBundle extends Model
     public function isInStock(): bool
     {
         foreach ($this->items as $item) {
-            $product = $item->variant ? $item->variant : $item->product;
-            $inventory = $product->inventory_count ?? 0;
-            
+            // Variants track stock in inventory_quantity; products in inventory_count.
+            $inventory = $item->variant
+                ? ($item->variant->inventory_quantity ?? 0)
+                : ($item->product->inventory_count ?? 0);
+
             if ($inventory < $item->quantity) {
                 return false;
             }

--- a/app/Models/ShippingMethod.php
+++ b/app/Models/ShippingMethod.php
@@ -16,11 +16,13 @@ class ShippingMethod extends Model
         'weight_rate',
         'max_weight',
         'estimated_delivery_time',
+        'is_active',
     ];
 
     protected $casts = [
         'base_rate' => 'float',
         'weight_rate' => 'float',
         'max_weight' => 'float',
+        'is_active' => 'boolean',
     ];
 }

--- a/app/Services/ShippingService.php
+++ b/app/Services/ShippingService.php
@@ -9,8 +9,8 @@ class ShippingService
 {
     public function getAvailableShippingMethods($cart = null, $address = null)
     {
-        // Get all shipping methods
-        $availableMethods = ShippingMethod::all();
+        // Only offer active methods; a deactivated method must never be selectable.
+        $availableMethods = ShippingMethod::where('is_active', true)->get();
 
         if (!$cart || !$address) {
             return $availableMethods;
@@ -29,7 +29,8 @@ class ShippingService
         $weightRate = $this->calculateWeightRate($method, $cart);
         $distanceRate = $this->calculateDistanceRate($method, $address);
 
-        return $baseRate + $weightRate + $distanceRate;
+        // Round to cents: float weight math otherwise leaks e.g. 0.30000000000000004.
+        return round($baseRate + $weightRate + $distanceRate, 2);
     }
 
     public function verifyAddress($address)
@@ -55,7 +56,9 @@ class ShippingService
         $totalWeight = $this->calculateTotalWeight($cart);
         $maxWeight = $method->max_weight;
 
-        return $totalWeight <= $maxWeight;
+        // Null max_weight = no weight limit. Without this guard, `$w <= null`
+        // evaluates as `$w <= 0` in PHP, wrongly rejecting unlimited methods.
+        return $maxWeight === null || $totalWeight <= $maxWeight;
     }
 
     private function calculateWeightRate($method, $cart)
@@ -74,7 +77,9 @@ class ShippingService
     private function calculateTotalWeight($cart)
     {
         return array_sum(array_map(function ($item) {
-            return $item['weight'] * $item['quantity'];
+            // ponytail: session cart items carry no 'weight' yet (wiring gap in
+            // Cart/CheckoutController) — treat missing weight as 0, don't fatal.
+            return ($item['weight'] ?? 0) * $item['quantity'];
         }, $cart));
     }
 

--- a/database/migrations/2026_02_04_000000_add_dropshipping_columns_to_orders_table.php
+++ b/database/migrations/2026_02_04_000000_add_dropshipping_columns_to_orders_table.php
@@ -12,12 +12,27 @@ return new class extends Migration
             // Add dropshipping related columns without using ->after() to avoid
             // relying on a specific existing column order which can fail when
             // running migrations in different environments or on existing DBs.
-            $table->string('supplier_id')->nullable();
-            $table->string('supplier_order_reference')->nullable();
-            $table->string('supplier_tracking_number')->nullable();
-            $table->text('supplier_response')->nullable();
-            $table->unsignedBigInteger('shipping_method_id')->nullable();
-            $table->boolean('is_dropshipped')->default(false);
+            // Guard each add with hasColumn so a partial/re-applied schema does
+            // not fatal with a duplicate-column error (matches the guarded
+            // sibling migrations 2026_02_04_000001 and 2026_03_10_000000).
+            if (! Schema::hasColumn('orders', 'supplier_id')) {
+                $table->string('supplier_id')->nullable();
+            }
+            if (! Schema::hasColumn('orders', 'supplier_order_reference')) {
+                $table->string('supplier_order_reference')->nullable();
+            }
+            if (! Schema::hasColumn('orders', 'supplier_tracking_number')) {
+                $table->string('supplier_tracking_number')->nullable();
+            }
+            if (! Schema::hasColumn('orders', 'supplier_response')) {
+                $table->text('supplier_response')->nullable();
+            }
+            if (! Schema::hasColumn('orders', 'shipping_method_id')) {
+                $table->unsignedBigInteger('shipping_method_id')->nullable();
+            }
+            if (! Schema::hasColumn('orders', 'is_dropshipped')) {
+                $table->boolean('is_dropshipped')->default(false);
+            }
         });
     }
 

--- a/tests/Feature/DropshippingOrderJobTest.php
+++ b/tests/Feature/DropshippingOrderJobTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\DispatchDropshippingOrder;
+use App\Models\Order;
+use App\Models\Product;
+use App\Services\DropshippingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class DropshippingOrderJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'dropshipping.suppliers.dropxl' => [
+                'name' => 'DropXL',
+                'description' => 'DropXL integration',
+                'auth' => [
+                    'type' => 'api_key',
+                    'header' => 'Authorization',
+                    'key' => 'Bearer dropxl-key',
+                ],
+                'endpoints' => [
+                    'availability' => 'https://api.dropxl.example/v1/products/availability',
+                    'orders' => 'https://api.dropxl.example/v1/orders',
+                    'tracking' => 'https://api.dropxl.example/v1/orders/track',
+                ],
+            ],
+        ]);
+    }
+
+    private function queuedDropshipOrder(): Order
+    {
+        $order = Order::create([
+            'customer_email' => 'buyer@example.com',
+            'total_amount' => 100,
+            'status' => Order::STATUS_SUPPLIER_QUEUED,
+            'is_dropshipped' => true,
+            'shipping_cost' => 0,
+        ]);
+
+        $product = Product::factory()->create();
+        $order->items()->create([
+            'product_id' => $product->id,
+            'quantity' => 2,
+            'price' => 25.00,
+        ]);
+
+        return $order;
+    }
+
+    private function runJob(Order $order): void
+    {
+        (new DispatchDropshippingOrder($order->id, 'dropxl'))
+            ->handle(app(DropshippingService::class));
+    }
+
+    public function test_successful_placement_moves_order_to_a_known_processing_status(): void
+    {
+        Http::fake([
+            'https://api.dropxl.example/v1/orders' => Http::response(
+                ['reference' => 'DROPXL-1', 'status' => 'received'],
+                200
+            ),
+        ]);
+
+        $order = $this->queuedDropshipOrder();
+
+        $this->runJob($order);
+        $order->refresh();
+
+        // The success status must be a status the rest of the system understands.
+        $this->assertArrayHasKey(
+            $order->status,
+            Order::TRANSITIONS,
+            "Job set an unknown order status [{$order->status}] that no transition map / consumer recognises"
+        );
+        $this->assertSame(Order::STATUS_PROCESSING, $order->status);
+        $this->assertSame('dropxl', $order->supplier_id);
+        $this->assertSame('DROPXL-1', $order->supplier_order_reference);
+        $this->assertSame(['reference' => 'DROPXL-1', 'status' => 'received'], $order->supplier_response);
+    }
+
+    public function test_supplier_rejection_moves_order_to_supplier_failed(): void
+    {
+        Notification::fake();
+
+        Http::fake([
+            'https://api.dropxl.example/v1/orders' => Http::response('Internal Server Error', 500),
+        ]);
+
+        $order = $this->queuedDropshipOrder();
+
+        $this->runJob($order);
+        $order->refresh();
+
+        $this->assertSame(Order::STATUS_SUPPLIER_FAILED, $order->status);
+    }
+}

--- a/tests/Feature/ShippingControllerTest.php
+++ b/tests/Feature/ShippingControllerTest.php
@@ -79,6 +79,36 @@ class ShippingControllerTest extends TestCase
         $response->assertSessionHasErrors('estimated_delivery_time');
     }
 
+    public function test_store_persists_is_active_false_when_unchecked(): void
+    {
+        // is_active is collected by the controller; it must actually persist.
+        $this->post('/shipping', [
+            'name' => 'Retired Method',
+            'base_rate' => 5.99,
+            'estimated_delivery_time' => '3-5 business days',
+            // is_active checkbox not submitted -> should store false
+        ]);
+
+        $this->assertDatabaseHas('shipping_methods', [
+            'name' => 'Retired Method',
+            'is_active' => false,
+        ]);
+    }
+
+    public function test_update_can_deactivate_shipping_method(): void
+    {
+        $method = $this->makeShipping(); // active by default
+
+        $this->put("/shipping/{$method->id}", [
+            'name' => 'Standard Shipping',
+            'base_rate' => 5.99,
+            'estimated_delivery_time' => '5-7 business days',
+            // is_active not submitted -> deactivate
+        ]);
+
+        $this->assertFalse($method->fresh()->is_active);
+    }
+
     public function test_update_changes_shipping_method(): void
     {
         $method = $this->makeShipping();

--- a/tests/Unit/DropshippingServiceTest.php
+++ b/tests/Unit/DropshippingServiceTest.php
@@ -176,6 +176,28 @@ class DropshippingServiceTest extends TestCase
         });
     }
 
+    public function test_dropxl_payload_falls_back_to_product_id_when_sku_missing()
+    {
+        Http::fake([
+            'https://api.dropxl.example/v1/orders' => Http::response(['reference' => 'DROPXL-9'], 200),
+        ]);
+
+        $this->service->placeOrder('dropxl', [
+            'reference' => 'order-9',
+            'items' => [
+                ['product_id' => 777, 'sku' => null, 'quantity' => 3, 'price' => 12.0],
+            ],
+        ]);
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+
+            return $body['items'][0]['sku'] === 777
+                && $body['items'][0]['quantity'] === 3
+                && $body['items'][0]['price'] === 12.0;
+        });
+    }
+
     public function test_place_order_failure_from_supplier()
     {
         Http::fake([

--- a/tests/Unit/ProductBundleItemModelTest.php
+++ b/tests/Unit/ProductBundleItemModelTest.php
@@ -6,6 +6,7 @@ use App\Models\Product;
 use App\Models\ProductBundle;
 use App\Models\ProductBundleItem;
 use App\Models\ProductCategory;
+use App\Models\ProductVariant;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -88,6 +89,67 @@ class ProductBundleItemModelTest extends TestCase
 
         $this->assertInstanceOf(ProductBundle::class, $item->bundle);
         $this->assertEquals($bundle->id, $item->bundle->id);
+    }
+
+    public function test_get_price_uses_product_price_with_quantity_and_discount(): void
+    {
+        $product = $this->makeProduct(); // price 20.00
+        $bundle = $this->makeBundle($product);
+        $itemProduct = $this->makeProduct(); // price 20.00
+
+        $item = ProductBundleItem::create([
+            'bundle_id' => $bundle->id,
+            'product_id' => $itemProduct->id,
+            'quantity' => 3,
+            'discount_amount' => 5,
+            'sort_order' => 1,
+        ]);
+
+        // 20 * 3 - 5 = 55
+        $this->assertEqualsWithDelta(55.0, $item->getPrice(), 0.01);
+    }
+
+    public function test_get_price_prefers_variant_price_over_product_price(): void
+    {
+        $product = $this->makeProduct();
+        $bundle = $this->makeBundle($product);
+        $variantProduct = $this->makeProduct(); // product price 20.00
+        $variant = ProductVariant::create([
+            'product_id' => $variantProduct->id,
+            'sku' => 'VAR-' . uniqid(),
+            'price' => 12.50,
+            'inventory_quantity' => 10,
+        ]);
+
+        $item = ProductBundleItem::create([
+            'bundle_id' => $bundle->id,
+            'product_id' => $variantProduct->id,
+            'product_variant_id' => $variant->id,
+            'quantity' => 2,
+            'discount_amount' => 0,
+            'sort_order' => 1,
+        ]);
+
+        // Uses the 12.50 variant price, not the 20.00 product price: 12.50 * 2 = 25
+        $this->assertEqualsWithDelta(25.0, $item->getPrice(), 0.01);
+        $this->assertInstanceOf(ProductVariant::class, $item->variant);
+    }
+
+    public function test_get_price_never_negative_when_discount_exceeds_value(): void
+    {
+        $product = $this->makeProduct();
+        $bundle = $this->makeBundle($product);
+        $itemProduct = $this->makeProduct(); // price 20.00
+
+        $item = ProductBundleItem::create([
+            'bundle_id' => $bundle->id,
+            'product_id' => $itemProduct->id,
+            'quantity' => 1,
+            'discount_amount' => 999,
+            'sort_order' => 1,
+        ]);
+
+        $this->assertEqualsWithDelta(0.0, $item->getPrice(), 0.01);
     }
 
     public function test_items_ordered_by_sort_order(): void

--- a/tests/Unit/ProductBundleModelTest.php
+++ b/tests/Unit/ProductBundleModelTest.php
@@ -6,6 +6,7 @@ use App\Models\Product;
 use App\Models\ProductBundle;
 use App\Models\ProductBundleItem;
 use App\Models\ProductCategory;
+use App\Models\ProductVariant;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -121,5 +122,73 @@ class ProductBundleModelTest extends TestCase
         $bundle = $this->makeBundle($product);
 
         $this->assertInstanceOf(Product::class, $bundle->product);
+    }
+
+    public function test_is_in_stock_true_when_variant_item_has_inventory(): void
+    {
+        $mainProduct = $this->makeProduct();
+        $variantProduct = $this->makeProduct();
+        $variant = ProductVariant::create([
+            'product_id' => $variantProduct->id,
+            'sku' => 'STOCK-' . uniqid(),
+            'price' => 10.00,
+            'inventory_quantity' => 5,
+        ]);
+
+        $bundle = $this->makeBundle($mainProduct);
+        ProductBundleItem::create([
+            'bundle_id' => $bundle->id,
+            'product_id' => $variantProduct->id,
+            'product_variant_id' => $variant->id,
+            'quantity' => 2,
+            'sort_order' => 1,
+        ]);
+
+        $bundle->load('items.variant', 'items.product');
+
+        // variant stock (5) >= qty (2) -> in stock. Regression: was reading the
+        // non-existent inventory_count column on the variant and always failing.
+        $this->assertTrue($bundle->isInStock());
+    }
+
+    public function test_is_in_stock_false_when_variant_item_out_of_stock(): void
+    {
+        $mainProduct = $this->makeProduct();
+        $variantProduct = $this->makeProduct();
+        $variant = ProductVariant::create([
+            'product_id' => $variantProduct->id,
+            'sku' => 'STOCK-' . uniqid(),
+            'price' => 10.00,
+            'inventory_quantity' => 1,
+        ]);
+
+        $bundle = $this->makeBundle($mainProduct);
+        ProductBundleItem::create([
+            'bundle_id' => $bundle->id,
+            'product_id' => $variantProduct->id,
+            'product_variant_id' => $variant->id,
+            'quantity' => 3,
+            'sort_order' => 1,
+        ]);
+
+        $bundle->load('items.variant', 'items.product');
+
+        // variant stock (1) < qty (3) -> out of stock.
+        $this->assertFalse($bundle->isInStock());
+    }
+
+    public function test_bundle_price_floored_at_zero_when_discount_over_100_percent(): void
+    {
+        $mainProduct = $this->makeProduct();
+        $item = $this->makeProduct(40.00);
+
+        $bundle = $this->makeBundle($mainProduct, ['discount_percentage' => 150]);
+        $this->addBundleItem($bundle, $item, 1);
+
+        $bundle->load('items.product');
+
+        // A >100% discount must never produce a negative price.
+        $this->assertEqualsWithDelta(0.0, $bundle->getBundlePrice(), 0.01);
+        $this->assertGreaterThanOrEqual(0.0, $bundle->getBundlePrice());
     }
 }

--- a/tests/Unit/ProductVariantModelTest.php
+++ b/tests/Unit/ProductVariantModelTest.php
@@ -96,6 +96,17 @@ class ProductVariantModelTest extends TestCase
         $this->assertEquals($this->product->id, $variant->product->id);
     }
 
+    public function test_price_stores_decimal_not_integer(): void
+    {
+        // Locks the money column as decimal(10,2): an integer column would
+        // truncate 19.99 -> 19/20 and this round-trip would fail.
+        $variant = $this->makeVariant(['price' => 19.99, 'compare_at_price' => 29.95]);
+
+        $fresh = $variant->fresh();
+        $this->assertEqualsWithDelta(19.99, (float) $fresh->price, 0.001);
+        $this->assertEqualsWithDelta(29.95, (float) $fresh->compare_at_price, 0.001);
+    }
+
     public function test_casts_are_correct(): void
     {
         $variant = $this->makeVariant([

--- a/tests/Unit/ShippingMethodModelTest.php
+++ b/tests/Unit/ShippingMethodModelTest.php
@@ -53,6 +53,15 @@ class ShippingMethodModelTest extends TestCase
         $this->assertEquals(100.0, $method->fresh()->max_weight);
     }
 
+    public function test_is_active_is_mass_assignable_and_cast_to_bool(): void
+    {
+        $method = $this->makeShipping(['is_active' => false]);
+
+        $fresh = $method->fresh();
+        $this->assertIsBool($fresh->is_active);
+        $this->assertFalse($fresh->is_active);
+    }
+
     public function test_multiple_shipping_methods_can_coexist(): void
     {
         $this->makeShipping(['name' => 'Standard', 'base_rate' => 5.99]);

--- a/tests/Unit/ShippingServiceTest.php
+++ b/tests/Unit/ShippingServiceTest.php
@@ -34,8 +34,8 @@ class ShippingServiceTest extends TestCase
 
     public function test_get_available_shipping_methods_returns_all_without_cart(): void
     {
-        $method1 = $this->makeMethod(['name' => 'Standard']);
-        $method2 = $this->makeMethod(['name' => 'Express', 'base_rate' => 15.00]);
+        $this->makeMethod(['name' => 'Standard']);
+        $this->makeMethod(['name' => 'Express', 'base_rate' => 15.00]);
 
         $methods = $this->service->getAvailableShippingMethods();
 
@@ -96,6 +96,64 @@ class ShippingServiceTest extends TestCase
         $cost = $this->service->calculateDropShippingCost($method, $cart, '123 Main St');
 
         $this->assertEquals(8.00, $cost);
+    }
+
+    public function test_null_max_weight_means_unlimited(): void
+    {
+        // A method with no max_weight (nullable column) should carry ANY weight.
+        $unlimited = $this->makeMethod(['name' => 'Freight', 'max_weight' => null]);
+
+        $cart = [['weight' => 40.0, 'quantity' => 3]]; // 120kg
+
+        $methods = $this->service->getAvailableShippingMethods($cart, '123 Main St');
+
+        $this->assertTrue($methods->contains('id', $unlimited->id));
+    }
+
+    public function test_max_weight_boundary_is_inclusive(): void
+    {
+        $method = $this->makeMethod(['max_weight' => 10.0]);
+
+        $cart = [['weight' => 5.0, 'quantity' => 2]]; // exactly 10kg
+
+        $methods = $this->service->getAvailableShippingMethods($cart, '123 Main St');
+
+        $this->assertTrue($methods->contains('id', $method->id));
+    }
+
+    public function test_calculate_shipping_cost_is_rounded_to_two_decimals(): void
+    {
+        // base 0.10 + weight_rate 0.10 * 2kg = 0.30, but naive float math yields
+        // 0.30000000000000004. Money must round to 2 dp.
+        $method = $this->makeMethod(['base_rate' => 0.10, 'weight_rate' => 0.10, 'max_weight' => 100]);
+
+        $cart = [['weight' => 2.0, 'quantity' => 1]];
+        $cost = $this->service->calculateShippingCost($method, $cart, '123 Main St');
+
+        $this->assertSame(0.30, $cost);
+    }
+
+    public function test_get_available_shipping_methods_excludes_inactive(): void
+    {
+        $active = $this->makeMethod(['name' => 'Active', 'is_active' => true]);
+        $inactive = $this->makeMethod(['name' => 'Inactive', 'is_active' => false]);
+
+        $methods = $this->service->getAvailableShippingMethods();
+
+        $this->assertTrue($methods->contains('id', $active->id));
+        $this->assertFalse($methods->contains('id', $inactive->id));
+    }
+
+    public function test_calculate_shipping_cost_tolerates_missing_weight_key(): void
+    {
+        // The live session cart stores items WITHOUT a 'weight' key (known wiring
+        // gap). The service must not error; missing weight contributes 0.
+        $method = $this->makeMethod(['base_rate' => 5.00, 'weight_rate' => 2.00, 'max_weight' => 100]);
+
+        $cart = [7 => ['name' => 'X', 'price' => 10, 'quantity' => 2, 'is_downloadable' => false]];
+        $cost = $this->service->calculateShippingCost($method, $cart, '123 Main St');
+
+        $this->assertSame(5.00, $cost); // base only, no weight
     }
 
     public function test_verify_address_returns_null_on_failure(): void


### PR DESCRIPTION
Fifth parallel subsystem audit. **Ten bugs** the green suite never exercised — additive/root-cause with tests, nothing weakened.

**Suite: 793 passed / 0 failed** (deterministic). Full migrate chain verified on MySQL 8.4.

## Product bundles & variants
- **`isInStock()` read `inventory_count` on variants**, but `ProductVariant` uses `inventory_quantity` → any bundle containing a variant **always reported out-of-stock**.
- **`getBundlePrice()` percentage branch had no floor** (`discount_percentage` allows >100) → **negative bundle price**. Added `max(0, …)`.

## Shipping
- **`max_weight` NULL (= unlimited) dropped every weighted method:** `$weight <= null` evaluates as `<= 0` → false. Guard null as unlimited.
- **Shipping cost unrounded** → `0.30000000000000004` leaked into order totals. `round(,2)`.
- **`is_active` missing from `$fillable`** (+ no cast) → a method could **never be deactivated**; `getAvailableShippingMethods` used `::all()` and offered inactive methods. Added fillable+cast+filter.
- **Null-deref fatal** on the live cart's missing `weight` key. Guard `?? 0`.

## Dropshipping
- **Invalid status:** on successful placement the job set `status = 'supplier_placed'` — a value in **neither** the constants nor `TRANSITIONS` → orders stuck in an unknown status. Fixed to `STATUS_PROCESSING`; magic strings → constants. (Kept direct assignment, not `transitionTo()`: retried success after a `supplier_failed` write would be an illegal transition.)
- **`$tries = 3` was a dynamic property** (assigned in `__construct`, never declared) → PHP 8.2+ deprecated **and** wouldn't survive queue serialization, so the retry config was **silently ignored**. Declared `public int $tries = 3`.
- **Unguarded migration** (`add_dropshipping_columns`) → duplicate-column fatal on a partial/re-applied schema. Added `hasColumn` guards.

## Reported, not fixed
- Weight-based shipping is structurally dead: no `weight` column on `products`, cart never stores weight (needs Product/Cart/Checkout).
- `DropxlService` reads `env()` in its constructor → null after `config:cache`.

## Test plan
`php artisan test` → 793 passed / 0 failed.