### PR TITLE
feat(tax): wire tax-inclusive price display on the product page

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Interfaces\Orderable;
 use App\Notifications\ProductBackInStockNotification;
+use App\Services\TaxCalculator;
 use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -172,6 +173,18 @@ class Product extends Model implements Orderable
     public function isDownloadable(): bool
     {
         return $this->is_downloadable && $this->downloadable()->exists();
+    }
+
+    /**
+     * Catalogue display price — tax-inclusive when the store is configured to
+     * show prices with tax, otherwise the bare price. Delegates to TaxCalculator.
+     *
+     * ponytail: resolves the calculator per call; fine for a product page, batch
+     * it (one rate lookup for the list) if a big catalogue index gets slow.
+     */
+    public function displayPrice(): float
+    {
+        return app(TaxCalculator::class)->displayPrice($this);
     }
 
     protected static function booted(): void

--- a/app/Services/TaxCalculator.php
+++ b/app/Services/TaxCalculator.php
@@ -2,8 +2,8 @@
 
 namespace App\Services;
 
-use App\Models\TaxRate;
 use App\Models\Product;
+use App\Models\TaxRate;
 
 class TaxCalculator
 {
@@ -20,7 +20,7 @@ class TaxCalculator
         $city = $shippingAddress['city'] ?? null;
         $zipCode = $shippingAddress['postal_code'] ?? null;
 
-        if (!$country) {
+        if (! $country) {
             return ['total' => 0, 'lines' => []];
         }
 
@@ -30,12 +30,12 @@ class TaxCalculator
             $quantity = $item['quantity'] ?? 1;
             $price = $item['price'] ?? 0;
 
-            if (!$product || !($product instanceof Product)) {
+            if (! $product || ! ($product instanceof Product)) {
                 continue;
             }
 
             // Skip if product is not taxable
-            if (!($product->tax_status ?? true)) {
+            if (! ($product->tax_status ?? true)) {
                 continue;
             }
 
@@ -51,7 +51,7 @@ class TaxCalculator
 
                 // Group by rate for tax lines
                 $rateKey = $rate->id;
-                if (!isset($taxLines[$rateKey])) {
+                if (! isset($taxLines[$rateKey])) {
                     $taxLines[$rateKey] = [
                         'label' => $rate->name,
                         'rate' => $rate->rate,
@@ -73,9 +73,9 @@ class TaxCalculator
                 $totalTax += $taxAmount;
 
                 $rateKey = $rate->id;
-                if (!isset($taxLines[$rateKey])) {
+                if (! isset($taxLines[$rateKey])) {
                     $taxLines[$rateKey] = [
-                        'label' => $rate->name . ' (Shipping)',
+                        'label' => $rate->name.' (Shipping)',
                         'rate' => $rate->rate,
                         'amount' => 0,
                         'compound' => $rate->compound,
@@ -96,7 +96,7 @@ class TaxCalculator
      */
     public function calculateProductTax(Product $product, float $price, array $location): float
     {
-        if (!($product->tax_status ?? true)) {
+        if (! ($product->tax_status ?? true)) {
             return 0;
         }
 
@@ -122,6 +122,7 @@ class TaxCalculator
     public function getPriceWithTax(float $price, Product $product, array $location): float
     {
         $tax = $this->calculateProductTax($product, $price, $location);
+
         return round($price + $tax, 2);
     }
 
@@ -131,5 +132,29 @@ class TaxCalculator
     public function shouldDisplayPricesWithTax(): bool
     {
         return config('ecommerce.display_prices_with_tax', false);
+    }
+
+    /**
+     * The price to show on catalogue/cart pages: bare when the store displays
+     * tax-exclusive prices, otherwise tax-inclusive using the store's own
+     * location (the visitor's address isn't known before checkout).
+     */
+    public function displayPrice(Product $product): float
+    {
+        $price = (float) $product->price;
+
+        if (! $this->shouldDisplayPricesWithTax()) {
+            return $price;
+        }
+
+        return $this->getPriceWithTax($price, $product, $this->storeLocation());
+    }
+
+    private function storeLocation(): array
+    {
+        return [
+            'country' => config('ecommerce.store_country', 'US'),
+            'state' => config('ecommerce.store_state'),
+        ];
     }
 }

--- a/config/ecommerce.php
+++ b/config/ecommerce.php
@@ -12,6 +12,11 @@ return [
 
     'display_prices_with_tax' => env('TAX_DISPLAY_PRICES_WITH_TAX', false),
 
+    // Store's own location — the rate used when showing tax-inclusive prices to a
+    // visitor whose address is not yet known (product/cart pages).
+    'store_country' => env('STORE_COUNTRY', 'US'),
+    'store_state' => env('STORE_STATE'),
+
     /*
     |--------------------------------------------------------------------------
     | Currency Settings

--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -38,7 +38,7 @@
                             <a href="{{ route('download.generate-link', $product->id) }}" class="btn btn-link">Download without donating</a>
                         @endif
                     @else
-                        <p><strong>Price:</strong> ${{ number_format($product->price, 2) }}</p>
+                        <p><strong>Price:</strong> ${{ number_format($product->displayPrice(), 2) }}@if(config('ecommerce.display_prices_with_tax')) <small>(inc. tax)</small>@endif</p>
                         @if($product->inventory_count > 0)
                             <form action="{{ route('cart.add', $product) }}" method="POST" class="d-inline">
                                 @csrf

--- a/tests/Feature/TaxInclusiveDisplayTest.php
+++ b/tests/Feature/TaxInclusiveDisplayTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\TaxClass;
+use App\Models\TaxRate;
+use App\Services\TaxCalculator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TaxInclusiveDisplayTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function taxedProduct(float $price): Product
+    {
+        $classId = TaxClass::create(['name' => 'Standard', 'slug' => 'standard', 'is_active' => true])->id;
+        TaxRate::create([
+            'tax_class_id' => $classId, 'name' => 'VAT', 'country' => 'GB', 'rate' => 20.00,
+            'priority' => 1, 'compound' => false, 'shipping' => false, 'is_active' => true,
+        ]);
+
+        return Product::factory()->create([
+            'price' => $price, 'tax_status' => true, 'tax_class_id' => $classId,
+            'inventory_count' => 5, 'pricing_type' => 'fixed',
+        ]);
+    }
+
+    public function test_display_price_is_bare_when_flag_off(): void
+    {
+        config(['ecommerce.display_prices_with_tax' => false]);
+        $product = $this->taxedProduct(100);
+
+        $this->assertSame(100.0, app(TaxCalculator::class)->displayPrice($product));
+    }
+
+    public function test_display_price_includes_tax_when_flag_on(): void
+    {
+        config(['ecommerce.display_prices_with_tax' => true, 'ecommerce.store_country' => 'GB']);
+        $product = $this->taxedProduct(100);
+
+        // 100 + 20% VAT
+        $this->assertSame(120.0, app(TaxCalculator::class)->displayPrice($product));
+    }
+
+    public function test_product_page_shows_tax_inclusive_price(): void
+    {
+        config(['ecommerce.display_prices_with_tax' => true, 'ecommerce.store_country' => 'GB']);
+        $product = $this->taxedProduct(100);
+
+        $this->get(route('products.show', $product))
+            ->assertStatus(200)
+            ->assertSee('120.00')
+            ->assertSee('inc. tax');
+    }
+}


### PR DESCRIPTION
## What

The tax engine (#706) computes tax-inclusive prices at checkout, but the **catalogue still showed bare, tax-exclusive prices**. The display helpers already existed — `TaxCalculator::getPriceWithTax()`, `shouldDisplayPricesWithTax()`, and the `config('ecommerce.display_prices_with_tax')` flag — but **nothing called them** (orphaned, same pattern as the rest of this codebase). For a B2C store in the EU/UK, showing prices *inclusive* of VAT on catalogue pages is a legal requirement.

## Change

Wired the orphaned helpers end-to-end:
- **`TaxCalculator::displayPrice(Product)`** — returns the bare price when the store displays tax-exclusive prices, otherwise the tax-inclusive price using the **store's own location** (a visitor's address isn't known before checkout).
- **New config** `ecommerce.store_country` / `store_state` — the location whose rate is applied for display. Defaults to `US`.
- **`Product::displayPrice()`** delegates to it; the **product show view** renders it with an `(inc. tax)` label when the flag is on.

The `display_prices_with_tax` flag defaults **false**, so there is **zero behaviour change** until a store opts in.

## Tests

+3 (`TaxInclusiveDisplayTest`): bare price when flag off, price + 20% VAT when on, and the product page actually renders the inclusive price + label. Suite **829 passed / 0 failed**, no migration.

## Follow-up (not this PR)

Apply the same `displayPrice()` helper to the catalogue index and cart views — batch the rate lookup once for a list page (the per-product resolve is fine for a single product page, noted in-code).