### PR TITLE
feat(refunds): approving a return spawns + processes a refund

### DIFF
--- a/app/Models/ReturnRequest.php
+++ b/app/Models/ReturnRequest.php
@@ -33,8 +33,8 @@ class ReturnRequest extends Model
     protected static function booted(): void
     {
         static::creating(function ($returnRequest) {
-            if (!$returnRequest->rma_number) {
-                $returnRequest->rma_number = 'RMA-' . strtoupper(uniqid());
+            if (! $returnRequest->rma_number) {
+                $returnRequest->rma_number = 'RMA-'.strtoupper(uniqid());
             }
         });
     }
@@ -60,15 +60,62 @@ class ReturnRequest extends Model
     }
 
     /**
-     * Approve the return request
+     * Approve the return request and spawn a refund for the returned items.
+     *
+     * Idempotent: re-approving is a no-op (returns null) so the customer is
+     * never refunded twice. Returns the processed Refund, or null when there is
+     * nothing itemized to refund.
      */
-    public function approve(?int $userId = null): void
+    public function approve(?int $userId = null): ?Refund
     {
+        if ($this->status === 'approved') {
+            return null;
+        }
+
         $this->update([
             'status' => 'approved',
             'approved_by' => $userId,
             'approved_at' => now(),
         ]);
+
+        return $this->spawnRefund($userId);
+    }
+
+    /**
+     * Build a Refund (+ items) from the returned lines and run it through the
+     * refund engine (gateway void → restock → order state transition).
+     */
+    private function spawnRefund(?int $userId): ?Refund
+    {
+        $lines = $this->items()->with('orderItem')->get()
+            ->filter(fn (ReturnRequestItem $item) => $item->orderItem !== null);
+
+        if ($lines->isEmpty()) {
+            return null;
+        }
+
+        $refund = Refund::create([
+            'order_id' => $this->order_id,
+            'amount' => $lines->sum(fn (ReturnRequestItem $item) => (float) $item->orderItem->price * $item->quantity),
+            'reason' => $this->reason,
+            'status' => 'pending',
+            'refund_method' => 'original_payment',
+            'restock_items' => true,
+        ]);
+
+        foreach ($lines as $item) {
+            $refund->items()->create([
+                'order_item_id' => $item->order_item_id,
+                'quantity' => $item->quantity,
+                'amount' => (float) $item->orderItem->price * $item->quantity,
+                // ponytail: damaged goods can't be resold — everything else restocks.
+                'restock' => $item->condition !== 'damaged',
+            ]);
+        }
+
+        $refund->process($userId);
+
+        return $refund;
     }
 
     /**

--- a/tests/Feature/ReturnApprovalRefundTest.php
+++ b/tests/Feature/ReturnApprovalRefundTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Interfaces\PaymentGatewayInterface;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\Refund;
+use App\Models\ReturnRequest;
+use App\Models\User;
+use App\Services\PaymentGateways\StripeGateway;
+use Closure;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReturnApprovalRefundTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function bindGateway(Closure $refundResult): object
+    {
+        $spy = new class($refundResult) implements PaymentGatewayInterface
+        {
+            public array $refundCalls = [];
+
+            public function __construct(private Closure $refundResult) {}
+
+            public function processPayment(float $amount, array $paymentDetails): array
+            {
+                return ['success' => true];
+            }
+
+            public function processSubscription(string $planId, array $subscriptionDetails): array
+            {
+                return ['success' => true];
+            }
+
+            public function refundPayment(string $transactionId, float $amount): array
+            {
+                $this->refundCalls[] = ['transaction_id' => $transactionId, 'amount' => $amount];
+
+                return ($this->refundResult)();
+            }
+        };
+
+        $this->app->instance(StripeGateway::class, $spy);
+
+        return $spy;
+    }
+
+    private function makeReturnWithItems(int $stock, float $price, int $qty, string $condition = 'unopened'): array
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create(['inventory_count' => $stock]);
+
+        $order = Order::create([
+            'customer_email' => $user->email,
+            'payment_method' => 'stripe',
+            'transaction_id' => 'ch_test',
+            'total_amount' => $price * $qty,
+            'status' => Order::STATUS_PAID,
+        ]);
+
+        $orderItem = $order->items()->create([
+            'product_id' => $product->id,
+            'quantity' => $qty,
+            'price' => $price,
+        ]);
+
+        $return = ReturnRequest::create([
+            'order_id' => $order->id,
+            'customer_id' => $user->id,
+            'reason' => 'defective',
+            'status' => 'pending',
+        ]);
+
+        $return->items()->create([
+            'order_item_id' => $orderItem->id,
+            'quantity' => $qty,
+            'condition' => $condition,
+        ]);
+
+        return [$user, $order, $product, $return];
+    }
+
+    public function test_approving_a_return_refunds_money_and_restocks(): void
+    {
+        $spy = $this->bindGateway(fn () => ['success' => true, 'refund_id' => 're_1']);
+        [$user, $order, $product, $return] = $this->makeReturnWithItems(stock: 3, price: 50, qty: 2);
+
+        $refund = $return->approve($user->id);
+
+        $this->assertNotNull($refund, 'approve() did not spawn a refund');
+        $this->assertSame(100.0, (float) $refund->amount); // 50 * 2
+        $this->assertCount(1, $spy->refundCalls);
+        $this->assertSame('ch_test', $spy->refundCalls[0]['transaction_id']);
+        $this->assertSame(5, $product->fresh()->inventory_count); // 3 + 2 restocked
+
+        $order = $order->fresh();
+        $this->assertTrue((bool) $order->fully_refunded);
+        $this->assertSame(Order::STATUS_REFUNDED, $order->status);
+
+        // Return itself is marked approved.
+        $this->assertSame('approved', $return->fresh()->status);
+    }
+
+    public function test_approving_twice_does_not_double_refund(): void
+    {
+        $spy = $this->bindGateway(fn () => ['success' => true, 'refund_id' => 're_1']);
+        [$user, $order, , $return] = $this->makeReturnWithItems(stock: 3, price: 50, qty: 2);
+
+        $return->approve($user->id);
+        $second = $return->approve($user->id);
+
+        $this->assertNull($second, 'second approve should be a no-op, not a second refund');
+        $this->assertCount(1, $spy->refundCalls);
+        $this->assertSame(1, Refund::where('order_id', $order->id)->count());
+    }
+
+    public function test_damaged_items_are_not_restocked(): void
+    {
+        $this->bindGateway(fn () => ['success' => true, 'refund_id' => 're_1']);
+        [$user, , $product, $return] = $this->makeReturnWithItems(stock: 3, price: 50, qty: 2, condition: 'damaged');
+
+        $return->approve($user->id);
+
+        $this->assertSame(3, $product->fresh()->inventory_count); // damaged → no restock
+    }
+}


### PR DESCRIPTION
## What

`ReturnRequest::approve()` only flipped a status string. The capable `Refund::process()` engine (gateway void → restock → order state-machine transition, shipped in #695) was **never reached from the return flow** — an approved return moved no money and restocked nothing. This is the `ReturnRequest->approve() → spawn refund (still orphaned)` gap called out in TASKS 1.4.

## Change

`approve()` now builds a `Refund` + `RefundItem`s from the returned lines (amount = order-item price × qty) and runs them through the existing engine. It is the **single seam** every future trigger surface (admin action, API, console) routes through — wire it once, all callers benefit.

Guards:
- **Idempotent** — re-approving is a no-op (returns null); the customer is never refunded twice.
- **Skips when nothing is itemized** (returns null) — keeps the existing no-item approve() contract green.
- **Does not restock `damaged` goods** — per-item `restock` flag set from the return item's condition.

No migration — every column already exists. Pure-Eloquent, no raw SQL.

## Tests

+3 feature tests (`ReturnApprovalRefundTest`): full refund + restock through the gateway spy; idempotent double-approve; damaged-item no-restock. Existing `ReturnRequestModelTest` / `RefundProcessTest` contracts unchanged.

Suite **809 passed / 0 failed**.

## Follow-up (not in this PR)

A thin UI/API surface to *invoke* approve() (Filament admin action on a ReturnRequest resource, or an authenticated route). The domain seam is done and tested; the glue is trivial.