### PR TITLE
fix(downloads): repair route param mismatch so digital downloads work

### DIFF
--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -2,24 +2,25 @@
 
 namespace App\Http\Controllers;
 
+use App\Factories\PaymentGatewayFactory;
+use App\Jobs\DispatchDropshippingOrder;
+use App\Models\Coupon;
+use App\Models\InventoryLog;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\ShippingMethod;
+use App\Notifications\OrderConfirmationNotification;
+use App\Notifications\SupplierFailureNotification;
+use App\Services\CouponService;
+use App\Services\ShippingService;
+use App\Services\TaxCalculator;
+use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
-use App\Models\ShippingMethod;
-use App\Services\ShippingService;
-use App\Models\Order;
-use App\Models\Coupon;
-use App\Models\InventoryLog;
-use App\Models\User;
-use Illuminate\Support\Facades\Notification;
-use App\Factories\PaymentGatewayFactory;
-use App\Models\Product;
-use App\Notifications\OrderConfirmationNotification;
-use App\Services\TaxCalculator;
-use App\Services\CouponService;
-use Exception;
 
 class CheckoutController extends Controller
 {
@@ -27,7 +28,9 @@ class CheckoutController extends Controller
     private const OUT_OF_STOCK = 'OUT_OF_STOCK';
 
     protected $shippingService;
+
     protected $taxCalculator;
+
     protected $couponService;
 
     public function __construct(ShippingService $shippingService, TaxCalculator $taxCalculator, CouponService $couponService)
@@ -90,7 +93,7 @@ class CheckoutController extends Controller
         }
 
         $cart = Session::get('cart', []);
