### PR TITLE
fix(orders): scope order-history to user_id (empty list + own-order 403 + IDOR)

### DIFF
--- a/app/Http/Controllers/OrderHistoryController.php
+++ b/app/Http/Controllers/OrderHistoryController.php
@@ -2,30 +2,28 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-use App\Models\Order;
 use Illuminate\Support\Facades\Auth;
 
 class OrderHistoryController extends Controller
 {
     public function index()
     {
-        $user = Auth::user();
-        $orders = Order::where('customer_id', $user->id)
-                       ->orderBy('created_at', 'desc')
-                       ->paginate(10);
+        // Order ownership is orders.user_id (set at authenticated checkout), not
+        // customer_id (a FK to the unrelated customers table, never populated) —
+        // scoping on customer_id made this list permanently empty.
+        $orders = Auth::user()->orders()
+            ->orderBy('created_at', 'desc')
+            ->paginate(10);
 
         return view('orders.history', compact('orders'));
     }
 
     public function show($id)
     {
-        $order = Order::findOrFail($id);
-
-        // Ensure the order belongs to the authenticated user
-        if ($order->customer_id !== Auth::id()) {
-            abort(403, 'Unauthorized action.');
-        }
+        // Scope the lookup to the user's own orders: a foreign or guest order is
+        // simply not found (404), which is both the ownership check and the fix
+        // for owners being 403'd off their own orders.
+        $order = Auth::user()->orders()->findOrFail($id);
 
         return view('orders.show', compact('order'));
     }

--- a/resources/views/orders/show.blade.php
+++ b/resources/views/orders/show.blade.php
@@ -5,8 +5,8 @@
     <h1>Order #{{ $order->id }}</h1>
     <p>Date: {{ $order->created_at->format('Y-m-d H:i') }}</p>
     <p>Status: {{ ucfirst($order->status) }}</p>
-    <p>Payment: {{ ucfirst($order->payment_status) }}</p>
-    <p>Shipping: {{ ucfirst($order->shipping_status) }}</p>
+    <p>Payment: {{ $order->payment_status ? ucfirst($order->payment_status) : '—' }}</p>
+    <p>Shipping: {{ $order->shipping_status ? ucfirst($order->shipping_status) : '—' }}</p>
     <p>Total: ${{ number_format($order->total_amount, 2) }}</p>
 
     <a href="{{ route('orders.index') }}" class="btn btn-secondary">Back to orders</a>

--- a/tests/Feature/OrderHistoryControllerTest.php
+++ b/tests/Feature/OrderHistoryControllerTest.php
@@ -32,6 +32,7 @@ class OrderHistoryControllerTest extends TestCase
         ]);
 
         return Order::create(array_merge([
+            'user_id' => $user->id,
             'customer_id' => $customer->id,
             'customer_email' => $user->email,
             'total_amount' => 100.00,
@@ -94,14 +95,16 @@ class OrderHistoryControllerTest extends TestCase
         $response->assertStatus(404);
     }
 
-    public function test_show_returns_403_when_order_belongs_to_other_user(): void
+    public function test_show_returns_404_when_order_belongs_to_other_user(): void
     {
         $userA = $this->makeUser();
         $userB = $this->makeUser();
         $order = $this->makeOrder($userA);
 
+        // Scoped to the user's own orders — a foreign order is not found (no
+        // existence-confirming 403).
         $response = $this->actingAs($userB)->get("/orders/{$order->id}");
 
-        $response->assertStatus(403);
+        $response->assertStatus(404);
     }
 }

--- a/tests/Feature/OrderHistoryTest.php
+++ b/tests/Feature/OrderHistoryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Order;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OrderHistoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function order(array $attrs): Order
+    {
+        return Order::create(array_merge([
+            'customer_email' => 'x@example.com',
+            'total_amount' => 42.00,
+            'status' => Order::STATUS_PAID,
+            'order_date' => now()->toDateString(),
+        ], $attrs));
+    }
+
+    public function test_my_orders_lists_only_my_orders(): void
+    {
+        $me = User::factory()->create();
+        $other = User::factory()->create();
+        $mine = $this->order(['user_id' => $me->id]);
+        $theirs = $this->order(['user_id' => $other->id]);
+        $guest = $this->order(['user_id' => null]);
+
+        $response = $this->actingAs($me)->get(route('orders.index'));
+
+        $response->assertStatus(200);
+        $response->assertSee(route('orders.show', $mine->id));
+        $response->assertDontSee(route('orders.show', $theirs->id));
+        $response->assertDontSee(route('orders.show', $guest->id));
+    }
+
+    public function test_can_view_my_own_order(): void
+    {
+        $me = User::factory()->create();
+        $order = $this->order(['user_id' => $me->id]);
+
+        $this->actingAs($me)->get(route('orders.show', $order->id))
+            ->assertStatus(200)
+            ->assertSee('42.00');
+    }
+
+    public function test_cannot_view_another_users_order_is_404(): void
+    {
+        $me = User::factory()->create();
+        $other = User::factory()->create();
+        $order = $this->order(['user_id' => $other->id]);
+
+        // IDOR guard: someone else's order is not found for me (404, not 403, not 200).
+        $this->actingAs($me)->get(route('orders.show', $order->id))->assertStatus(404);
+    }
+
+    public function test_guest_order_is_not_viewable_is_404(): void
+    {
+        $me = User::factory()->create();
+        $order = $this->order(['user_id' => null]);
+
+        $this->actingAs($me)->get(route('orders.show', $order->id))->assertStatus(404);
+    }
+}


