### PR TITLE
fix(api): validate sort_order and stop mangling product search

### DIFF
--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -7,15 +7,11 @@ use App\Models\Product;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Str;
 
 class ProductController extends Controller
 {
     /**
      * Display a paginated listing of products.
-     *
-     * @param Request $request
-     * @return JsonResponse
      */
     public function index(Request $request): JsonResponse
     {
@@ -25,19 +21,16 @@ class ProductController extends Controller
         $query = Product::query();
 
         // Apply search filter if provided
-        if ($request->has('search')) {
-            $search = $request->input('search');
-            // Sanitize search input to prevent SQL injection
-            $search = strip_tags($search);
-            $search = preg_replace('/[^\w\s\-]/', '', $search);
-            
-            if (!empty($search)) {
-                $query->where(function ($q) use ($search) {
-                    $q->where('name', 'like', '%' . $search . '%')
-                        ->orWhere('description', 'like', '%' . $search . '%')
-                        ->orWhere('short_description', 'like', '%' . $search . '%');
-                });
-            }
+        if ($request->filled('search')) {
+            // The value is a bound parameter (injection-safe already); escape only
+            // the LIKE wildcards so a literal % / _ can't match everything.
+            $search = addcslashes(trim($request->input('search')), '%_\\');
+
+            $query->where(function ($q) use ($search) {
+                $q->where('name', 'like', '%'.$search.'%')
+                    ->orWhere('description', 'like', '%'.$search.'%')
+                    ->orWhere('short_description', 'like', '%'.$search.'%');
+            });
         }
 
         // Apply category filter if provided
@@ -54,12 +47,13 @@ class ProductController extends Controller
             $query->where('price', '<=', $request->input('price_max'));
         }
 
-        // Apply sorting
+        // Apply sorting — whitelist the column AND clamp the direction (orderBy()
+        // throws on anything but asc/desc, which 500'd the endpoint).
         $sortBy = $request->input('sort_by', 'created_at');
-        $sortOrder = $request->input('sort_order', 'desc');
-        
+        $sortOrder = strtolower($request->input('sort_order', 'desc')) === 'asc' ? 'asc' : 'desc';
+
         $allowedSortFields = ['name', 'price', 'created_at', 'updated_at'];
-        if (in_array($sortBy, $allowedSortFields)) {
+        if (in_array($sortBy, $allowedSortFields, true)) {
             $query->orderBy($sortBy, $sortOrder);
         }
 
@@ -70,9 +64,6 @@ class ProductController extends Controller
 
     /**
      * Display the specified product by ID or slug.
-     *
-     * @param string $identifier
-     * @return JsonResponse
      */
     public function show(string $identifier): JsonResponse
     {
@@ -84,7 +75,7 @@ class ProductController extends Controller
                 ->where('slug', $identifier)
                 ->first();
 
-        if (!$product) {
+        if (! $product) {
             return response()->json([
                 'success' => false,
                 'message' => 'Product not found',
@@ -99,9 +90,6 @@ class ProductController extends Controller
 
     /**
      * Store a newly created product.
-     *
-     * @param Request $request
-     * @return JsonResponse
      */
     public function store(Request $request): JsonResponse
     {
@@ -145,16 +133,12 @@ class ProductController extends Controller
 
     /**
      * Update the specified product.
-     *
-     * @param Request $request
-     * @param int $id
-     * @return JsonResponse
      */
     public function update(Request $request, int $id): JsonResponse
     {
         $product = Product::find($id);
 
-        if (!$product) {
+        if (! $product) {
             return response()->json([
                 'success' => false,
                 'message' => 'Product not found',
@@ -201,15 +185,12 @@ class ProductController extends Controller
 
     /**
      * Soft delete the specified product.
-     *
-     * @param int $id
-     * @return JsonResponse
      */
     public function destroy(int $id): JsonResponse
     {
         $product = Product::find($id);
 
-        if (!$product) {
+        if (! $product) {
             return response()->json([
                 'success' => false,
                 'message' => 'Product not found',

--- a/tests/Feature/Api/ProductApiSearchSortTest.php
+++ b/tests/Feature/Api/ProductApiSearchSortTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ProductApiSearchSortTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Sanctum::actingAs(User::factory()->create());
+    }
+
+    public function test_invalid_sort_order_does_not_500(): void
+    {
+        Product::factory()->count(2)->create();
+
+        // orderBy() throws InvalidArgumentException on anything but asc/desc;
+        // an unvalidated sort_order therefore crashed the endpoint.
+        $this->getJson('/api/products?sort_order=lowest')->assertStatus(200);
+        $this->getJson('/api/products?sort_by=price&sort_order=ascending')->assertStatus(200);
+    }
+
+    public function test_search_matches_terms_containing_an_apostrophe(): void
+    {
+        Product::factory()->create(['name' => "O'Neill Wetsuit"]);
+
+        // The old sanitizer stripped the apostrophe -> "ONeill" -> no match.
+        $response = $this->getJson('/api/products?search='.urlencode("O'Neill"));
+
+        $response->assertStatus(200);
+        $this->assertCount(1, $response->json('data'));
+        $this->assertSame("O'Neill Wetsuit", $response->json('data.0.name'));
+    }
+
+    public function test_like_wildcard_in_search_is_escaped(): void
+    {
+        Product::factory()->create(['name' => 'Ordinary Product']);
+
+        // A bare "%" must not match every product (it did — raw wildcard in LIKE).
+        $response = $this->getJson('/api/products?search='.urlencode('%'));
+
+        $response->assertStatus(200);
+        $this->assertCount(0, $response->json('data'));
+    }
+}


### PR DESCRIPTION
## Two bugs in `GET /api/products`

**1. `sort_order` unvalidated → uncaught 500.** `sort_by` was whitelisted but `sort_order` went straight into `orderBy($sortBy, $sortOrder)`, which throws `InvalidArgumentException('Order direction must be "asc" or "desc".')` for anything else. `?sort_order=lowest` (or `ascending`, `asc,desc`, …) → **500**. Triggers even without `sort_by`, since the default `created_at` is in the allowed list. Now clamped to `asc`, else `desc`.

**2. Search sanitizer corrupted legitimate queries.** `preg_replace('/[^\w\s\-]/', '', $search)` stripped apostrophes, ampersands and accented letters, so `O'Neill` → `ONeill` → no match; `L'Oréal` → `LOral`; `AT&T` → `ATT`. It was also **redundant** — the term is a bound LIKE parameter, so SQL injection was never possible. Replaced with proper **LIKE-wildcard escaping** (`addcslashes` for `%`, `_`, `\`), which also fixes a bare `%` matching every product (mild full-scan vector).

## Tests

Found via a read-only audit sweep. +3 (`ProductApiSearchSortTest`): invalid `sort_order` returns 200, apostrophe search matches, a bare `%` matches nothing. Existing `ProductApiTest` search/sort cases still green. Suite **842 passed / 0 failed**. No migration, no raw SQL.