-        
+
         if (empty($cart)) {
             return redirect()->route('products.index')
                 ->with('error', 'Your cart is empty');
@@ -99,13 +102,13 @@ class CheckoutController extends Controller
         // Verify inventory before processing
         foreach ($cart as $productId => $item) {
             $product = Product::find($productId);
-            if (!$product || $product->inventory_count < $item['quantity']) {
+            if (! $product || $product->inventory_count < $item['quantity']) {
                 return redirect()->back()->with('error', 'Some items in your cart are no longer available in the requested quantity.');
             }
         }
 
         // Calculate total amount
-        $subtotal = collect($cart)->sum(function($item) {
+        $subtotal = collect($cart)->sum(function ($item) {
             return $item['price'] * $item['quantity'];
         });
 
@@ -227,20 +230,22 @@ class CheckoutController extends Controller
         if ($totalAmount > 0) {
             if ($request->payment_method === 'stripe' && $request->has('stripeToken')) {
                 $paymentResult = $this->processStripePayment($order, $request->stripeToken);
-            } else if ($request->payment_method === 'paypal' && $request->has('paypal_payment_id')) {
+            } elseif ($request->payment_method === 'paypal' && $request->has('paypal_payment_id')) {
                 $paymentResult = $this->processPayPalPayment($order, $request->paypal_payment_id);
             } else {
                 $this->releaseInventory($order, $cart);
                 $order->transitionTo(Order::STATUS_FAILED, notes: 'Invalid payment information');
+
                 return redirect()->back()
                     ->with('error', 'Invalid payment information. Please try again.');
             }
 
-            if (!$paymentResult['success']) {
+            if (! $paymentResult['success']) {
                 $this->releaseInventory($order, $cart);
-                $order->transitionTo(Order::STATUS_FAILED, notes: 'Payment failed: ' . ($paymentResult['error'] ?? 'unknown'));
+                $order->transitionTo(Order::STATUS_FAILED, notes: 'Payment failed: '.($paymentResult['error'] ?? 'unknown'));
+
                 return redirect()->back()
-                    ->with('error', 'Payment failed: ' . ($paymentResult['error'] ?? 'Please try again.'));
+                    ->with('error', 'Payment failed: '.($paymentResult['error'] ?? 'Please try again.'));
             }
         }
 
@@ -263,17 +268,17 @@ class CheckoutController extends Controller
                 $order->update(['supplier_id' => $supplierId]);
 
                 // dispatch a job to place the supplier order asynchronously
-                \App\Jobs\DispatchDropshippingOrder::dispatch($order->id, $supplierId);
+                DispatchDropshippingOrder::dispatch($order->id, $supplierId);
 
                 // set temporary status indicating background placement
                 $order->transitionTo(Order::STATUS_SUPPLIER_QUEUED, notes: "Supplier order queued ({$supplierId})");
 
             } catch (Exception $e) {
-                \Log::error('Dropshipping dispatch error: ' . $e->getMessage());
-                $order->transitionTo(Order::STATUS_SUPPLIER_FAILED, notes: 'Dropshipping dispatch error: ' . $e->getMessage());
+                \Log::error('Dropshipping dispatch error: '.$e->getMessage());
+                $order->transitionTo(Order::STATUS_SUPPLIER_FAILED, notes: 'Dropshipping dispatch error: '.$e->getMessage());
 
                 Notification::route('mail', config('mail.from.address'))
-                    ->notify(new \App\Notifications\SupplierFailureNotification("Error queuing dropshipping order for order {$order->id}: " . $e->getMessage()));
+                    ->notify(new SupplierFailureNotification("Error queuing dropshipping order for order {$order->id}: ".$e->getMessage()));
 
                 return redirect()->route('checkout.confirmation', ['order' => $order->id])
                     ->with('warning', 'Order placed but an error occurred while queuing the supplier order. Our team will follow up.');
@@ -289,13 +294,11 @@ class CheckoutController extends Controller
                 if ($orderItem && $product) {
                     // Generate secure download link with expiration (30 days)
                     $token = Str::random(64);
-                    $categoryId = $product->category ? $product->category->id : 'general';
                     $downloadLink = route('download.serve-file', [
-                        'category' => $categoryId,
                         'product' => $product->id,
-                        'token' => $token
+                        'token' => $token,
                     ]);
-                    
+
                     $orderItem->update([
                         'download_link' => $token, // Store token, not full URL
                         'download_expires_at' => now()->addDays(30),
@@ -308,7 +311,7 @@ class CheckoutController extends Controller
         // Clear cart and coupon
         Session::forget('cart');
         Session::forget('coupon');
-        
+
         return redirect()->route('checkout.confirmation', ['order' => $order->id])
             ->with('success', 'Order placed successfully!');
     }
@@ -316,14 +319,14 @@ class CheckoutController extends Controller
     public function showConfirmation(Order $order)
     {
         return view('checkout.confirmation', [
-            'order' => $order
+            'order' => $order,
         ]);
     }
 
     public function guestCheckout(Request $request)
     {
         $cart = Session::get('cart', []);
-        
+
         // Store cart in guest session
         Session::put('guest_cart', $cart);
         Session::put('is_guest', true);
@@ -334,9 +337,10 @@ class CheckoutController extends Controller
     protected function processPayment($order, $paymentMethod)
     {
         $paymentGateway = PaymentGatewayFactory::create($paymentMethod);
+
         return $paymentGateway->processPayment($order->total_amount, [
             'order_id' => $order->id,
-            'customer_email' => $order->customer_email
+            'customer_email' => $order->customer_email,
         ]);
     }
 
@@ -369,30 +373,33 @@ class CheckoutController extends Controller
     private function hasPhysicalProducts($cart)
     {
         foreach ($cart as $item) {
-            if (!$item['is_downloadable']) {
+            if (! $item['is_downloadable']) {
                 return true;
             }
         }
+
         return false;
     }
 
     protected function processStripePayment($order, $stripeToken)
     {
         $paymentGateway = PaymentGatewayFactory::create('stripe');
+
         return $paymentGateway->processPayment($order->total_amount, [
             'order_id' => $order->id,
             'customer_email' => $order->customer_email,
-            'token' => $stripeToken
+            'token' => $stripeToken,
         ]);
     }
 
     protected function processPayPalPayment($order, $paypalPaymentId)
     {
         $paymentGateway = PaymentGatewayFactory::create('paypal');
+
         return $paymentGateway->processPayment($order->total_amount, [
             'order_id' => $order->id,
             'customer_email' => $order->customer_email,
-            'payment_id' => $paypalPaymentId
+            'payment_id' => $paypalPaymentId,
         ]);
     }
 }

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -6,37 +6,36 @@ use App\Models\DownloadableProduct;
 use App\Models\Order;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class DownloadController extends Controller
 {
-    public function generateSecureLink(Request $request, $productId)
+    public function generateSecureLink(Request $request, $product)
     {
-        $downloadableProduct = DownloadableProduct::where('product_id', $productId)
+        $downloadableProduct = DownloadableProduct::where('product_id', $product)
             ->firstOrFail();
 
-        if (!$downloadableProduct->isDownloadable() || !$this->authorizeDownload($request->user(), $downloadableProduct)) {
+        if (! $downloadableProduct->isDownloadable() || ! $this->authorizeDownload($request->user(), $downloadableProduct)) {
             abort(403, 'Download limit reached or not authorized.');
         }
 
         $temporaryUrl = Storage::disk('local')->temporaryUrl(
-            $downloadableProduct->file_url, 
+            $downloadableProduct->file_url,
             now()->addMinutes(5)
         );
 
         return response()->json([
             'url' => $temporaryUrl,
             'expires_in' => 300, // 5 minutes in seconds
-            'downloads_remaining' => $downloadableProduct->download_limit - $downloadableProduct->downloads_count
+            'downloads_remaining' => $downloadableProduct->download_limit - $downloadableProduct->downloads_count,
         ]);
     }
 
-    public function serveFile(Request $request, $productId)
+    public function serveFile(Request $request, $product)
     {
-        $downloadableProduct = DownloadableProduct::where('product_id', $productId)
+        $downloadableProduct = DownloadableProduct::where('product_id', $product)
             ->firstOrFail();
 
-        if (!$downloadableProduct->isDownloadable() || !$this->authorizeDownload($request->user(), $downloadableProduct)) {
+        if (! $downloadableProduct->isDownloadable() || ! $this->authorizeDownload($request->user(), $downloadableProduct)) {
             abort(403, 'Download limit reached or not authorized.');
         }
 
@@ -56,7 +55,7 @@ class DownloadController extends Controller
             return true;
         }
 
-        if (!$user) {
+        if (! $user) {
             return false;
         }
 

--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -18,7 +18,7 @@
                     <br>
                     @if($product->isFree())
                         <p><strong>Price:</strong> Free</p>
-                        <a href="{{ route('download.generate-link', $product->id) }}" class="btn btn-success mt-2">Download Now</a>
+                        <a href="{{ route('download.serve-file', $product->id) }}" class="btn btn-success mt-2">Download Now</a>
                     @elseif($product->isDonationBased())
                         <form action="{{ route('cart.add', $product) }}" method="POST" class="d-inline">
                             @csrf
@@ -35,7 +35,7 @@
                             <button type="submit" class="btn btn-success mt-2">Support & Download</button>
                         </form>
                         @if($product->minimum_price <= 0)
-                            <a href="{{ route('download.generate-link', $product->id) }}" class="btn btn-link">Download without donating</a>
+                            <a href="{{ route('download.serve-file', $product->id) }}" class="btn btn-link">Download without donating</a>
                         @endif
                     @else
                         <p><strong>Price:</strong> ${{ number_format($product->displayPrice(), 2) }}@if(config('ecommerce.display_prices_with_tax')) <small>(inc. tax)</small>@endif</p>
@@ -116,7 +116,7 @@
 </div>
 
 @if(isset($product->downloadable) && $product->downloadable->count() > 0 && auth()->user() && auth()->user()->hasPurchased($product))
-    <a href="{{ route('download.generate-link', $product->id) }}" class="btn btn-success mt-3">Download</a>
+    <a href="{{ route('download.serve-file', $product->id) }}" class="btn btn-success mt-3">Download</a>
 @endif
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -144,8 +144,8 @@ Route::delete('/product/{category}/{product}/compare', [ProductController::class
 Route::delete('/products/compare/clear', [ProductController::class, 'clearCompare'])->name('products.clearCompare');
 
 Route::middleware('auth')->group(function () {
-    Route::get('/download/{category}/{product}', [DownloadController::class, 'generateSecureLink'])->name('download.generate-link');
-    Route::get('/download/file/{category}/{product}', [DownloadController::class, 'serveFile'])->name('download.serve-file');
+    Route::get('/download/{product}', [DownloadController::class, 'generateSecureLink'])->name('download.generate-link');
+    Route::get('/download/file/{product}', [DownloadController::class, 'serveFile'])->name('download.serve-file');
 
     // Invoice routes
     Route::get('/invoices', [InvoiceController::class, 'index'])->name('invoices.index');

--- a/tests/Feature/DownloadControllerTest.php
+++ b/tests/Feature/DownloadControllerTest.php
@@ -32,7 +32,7 @@ class DownloadControllerTest extends TestCase
     {
         $product = $this->makeProduct();
 
-        $response = $this->get("/download/category/{$product->id}");
+        $response = $this->get(route('download.generate-link', $product->id));
 
         $response->assertRedirect('/login');
     }
@@ -41,7 +41,7 @@ class DownloadControllerTest extends TestCase
     {
         $product = $this->makeProduct();
 
-        $response = $this->get("/download/file/category/{$product->id}");
+        $response = $this->get(route('download.serve-file', $product->id));
 
         $response->assertRedirect('/login');
     }
@@ -52,7 +52,7 @@ class DownloadControllerTest extends TestCase
         $product = $this->makeProduct();
 
         // No DownloadableProduct record = not downloadable
-        $response = $this->actingAs($user)->get("/download/category/{$product->slug}");
+        $response = $this->actingAs($user)->get(route('download.generate-link', $product->id));
 
         $response->assertStatus(404);
     }

--- a/tests/Feature/DownloadTest.php
+++ b/tests/Feature/DownloadTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\DownloadableProduct;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class DownloadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function downloadableProduct(): Product
+    {
+        Storage::fake('local');
+        Storage::disk('local')->put('downloads/file.zip', 'PAYLOAD');
+
+        $product = Product::factory()->create([
+            'is_downloadable' => true, 'pricing_type' => 'fixed', 'inventory_count' => 5,
+        ]);
+        DownloadableProduct::create([
+            'product_id' => $product->id,
+            'file_url' => 'downloads/file.zip',
+            'download_limit' => 5,
+            'downloads_count' => 0,
+        ]);
+
+        return $product;
+    }
+
+    private function purchase(User $user, Product $product): void
+    {
+        $order = Order::create([
+            'user_id' => $user->id,
+            'customer_email' => $user->email,
+            'total_amount' => 10,
+            'status' => Order::STATUS_PAID,
+        ]);
+        $order->items()->create(['product_id' => $product->id, 'quantity' => 1, 'price' => 10]);
+    }
+
+    public function test_buyer_can_download_their_purchased_product(): void
+    {
+        // The route param mismatch ({category}/{product} vs $productId) made the
+        // controller look up by the category id → 404 for legitimate buyers.
+        $user = User::factory()->create();
+        $product = $this->downloadableProduct();
+        $this->purchase($user, $product);
+
+        $this->actingAs($user)->get(route('download.serve-file', $product->id))
+            ->assertStatus(200);
+    }
+
+    public function test_non_purchaser_is_denied(): void
+    {
+        $user = User::factory()->create();
+        $product = $this->downloadableProduct(); // no purchase for this user
+
+        $this->actingAs($user)->get(route('download.serve-file', $product->id))
+            ->assertStatus(403);
+    }
+
+    public function test_download_url_generates_from_a_single_product_arg(): void
+    {
+        // Guards the route arity: the two-segment {category}/{product} route threw
+        // UrlGenerationException from the blade's single-arg route() call → 500 on
+        // every product page carrying a download button.
+        $product = Product::factory()->create();
+
+        $url = route('download.serve-file', $product->id);
+
+        $this->assertStringContainsString('/download/file/'.$product->id, $url);
+    }
+}


### PR DESCRIPTION
## The bug (digital delivery completely broken)

Download routes declared **two** segments — `/download/{category}/{product}` and `/download/file/{category}/{product}` — but the controller methods take a single `$productId`. Laravel binds it **positionally to the first segment (the category id)**, so `DownloadableProduct::where('product_id', $productId)` actually queried by category id:

- Legitimate buyers → `firstOrFail()` **404** (or, on an id collision, served a **different product's file**).
- `resources/views/products/show.blade.php` called `route('download.generate-link', $product->id)` with **one arg for a two-segment route** → `UrlGenerationException` → **500 on every product page carrying a download button**.

Same writer/reader shape as the recent order-history fix: the declared contract and the code that uses it disagreed on the parameter.

## The fix

The `{category}` segment is vestigial — downloads are per-product. Dropped it end-to-end:
- Routes → `/download/{product}`, `/download/file/{product}`.
- `DownloadController` params → `$product`, querying `where('product_id', $product)`.
- `CheckoutController` download-link generation updated to the single-segment route.
- Repointed the show-view download buttons to **`download.serve-file`** (streams the file) instead of `generate-link` (returns JSON via `Storage::temporaryUrl()`, which **throws on the local disk driver**).

**Auth gate verified intact** (not changed): `serveFile` → `authorizeDownload` scopes to `$user->orders()` + `whereIn('status', [PAID, COMPLETED])`, so no unpaid, guest, or foreign-user download. No IDOR.

## Tests

Found via a read-only audit sweep of unswept subsystems. +3 (`DownloadTest`): buyer downloads their purchased product (200), non-purchaser denied (403), single-arg download URL generates. Updated the 3 `DownloadControllerTest` cases that hardcoded the old two-segment URLs. Suite **836 passed / 0 failed**. No migration, no raw SQL.

## Follow-ups (same sweep — filed, not in this PR)

- **Per-order token + 30-day expiry not enforced**: checkout stores `order_items.download_link` (token) + `download_expires_at`, but `serveFile` reads neither — it uses the **product-global** `download_limit`/`downloads_count`/`expiration_time` (shared across all buyers), so after N total downloads every buyer is blocked, and the 30-day window is never applied.
- `generateSecureLink` `temporaryUrl()` is unsupported on the local disk driver (needs S3-style disk or a signed route).
- Download-count check-then-serve is non-atomic (TOCTOU) → limit can be overshot.
- Free downloadable products are downloadable by any authenticated user (not just buyers).