### PR TITLE
feat(downloads): enforce per-purchase download limit + expiry

### DIFF
--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\DownloadableProduct;
 use App\Models\Order;
+use App\Models\OrderItem;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 
@@ -35,12 +36,54 @@ class DownloadController extends Controller
         $downloadableProduct = DownloadableProduct::where('product_id', $product)
             ->firstOrFail();
 
-        if (! $downloadableProduct->isDownloadable() || ! $this->authorizeDownload($request->user(), $downloadableProduct)) {
-            abort(403, 'Download limit reached or not authorized.');
+        // Free products carry no purchase — serve without per-order limits.
+        if ($downloadableProduct->product->isFree()) {
+            return $this->streamFile($downloadableProduct);
         }
 
-        $downloadableProduct->incrementDownloadCount();
+        // Paid products are gated PER PURCHASE: each buyer's own order line item
+        // carries its download window (30-day expiry) and its own counter, so one
+        // buyer can't exhaust the allowance for everyone (the product-global
+        // download_limit is the per-purchase cap, not a shared pool).
+        $item = $this->resolvePurchasedItem($request->user(), $product, $request->query('token'));
 
+        if (! $item || ! $item->isDownloadValid()) {
+            abort(403, 'This download link is invalid or has expired.');
+        }
+
+        $limit = $downloadableProduct->download_limit;
+        if ($limit !== null && $item->download_count >= $limit) {
+            abort(403, 'Download limit reached for this purchase.');
+        }
+
+        $item->increment('download_count');
+
+        return $this->streamFile($downloadableProduct);
+    }
+
+    /**
+     * The authenticated user's purchased line item for this product, from a paid
+     * order. A token (from the emailed link) pins a specific purchase; otherwise
+     * the most recent one is used.
+     */
+    private function resolvePurchasedItem($user, $productId, ?string $token): ?OrderItem
+    {
+        if (! $user) {
+            return null;
+        }
+
+        return OrderItem::where('product_id', $productId)
+            ->whereHas('order', function ($query) use ($user) {
+                $query->where('user_id', $user->id)
+                    ->whereIn('status', [Order::STATUS_PAID, Order::STATUS_COMPLETED]);
+            })
+            ->when($token, fn ($query) => $query->where('download_link', $token))
+            ->latest()
+            ->first();
+    }
+
+    private function streamFile(DownloadableProduct $downloadableProduct)
+    {
         return Storage::disk('local')->download(
             $downloadableProduct->file_url,
             null,

--- a/tests/Feature/DownloadTest.php
+++ b/tests/Feature/DownloadTest.php
@@ -4,17 +4,19 @@ namespace Tests\Feature;
 
 use App\Models\DownloadableProduct;
 use App\Models\Order;
+use App\Models\OrderItem;
 use App\Models\Product;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class DownloadTest extends TestCase
 {
     use RefreshDatabase;
 
-    private function downloadableProduct(): Product
+    private function downloadableProduct(int $limit = 5): Product
     {
         Storage::fake('local');
         Storage::disk('local')->put('downloads/file.zip', 'PAYLOAD');
@@ -25,14 +27,14 @@ class DownloadTest extends TestCase
         DownloadableProduct::create([
             'product_id' => $product->id,
             'file_url' => 'downloads/file.zip',
-            'download_limit' => 5,
+            'download_limit' => $limit,
             'downloads_count' => 0,
         ]);
 
         return $product;
     }
 
-    private function purchase(User $user, Product $product): void
+    private function purchase(User $user, Product $product, array $itemOverrides = []): OrderItem
     {
         $order = Order::create([
             'user_id' => $user->id,
@@ -40,19 +42,27 @@ class DownloadTest extends TestCase
             'total_amount' => 10,
             'status' => Order::STATUS_PAID,
         ]);
-        $order->items()->create(['product_id' => $product->id, 'quantity' => 1, 'price' => 10]);
+
+        return $order->items()->create(array_merge([
+            'product_id' => $product->id,
+            'quantity' => 1,
+            'price' => 10,
+            'download_link' => Str::random(64),
+            'download_expires_at' => now()->addDays(30),
+            'download_count' => 0,
+        ], $itemOverrides));
     }
 
-    public function test_buyer_can_download_their_purchased_product(): void
+    public function test_buyer_can_download_within_limit_and_window(): void
     {
-        // The route param mismatch ({category}/{product} vs $productId) made the
-        // controller look up by the category id → 404 for legitimate buyers.
         $user = User::factory()->create();
-        $product = $this->downloadableProduct();
-        $this->purchase($user, $product);
+        $product = $this->downloadableProduct(limit: 3);
+        $item = $this->purchase($user, $product);
 
-        $this->actingAs($user)->get(route('download.serve-file', $product->id))
-            ->assertStatus(200);
+        $this->actingAs($user)->get(route('download.serve-file', $product->id))->assertStatus(200);
+
+        // The buyer's own line item is what gets counted.
+        $this->assertSame(1, $item->fresh()->download_count);
     }
 
     public function test_non_purchaser_is_denied(): void
@@ -60,15 +70,44 @@ class DownloadTest extends TestCase
         $user = User::factory()->create();
         $product = $this->downloadableProduct(); // no purchase for this user
 
-        $this->actingAs($user)->get(route('download.serve-file', $product->id))
-            ->assertStatus(403);
+        $this->actingAs($user)->get(route('download.serve-file', $product->id))->assertStatus(403);
+    }
+
+    public function test_download_blocked_after_per_purchase_limit_reached(): void
+    {
+        $user = User::factory()->create();
+        $product = $this->downloadableProduct(limit: 2);
+        $this->purchase($user, $product, ['download_count' => 2]); // allotment used up
+
+        $this->actingAs($user)->get(route('download.serve-file', $product->id))->assertStatus(403);
+    }
+
+    public function test_expired_download_is_blocked(): void
+    {
+        $user = User::factory()->create();
+        $product = $this->downloadableProduct();
+        $this->purchase($user, $product, ['download_expires_at' => now()->subDay()]);
+
+        $this->actingAs($user)->get(route('download.serve-file', $product->id))->assertStatus(403);
+    }
+
+    public function test_download_limit_is_per_buyer_not_global(): void
+    {
+        // A product-global counter would let one buyer exhaust the limit for
+        // everyone. Each buyer must have their own allotment.
+        $product = $this->downloadableProduct(limit: 1);
+
+        $buyerA = User::factory()->create();
+        $this->purchase($buyerA, $product);
+        $buyerB = User::factory()->create();
+        $this->purchase($buyerB, $product);
+
+        $this->actingAs($buyerA)->get(route('download.serve-file', $product->id))->assertStatus(200);
+        $this->actingAs($buyerB)->get(route('download.serve-file', $product->id))->assertStatus(200);
     }
 
     public function test_download_url_generates_from_a_single_product_arg(): void
     {
-        // Guards the route arity: the two-segment {category}/{product} route threw
-        // UrlGenerationException from the blade's single-arg route() call → 500 on
-        // every product page carrying a download button.
         $product = Product::factory()->create();
 
         $url = route('download.serve-file', $product->id);


### PR DESCRIPTION
## What (follow-up to #714)

`serveFile` gated on the **product-global** `download_limit` / `downloads_count` — a **shared pool**. Once total downloads across **all** buyers hit the cap, every buyer got 403. And the per-buyer machinery set at checkout — `order_items.download_expires_at` (30-day window) and `order_items.download_count` (per-purchase counter) — was **never read**, so the expiry was never enforced.

## Change

`serveFile` now gates **per purchase**, via the buyer's own order line item:
- Resolve the user's paid/completed `order_item` for the product (a `?token` pins a specific purchase; otherwise the latest).
- Reject if missing or expired (`OrderItem::isDownloadValid()` — token present + `download_expires_at` in the future).
- Reject if that item's `download_count` has reached the product's `download_limit` (now a **per-purchase cap**, not a shared pool).
- Increment the **item's** counter.

Free products keep the no-purchase, no-limit path. Authorization is implicit in the scoping (`user_id` + paid/completed status) — a non-purchaser resolves no item → 403, so no IDOR.

## Tests

+3 (`DownloadTest`, now 6): per-purchase limit reached → 403, expired window → 403, and the key one — **two buyers each get their own allotment** (a global counter would 403 the second). Existing buyer-can-download / non-buyer / URL-arity cases retained. Suite **839 passed / 0 failed**, no migration.

## Remaining download follow-ups (filed)

- `generateSecureLink` `temporaryUrl()` unsupported on the local disk driver (needs an S3-style disk or signed route).
- Free downloadable products are downloadable by any authenticated user (not only buyers).