### PR TITLE
fix(orders): sync payment_status on transition so analytics sees revenue

### DIFF
--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -14,14 +14,23 @@ class Order extends Model
     use IsTenantModel;
 
     public const STATUS_PENDING = 'pending';
+
     public const STATUS_PAID = 'paid';
+
     public const STATUS_FAILED = 'failed';
+
     public const STATUS_PROCESSING = 'processing';
+
     public const STATUS_SUPPLIER_QUEUED = 'supplier_queued';
+
     public const STATUS_SUPPLIER_FAILED = 'supplier_failed';
+
     public const STATUS_COMPLETED = 'completed';
+
     public const STATUS_CANCELLED = 'cancelled';
+
     public const STATUS_REFUNDED = 'refunded';
+
     public const STATUS_PARTIALLY_REFUNDED = 'partially_refunded';
 
     /**
@@ -127,7 +136,23 @@ class Order extends Model
             throw new InvalidOrderTransitionException($from, $status);
         }
 
-        $this->update(['status' => $status]);
+        $attributes = ['status' => $status];
+
+        // Keep the separate payment_status column in sync — analytics, customer LTV,
+        // invoices and the admin sales widgets all filter on payment_status='paid',
+        // and every payment-affecting transition routes through here. Refund states
+        // deliberately leave it 'paid' (the payment did happen; refund_total tracks
+        // the money returned).
+        $paymentStatus = match ($status) {
+            self::STATUS_PAID => 'paid',
+            self::STATUS_FAILED => 'failed',
+            default => null,
+        };
+        if ($paymentStatus !== null) {
+            $attributes['payment_status'] = $paymentStatus;
+        }
+
+        $this->update($attributes);
 
         $this->statusHistory()->create([
             'from_status' => $from,

--- a/tests/Feature/OrderPaymentStatusTest.php
+++ b/tests/Feature/OrderPaymentStatusTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Order;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OrderPaymentStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function order(string $status = 'pending'): Order
+    {
+        return Order::create([
+            'customer_email' => 'b@example.com',
+            'total_amount' => 50,
+            'status' => $status,
+        ]);
+    }
+
+    public function test_transition_to_paid_marks_payment_status_paid(): void
+    {
+        // The bug: analytics, LTV, invoices and widgets all filter payment_status='paid',
+        // but a captured payment only set `status`, leaving payment_status unset → zero revenue.
+        $order = $this->order();
+
+        $order->transitionTo(Order::STATUS_PAID);
+
+        $this->assertSame('paid', $order->fresh()->payment_status);
+    }
+
+    public function test_transition_to_failed_marks_payment_status_failed(): void
+    {
+        $order = $this->order();
+
+        $order->transitionTo(Order::STATUS_FAILED);
+
+        $this->assertSame('failed', $order->fresh()->payment_status);
+    }
+
+    public function test_refund_transition_does_not_clobber_paid_status(): void
+    {
+        $order = $this->order();
+        $order->transitionTo(Order::STATUS_PAID);
+
+        $order->transitionTo(Order::STATUS_REFUNDED);
+
+        // A refunded order was still genuinely paid — analytics counts gross revenue;
+        // refund_total tracks the money returned.
+        $this->assertSame('paid', $order->fresh()->payment_status);
+    }
+}


### PR DESCRIPTION
## The bug

A captured payment moved the order's `status` column to `paid` (via `transitionTo(STATUS_PAID)`), but the **separate `payment_status` column was never set**. Every revenue reader in the app filters `payment_status = 'paid'`:

- `AnalyticsService` — `getSalesMetrics`, `getSalesTrends`, `getTopProducts`, segments (6 sites)
- Customer **LTV** — `Customer::getTotalSpent()`
- Admin **sales widgets** — `TopProductsWidget`, `SalesTrendsChart`
- `InvoiceController` status filter

Nothing wrote `payment_status = 'paid'`, so **the entire reporting/analytics/LTV surface read zero revenue** from real orders. (Only test fixtures that hand-set `payment_status` looked correct — masking it.)

## The fix

`Order::transitionTo()` — the single gateway every payment-affecting status change routes through — now syncs `payment_status`:

| transition | payment_status |
|---|---|
| → PAID | `paid` |
| → FAILED | `failed` |
| → REFUNDED / PARTIALLY_REFUNDED | *unchanged* (stays `paid`) |

Refund states deliberately leave it `paid`: the payment genuinely happened, analytics counts **gross** revenue, and `refund_total` already tracks money returned. Checkout is fixed **transitively** — it calls `transitionTo(STATUS_PAID)` — as are refunds and any admin lifecycle change.

## Tests

+3 (`OrderPaymentStatusTest`): → PAID sets `paid`, → FAILED sets `failed`, refund transition doesn't clobber `paid`. No existing test regressed (826/0) — none relied on `payment_status` staying unset after a transition.

Root-cause, one-method change. No migration, no raw SQL.