### PR TITLE
feat(refunds): notify the customer when a refund is processed

### DIFF
--- a/app/Models/Refund.php
+++ b/app/Models/Refund.php
@@ -2,11 +2,13 @@
 
 namespace App\Models;
 
+use App\Notifications\OrderRefundedNotification;
 use App\Services\PaymentGatewayService;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Notification;
 
 class Refund extends Model
 {
@@ -103,6 +105,23 @@ class Refund extends Model
             $order->transitionTo($target, $userId, 'Refund processed');
         }
 
+        $this->notifyCustomer($order);
+
         return true;
+    }
+
+    /**
+     * Tell the customer the refund went through. Logged-in customers get the
+     * mail + database (bell) notification; guests get an on-demand email.
+     */
+    private function notifyCustomer(Order $order): void
+    {
+        $notification = new OrderRefundedNotification($order, (float) $this->amount);
+
+        if ($order->user_id && $user = User::find($order->user_id)) {
+            $user->notify($notification);
+        } elseif ($order->customer_email) {
+            Notification::route('mail', $order->customer_email)->notify($notification);
+        }
     }
 }

--- a/app/Notifications/OrderRefundedNotification.php
+++ b/app/Notifications/OrderRefundedNotification.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\Order;
+use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -18,18 +19,20 @@ class OrderRefundedNotification extends Notification
 
     public function via($notifiable): array
     {
-        return ['mail', 'database'];
+        // Guests are notified on-demand by email only; the database (bell) channel
+        // needs a stored User notifiable.
+        return $notifiable instanceof User ? ['mail', 'database'] : ['mail'];
     }
 
     public function toMail($notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Refund Processed - Order #' . $this->order->id)
+            ->subject('Refund Processed - Order #'.$this->order->id)
             ->greeting('Hello!')
             ->line("Your refund has been processed for order #{$this->order->id}.")
-            ->line("Refund amount: $" . number_format($this->refundAmount, 2))
+            ->line('Refund amount: $'.number_format($this->refundAmount, 2))
             ->line('The refund should appear in your account within 5-10 business days.')
-            ->action('View Order', url('/orders/' . $this->order->id))
+            ->action('View Order', url('/orders/'.$this->order->id))
             ->line('Thank you for your business!');
     }
 
@@ -38,7 +41,7 @@ class OrderRefundedNotification extends Notification
         return [
             'order_id' => $this->order->id,
             'refund_amount' => $this->refundAmount,
-            'message' => "Refund of $" . number_format($this->refundAmount, 2) . " processed for order #{$this->order->id}",
+            'message' => 'Refund of $'.number_format($this->refundAmount, 2)." processed for order #{$this->order->id}",
         ];
     }
 }

