### PR TITLE
fix(security): gate shipping-method management behind admin auth

### DIFF
--- a/app/Http/Controllers/ShippingController.php
+++ b/app/Http/Controllers/ShippingController.php
@@ -7,14 +7,28 @@ use Illuminate\Http\Request;
 
 class ShippingController extends Controller
 {
+    /**
+     * Shipping methods are store-wide checkout config — restrict every action to
+     * staff (the `auth` middleware on the routes already blocks guests).
+     */
+    private function ensureAdmin(): void
+    {
+        abort_unless(auth()->user()?->hasRole(['super_admin', 'admin']), 403);
+    }
+
     public function index()
     {
+        $this->ensureAdmin();
+
         $shippingMethods = ShippingMethod::all();
+
         return view('shipping.index', compact('shippingMethods'));
     }
 
     public function store(Request $request)
     {
+        $this->ensureAdmin();
+
         $validatedData = $request->validate([
             'name' => 'required|string|max:255',
             'description' => 'nullable|string',
@@ -25,7 +39,7 @@ class ShippingController extends Controller
             'is_active' => 'nullable|boolean',
         ]);
 
-        $validatedData['is_active'] = $request->has('is_active');
+        $validatedData['is_active'] = $request->boolean('is_active');
 
         ShippingMethod::create($validatedData);
 
@@ -34,6 +48,8 @@ class ShippingController extends Controller
 
     public function update(Request $request, ShippingMethod $shippingMethod)
     {
+        $this->ensureAdmin();
+
         $validatedData = $request->validate([
             'name' => 'required|string|max:255',
             'description' => 'nullable|string',
@@ -44,7 +60,7 @@ class ShippingController extends Controller
             'is_active' => 'nullable|boolean',
         ]);
 
-        $validatedData['is_active'] = $request->has('is_active');
+        $validatedData['is_active'] = $request->boolean('is_active');
 
         $shippingMethod->update($validatedData);
 
@@ -53,6 +69,8 @@ class ShippingController extends Controller
 
     public function destroy(ShippingMethod $shippingMethod)
     {
+        $this->ensureAdmin();
+
         $shippingMethod->delete();
 
         return redirect()->route('shipping.index')->with('success', 'Shipping method deleted successfully.');

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,11 +82,13 @@ Route::get('/checkout', [CheckoutController::class, 'initiateCheckout'])->name('
 Route::post('/checkout/process', [CheckoutController::class, 'processCheckout'])->name('checkout.process');
 Route::get('/checkout/confirmation/{order}', [CheckoutController::class, 'showConfirmation'])->name('checkout.confirmation');
 
-// Shipping routes
-Route::get('/shipping', [ShippingController::class, 'index'])->name('shipping.index');
-Route::post('/shipping', [ShippingController::class, 'store'])->name('shipping.store');
-Route::put('/shipping/{shippingMethod}', [ShippingController::class, 'update'])->name('shipping.update');
-Route::delete('/shipping/{shippingMethod}', [ShippingController::class, 'destroy'])->name('shipping.destroy');
+// Shipping routes — store-wide config, admin-only (auth here, role checked in the controller)
+Route::middleware('auth')->group(function () {
+    Route::get('/shipping', [ShippingController::class, 'index'])->name('shipping.index');
+    Route::post('/shipping', [ShippingController::class, 'store'])->name('shipping.store');
+    Route::put('/shipping/{shippingMethod}', [ShippingController::class, 'update'])->name('shipping.update');
+    Route::delete('/shipping/{shippingMethod}', [ShippingController::class, 'destroy'])->name('shipping.destroy');
+});
 
 // Order history routes
 Route::middleware('auth')->group(function () {

--- a/tests/Feature/ShippingAdminAuthTest.php
+++ b/tests/Feature/ShippingAdminAuthTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ShippingMethod;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class ShippingAdminAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        return User::factory()->create()->assignRole('super_admin');
+    }
+
+    private function payload(array $overrides = []): array
+    {
+        return array_merge([
+            'name' => 'Express',
+            'base_rate' => 9.99,
+            'estimated_delivery_time' => '2 days',
+        ], $overrides);
+    }
+
+    public function test_guests_cannot_access_shipping_management(): void
+    {
+        $this->get('/shipping')->assertRedirect('/login');
+        $this->post('/shipping', $this->payload())->assertRedirect('/login');
+
+        $method = ShippingMethod::create($this->payload());
+        $this->delete("/shipping/{$method->id}")->assertRedirect('/login');
+        $this->assertDatabaseHas('shipping_methods', ['id' => $method->id]);
+    }
+
+    public function test_non_admin_cannot_manage_shipping(): void
+    {
+        $user = User::factory()->create(); // no role
+
+        $this->actingAs($user)->post('/shipping', $this->payload())->assertStatus(403);
+
+        $method = ShippingMethod::create($this->payload());
+        $this->actingAs($user)->delete("/shipping/{$method->id}")->assertStatus(403);
+        $this->assertDatabaseHas('shipping_methods', ['id' => $method->id]);
+    }
+
+    public function test_admin_can_create_shipping_method(): void
+    {
+        $admin = $this->admin();
+
+        $this->actingAs($admin)->post('/shipping', $this->payload(['name' => 'Overnight']))
+            ->assertRedirect(route('shipping.index'));
+
+        $this->assertDatabaseHas('shipping_methods', ['name' => 'Overnight']);
+    }
+
+    public function test_admin_can_delete_shipping_method(): void
+    {
+        $admin = $this->admin();
+        $method = ShippingMethod::create($this->payload());
+
+        $this->actingAs($admin)->delete("/shipping/{$method->id}")
+            ->assertRedirect(route('shipping.index'));
+
+        $this->assertDatabaseMissing('shipping_methods', ['id' => $method->id]);
+    }
+
+    public function test_explicit_is_active_false_deactivates_method(): void
+    {
+        $admin = $this->admin();
+        $method = ShippingMethod::create($this->payload(['is_active' => true]));
+
+        // has() treated key-presence as true, so is_active=0 couldn't deactivate.
+        $this->actingAs($admin)->put("/shipping/{$method->id}", $this->payload(['is_active' => 0]));
+
+        $this->assertFalse((bool) $method->fresh()->is_active);
+    }
+}

--- a/tests/Feature/ShippingControllerTest.php
+++ b/tests/Feature/ShippingControllerTest.php
@@ -3,12 +3,24 @@
 namespace Tests\Feature;
 
 use App\Models\ShippingMethod;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class ShippingControllerTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Shipping management is admin-only; these exercise controller behaviour,
+        // so authenticate as an admin (authorization itself is covered in
+        // ShippingAdminAuthTest).
+        Role::findOrCreate('super_admin', 'web');
+        $this->actingAs(User::factory()->create()->assignRole('super_admin'));
+    }
 
     private function makeShipping(array $overrides = []): ShippingMethod
     {


### PR DESCRIPTION
## Unauthenticated mutation of store-wide shipping config

The `/shipping` routes — `index` **and** `store`/`update`/`destroy` — had **no `auth` middleware** (unlike the orders/wishlist/downloads/payment-methods groups). Any anonymous visitor could create, edit, or **delete** shipping methods. These rows drive `ShippingService::getAvailableShippingMethods()` / `calculateShippingCost()` at checkout, so the exploit is real:

- `POST /shipping` with `base_rate: 0` → injects a "Free Express" option into **every** checkout.
- `DELETE /shipping/{id}` → wipes shipping options store-wide.

## Fixes

- Wrapped the four routes in `Route::middleware('auth')`.
- Added an admin guard in the controller — `abort_unless(auth()->user()?->hasRole(['super_admin','admin']), 403)` on `index`/`store`/`update`/`destroy`. This matches the app's existing inline-role pattern (`ChatController`), since no `role` middleware alias is registered.
- Fixed `is_active`: `store`/`update` used `$request->has('is_active')`, which is `true` whenever the key is present — so a method could **never be deactivated** by posting `is_active=0`. Now `$request->boolean('is_active')`.

## Tests

Found via a read-only audit sweep. +5 (`ShippingAdminAuthTest`): guests redirected to login; authenticated non-admin → 403 (and the method survives); admin can create/delete; explicit `is_active=0` deactivates. The existing `ShippingControllerTest` (controller behaviour/validation) now authenticates as an admin in `setUp`. Validation and mass-assignment were already sound (verified) — the hole was purely authorization. Suite **853 passed / 0 failed**. No migration, no raw SQL.

## Remaining from the sweep (filed)

- **Subscriptions**: every route fatals — `laravel/cashier` + PayPal SDK both uninstalled, `User` not `Billable`; also no `auth`. Large (needs packages + real integration).
- `payment_methods.details` stores raw card data (PCI — token+last4 redesign).
