### PR TITLE
feat(api): customer-facing read-only Orders API

### DIFF
--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Order;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class OrderController extends Controller
+{
+    /**
+     * Paginated list of the authenticated user's own orders, newest first.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $perPage = min((int) $request->input('per_page', 15), 100);
+
+        $orders = Order::where('user_id', $request->user()->id)
+            ->with('items')
+            ->latest()
+            ->paginate($perPage);
+
+        return response()->json($orders);
+    }
+
+    /**
+     * A single order owned by the authenticated user. Scoping by user_id is the
+     * IDOR guard — another user's (or a guest's) order is simply not found.
+     */
+    public function show(Request $request, int $id): JsonResponse
+    {
+        $order = Order::where('user_id', $request->user()->id)
+            ->with(['items', 'statusHistory'])
+            ->find($id);
+
+        if (! $order) {
+            return response()->json(['success' => false, 'message' => 'Order not found'], 404);
+        }
+
+        return response()->json(['success' => true, 'data' => $order]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,10 +1,11 @@
 <?php
 
+use App\Http\Controllers\Api\CollectionController;
+use App\Http\Controllers\Api\DropshippingController;
+use App\Http\Controllers\Api\OrderController;
+use App\Http\Controllers\Api\ProductController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\Api\DropshippingController;
-use App\Http\Controllers\Api\ProductController;
-use App\Http\Controllers\Api\CollectionController;
 
 /*
 |--------------------------------------------------------------------------
@@ -37,6 +38,11 @@ Route::middleware('auth:sanctum')->prefix('products')->group(function () {
     Route::put('/{id}', [ProductController::class, 'update']);
     Route::patch('/{id}', [ProductController::class, 'update']);
     Route::delete('/{id}', [ProductController::class, 'destroy']);
+});
+// Order API routes (customer-facing: read-only, scoped to the authenticated user)
+Route::middleware('auth:sanctum')->prefix('orders')->group(function () {
+    Route::get('/', [OrderController::class, 'index']);
+    Route::get('/{id}', [OrderController::class, 'show']);
 });
 // Collection API routes
 Route::middleware('auth:sanctum')->prefix('collections')->group(function () {

--- a/tests/Feature/Api/OrderApiTest.php
+++ b/tests/Feature/Api/OrderApiTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Order;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class OrderApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function order(array $attrs): Order
+    {
+        return Order::create(array_merge([
+            'customer_email' => 'x@example.com',
+            'total_amount' => 25,
+            'status' => Order::STATUS_PAID,
+            'order_date' => now()->toDateString(),
+        ], $attrs));
+    }
+
+    public function test_unauthenticated_cannot_list_orders(): void
+    {
+        $this->getJson('/api/orders')->assertStatus(401);
+    }
+
+    public function test_lists_only_the_authenticated_users_orders(): void
+    {
+        $me = User::factory()->create();
+        $other = User::factory()->create();
+        $this->order(['user_id' => $me->id, 'total_amount' => 10]);
+        $this->order(['user_id' => $me->id, 'total_amount' => 20]);
+        $this->order(['user_id' => $other->id, 'total_amount' => 99]);
+        $this->order(['user_id' => null]); // guest order — never exposed via the authed API
+
+        Sanctum::actingAs($me);
+        $res = $this->getJson('/api/orders');
+
+        $res->assertStatus(200)->assertJsonStructure(['data', 'total', 'per_page', 'current_page']);
+        $this->assertSame(2, $res->json('total'));
+        $userIds = collect($res->json('data'))->pluck('user_id')->unique()->values()->all();
+        $this->assertSame([$me->id], $userIds);
+    }
+
+    public function test_show_returns_own_order(): void
+    {
+        $me = User::factory()->create();
+        $order = $this->order(['user_id' => $me->id]);
+
+        Sanctum::actingAs($me);
+
+        $this->getJson("/api/orders/{$order->id}")
+            ->assertStatus(200)
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.id', $order->id);
+    }
+
+    public function test_cannot_view_another_users_order(): void
+    {
+        $me = User::factory()->create();
+        $other = User::factory()->create();
+        $order = $this->order(['user_id' => $other->id]);
+
+        Sanctum::actingAs($me);
+
+        // IDOR guard: someone else's order is simply not found for me.
+        $this->getJson("/api/orders/{$order->id}")->assertStatus(404);
+    }
+
+    public function test_show_missing_order_is_404(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+
+        $this->getJson('/api/orders/999999')->assertStatus(404);
+    }
+}


### PR DESCRIPTION
## What

Products and collections each expose a full `auth:sanctum` REST API (72 tests), but **orders had no API at all** (TASKS 1.7). Headless/mobile clients had no way to fetch a customer's order history.

## Change

Two read-only endpoints under `auth:sanctum`:
- `GET /api/orders` — paginated list of the **authenticated user's own** orders, newest-first, with items. Mirrors the Product API's paginator JSON shape (`data`/`total`/`per_page`/`current_page`), `per_page` capped at 100.
- `GET /api/orders/{id}` — a single owned order with items + status history; `{success, data}` or 404.

## Security

Every query is **scoped by `user_id`** (the authenticated-checkout link from #699). An order belonging to another user — or a guest order (`user_id` null) — is simply **not found (404)**, so there's no IDOR leak and no 403 that confirms existence.

## Tests

+5 (`OrderApiTest`): 401 unauthenticated; list returns only own orders (excludes another user's **and** guest orders); show own → 200; **show another user's → 404 (IDOR guard)**; missing → 404.

Read-only by design — no create/update/delete (orders are created through checkout, mutated through the state machine). No migration, no raw SQL. Suite **817 passed / 0 failed**.