--- a/tests/Feature/RefundNotificationTest.php
+++ b/tests/Feature/RefundNotificationTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Interfaces\PaymentGatewayInterface;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\Refund;
+use App\Models\User;
+use App\Notifications\OrderRefundedNotification;
+use App\Services\PaymentGateways\StripeGateway;
+use Closure;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class RefundNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function bindGateway(Closure $refundResult): void
+    {
+        $this->app->instance(StripeGateway::class, new class($refundResult) implements PaymentGatewayInterface
+        {
+            public function __construct(private Closure $refundResult) {}
+
+            public function processPayment(float $amount, array $paymentDetails): array
+            {
+                return ['success' => true];
+            }
+
+            public function processSubscription(string $planId, array $subscriptionDetails): array
+            {
+                return ['success' => true];
+            }
+
+            public function refundPayment(string $transactionId, float $amount): array
+            {
+                return ($this->refundResult)();
+            }
+        });
+    }
+
+    private function makeRefund(array $orderOverrides = []): Refund
+    {
+        $product = Product::factory()->create(['inventory_count' => 3]);
+
+        $order = Order::create(array_merge([
+            'customer_email' => 'buyer@example.com',
+            'payment_method' => 'stripe',
+            'transaction_id' => 'ch_test',
+            'total_amount' => 100,
+            'status' => Order::STATUS_PAID,
+        ], $orderOverrides));
+
+        $item = $order->items()->create(['product_id' => $product->id, 'quantity' => 2, 'price' => 50]);
+
+        $refund = Refund::create([
+            'order_id' => $order->id,
+            'amount' => 100,
+            'reason' => 'customer request',
+            'status' => 'pending',
+            'restock_items' => true,
+        ]);
+
+        $refund->items()->create(['order_item_id' => $item->id, 'quantity' => 2, 'amount' => 100, 'restock' => true]);
+
+        return $refund;
+    }
+
+    public function test_processed_refund_notifies_guest_customer_by_email(): void
+    {
+        Notification::fake();
+        $this->bindGateway(fn () => ['success' => true, 'refund_id' => 're_1']);
+        $refund = $this->makeRefund();
+
+        $refund->process();
+
+        Notification::assertSentOnDemand(
+            OrderRefundedNotification::class,
+            fn ($notification, $channels, $notifiable) => $notifiable->routes['mail'] === 'buyer@example.com'
+                && (float) $notification->refundAmount === 100.0
+        );
+    }
+
+    public function test_processed_refund_notifies_the_order_user(): void
+    {
+        Notification::fake();
+        $this->bindGateway(fn () => ['success' => true, 'refund_id' => 're_1']);
+        $user = User::factory()->create();
+        $refund = $this->makeRefund(['user_id' => $user->id, 'customer_email' => $user->email]);
+
+        $refund->process();
+
+        Notification::assertSentTo(
+            $user,
+            OrderRefundedNotification::class,
+            fn ($notification) => (float) $notification->refundAmount === 100.0
+        );
+    }
+
+    public function test_failed_gateway_refund_sends_no_notification(): void
+    {
+        Notification::fake();
+        $this->bindGateway(fn () => ['success' => false, 'error' => 'declined']);
+        $refund = $this->makeRefund();
+
+        $refund->process();
+
+        Notification::assertNothingSent();
+    }
+}

--- a/tests/Feature/RefundProcessTest.php
+++ b/tests/Feature/RefundProcessTest.php
@@ -9,15 +9,23 @@ use App\Models\Refund;
 use App\Services\PaymentGateways\StripeGateway;
 use Closure;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 class RefundProcessTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Notification::fake();
+    }
+
     private function bindGateway(Closure $refundResult): object
     {
-        $spy = new class($refundResult) implements PaymentGatewayInterface {
+        $spy = new class($refundResult) implements PaymentGatewayInterface
+        {
             public array $refundCalls = [];
 
             public function __construct(private Closure $refundResult) {}

--- a/tests/Feature/ReturnApprovalRefundTest.php
+++ b/tests/Feature/ReturnApprovalRefundTest.php
@@ -11,11 +11,18 @@ use App\Models\User;
 use App\Services\PaymentGateways\StripeGateway;
 use Closure;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 class ReturnApprovalRefundTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Notification::fake();
+    }
 
     private function bindGateway(Closure $refundResult): object
     {

--- a/tests/Unit/RefundModelTest.php
+++ b/tests/Unit/RefundModelTest.php
@@ -7,11 +7,18 @@ use App\Models\Order;
 use App\Models\Refund;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 class RefundModelTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Notification::fake();
+    }
 
     private function makeOrder(): Order
     {


### PR DESCRIPTION
## What

`OrderRefundedNotification` was fully written but **never sent** (0 call sites). Now that refunds actually move money — checkout persists the charge id (#695), `approve()` spawns refunds (#707), `Refund::process()` voids the charge and restocks — the customer was refunded **silently**: no email, no bell notification.

## Change

`Refund::process()` notifies on the success path:
- **Logged-in customer** (order has `user_id`, #699) → notified via the `User` → mail **+ database** (bell).
- **Guest** (email only) → on-demand mail to `customer_email`, mirroring how `OrderConfirmationNotification` is sent at checkout.

`via()` now returns the `database` channel **only for a real `User`** — an `AnonymousNotifiable` (guest) can't route `database`, so guests get mail only.

A **declined-gateway refund sends nothing** (money didn't move → no false 'refunded' email).

## Tests

+3 (`RefundNotificationTest`): guest emailed on-demand, user gets mail+db, failed gateway sends nothing. Existing `process()`-exercising tests (`RefundProcessTest`, `ReturnApprovalRefundTest`, `RefundModelTest`) now `Notification::fake()` to absorb the new side effect — standard when a method gains a notification.

No migration, no raw SQL. Suite **812 passed / 0 failed**.

_(Branch name is a leftover from the originally-scoped admin surface; that pivoted to this notification gap — see thread.)_