### PR DESCRIPTION
## The bug

The customer-facing **"My Orders"** page (`/orders`, `/orders/{id}`) keyed ownership on the wrong column. `OrderHistoryController` read `orders.customer_id` — a FK to the unrelated `customers` table that **checkout never populates** — while checkout writes `orders.user_id` (`CheckoutController` `'user_id' => auth()->id()`). Same writer/reader-column pattern as the recent `payment_status` fix.

Three concrete failures:
- **`index()`** — `where('customer_id', user->id)` matched nothing → the order list was **always empty** for every user ("You haven't placed any orders yet").
- **`show()`** — guard `$order->customer_id !== Auth::id()` → `customer_id` is null on every real order → **owners got 403 on their own orders**, and the check was against the wrong id-space (**IDOR** for any legacy row whose `customer_id` collided with the attacker's id).
- On MySQL the **uncast integer id** compares as a string (`'5' !== 5`), 403ing unconditionally — the sqlite `:memory:` test DB returned ints and masked it.

## The fix

Scope both actions through `Auth::user()->orders()` (the `hasMany` on `user_id`). `show()` uses `->findOrFail()`, so a foreign or guest order is **404** — the ownership check and the no-existence-leak behaviour in one. Also null-guarded `ucfirst(payment_status/shipping_status)` in the show view (nullable columns → PHP 8 deprecation).

## Tests

Found via a read-only audit sweep of unswept subsystems. +4 (`OrderHistoryTest`): list returns only my orders (excludes other-user **and** guest), own-order 200, **cross-user 404**, guest 404. Updated the 2 existing `OrderHistoryControllerTest` cases that encoded the old `customer_id`/403 contract (fixture now sets real `user_id`; 403 → 404).

Suite **833 passed / 0 failed**. No migration, no raw SQL.

## Related findings (same sweep — filed, not in this PR)

- **Invoices**: `/invoices` + `/invoices/{id}` have no ownership scoping (IDOR) — but currently leak an empty table since `createInvoiceForOrder()` is broken (reads `$order->total`/`$order->products`/`coupon_id` — none exist) and unrouted. Worth fixing before invoice generation is wired.
- **API search**: `sort_order` passed to `orderBy()` unvalidated → 500 on any non-asc/desc value.