### PR TITLE
fix(security): gate inventory adjustment behind admin auth + make it atomic

### DIFF
--- a/app/Http/Controllers/InventoryController.php
+++ b/app/Http/Controllers/InventoryController.php
@@ -6,33 +6,54 @@ use App\Models\InventoryLog;
 use App\Models\Product;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
 
 class InventoryController extends Controller
 {
+    /** Sentinel thrown inside the transaction to reject a negative result. */
+    private const NEGATIVE = 'NEGATIVE_INVENTORY';
+
     public function adjustInventory(Request $request)
     {
+        // Stock is store-wide config that the oversell guard depends on — staff only.
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
         $validatedData = $request->validate([
-            'product_id' => 'required|exists:products,id',
+            'product_id' => 'required|integer|exists:products,id',
             'quantity_change' => 'required|integer',
             'reason' => 'required|string|max:255',
         ]);
 
-        $product = Product::find($validatedData['product_id']);
-        $newInventoryCount = $product->inventory_count + $validatedData['quantity_change'];
+        try {
+            // Lock the row so concurrent adjustments (and the checkout decrement)
+            // can't lose an update; log + stock write commit together.
+            $product = DB::transaction(function () use ($validatedData) {
+                $product = Product::lockForUpdate()->findOrFail($validatedData['product_id']);
+                $old = $product->inventory_count;
+                $new = $old + $validatedData['quantity_change'];
 
-        if ($newInventoryCount < 0) {
-            return response()->json(['message' => 'Invalid quantity change. Inventory count cannot be negative.'], Response::HTTP_BAD_REQUEST);
+                if ($new < 0) {
+                    throw new \RuntimeException(self::NEGATIVE);
+                }
+
+                $product->update(['inventory_count' => $new]);
+
+                InventoryLog::create([
+                    'product_id' => $product->id,
+                    'quantity_change' => $validatedData['quantity_change'],
+                    'old_quantity' => $old,
+                    'new_quantity' => $new,
+                    'reason' => $validatedData['reason'],
+                ]);
+
+                return $product;
+            });
+        } catch (\RuntimeException $e) {
+            if ($e->getMessage() === self::NEGATIVE) {
+                return response()->json(['message' => 'Invalid quantity change. Inventory count cannot be negative.'], Response::HTTP_BAD_REQUEST);
+            }
+            throw $e;
         }
-
-        $product->inventory_count = $newInventoryCount;
-        $product->save();
-
-        $inventoryLog = new InventoryLog([
-            'product_id' => $validatedData['product_id'],
-            'quantity_change' => $validatedData['quantity_change'],
-            'reason' => $validatedData['reason'],
-        ]);
-        $inventoryLog->save();
 
         return response()->json(['message' => 'Inventory adjusted successfully', 'product' => $product], Response::HTTP_OK);
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -161,7 +161,7 @@ Route::post('/site-settings/{id}', [SiteSettingController::class, 'update'])->na
 Route::get('/sitemap.xml', [SitemapController::class, 'index'])->name('sitemap.xml');
 
 // Inventory routes
-Route::post('/inventory/adjust', [InventoryController::class, 'adjustInventory'])->name('inventory.adjust');
+Route::post('/inventory/adjust', [InventoryController::class, 'adjustInventory'])->middleware('auth')->name('inventory.adjust');
 
 // Pages
 // TODO: implement CMS features for page and form editing

--- a/tests/Feature/InventoryAdjustSecurityTest.php
+++ b/tests/Feature/InventoryAdjustSecurityTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class InventoryAdjustSecurityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        return User::factory()->create()->assignRole('super_admin');
+    }
+
+    private function product(int $stock = 10): Product
+    {
+        return Product::factory()->create(['inventory_count' => $stock]);
+    }
+
+    public function test_adjust_requires_authentication(): void
+    {
+        $product = $this->product();
+
+        $this->postJson('/inventory/adjust', [
+            'product_id' => $product->id, 'quantity_change' => 5, 'reason' => 'x',
+        ])->assertStatus(401);
+
+        $this->assertEquals(10, $product->fresh()->inventory_count);
+    }
+
+    public function test_non_admin_cannot_adjust(): void
+    {
+        $product = $this->product();
+
+        $this->actingAs(User::factory()->create())->postJson('/inventory/adjust', [
+            'product_id' => $product->id, 'quantity_change' => 5, 'reason' => 'x',
+        ])->assertStatus(403);
+
+        $this->assertEquals(10, $product->fresh()->inventory_count);
+    }
+
+    public function test_admin_can_adjust_and_writes_full_log(): void
+    {
+        $admin = $this->admin();
+        $product = $this->product(10);
+
+        $this->actingAs($admin)->postJson('/inventory/adjust', [
+            'product_id' => $product->id, 'quantity_change' => 5, 'reason' => 'restock',
+        ])->assertStatus(200);
+
+        $this->assertEquals(15, $product->fresh()->inventory_count);
+        $this->assertDatabaseHas('inventory_logs', [
+            'product_id' => $product->id, 'quantity_change' => 5,
+            'old_quantity' => 10, 'new_quantity' => 15, 'reason' => 'restock',
+        ]);
+    }
+
+    public function test_soft_deleted_product_returns_404_not_500(): void
+    {
+        $admin = $this->admin();
+        $product = $this->product();
+        $product->delete(); // soft delete — passes the exists rule but not findOrFail
+
+        $this->actingAs($admin)->postJson('/inventory/adjust', [
+            'product_id' => $product->id, 'quantity_change' => 5, 'reason' => 'x',
+        ])->assertStatus(404);
+    }
+}

--- a/tests/Feature/InventoryControllerTest.php
+++ b/tests/Feature/InventoryControllerTest.php
@@ -4,23 +4,35 @@ namespace Tests\Feature;
 
 use App\Models\Product;
 use App\Models\ProductCategory;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class InventoryControllerTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Stock adjustment is admin-only; these cover controller behaviour, so
+        // authenticate as an admin (authorization is covered in
+        // InventoryAdjustSecurityTest).
+        Role::findOrCreate('super_admin', 'web');
+        $this->actingAs(User::factory()->create()->assignRole('super_admin'));
+    }
+
     private function makeProduct(array $overrides = []): Product
     {
         $category = ProductCategory::create([
             'name' => 'Inventory Category',
-            'slug' => 'inv-cat-' . uniqid(),
+            'slug' => 'inv-cat-'.uniqid(),
         ]);
 
         return Product::create(array_merge([
             'name' => 'Inventory Product',
-            'slug' => 'inv-prod-' . uniqid(),
+            'slug' => 'inv-prod-'.uniqid(),
             'price' => 10.00,
             'category_id' => $category->id,
             'inventory_count' => 10,


### PR DESCRIPTION
## Unauthenticated stock manipulation

`POST /inventory/adjust` had **no `auth` middleware and no role check** (it sat just outside the `auth` group). Any anonymous visitor could set **any** product's stock:

- inflate it to defeat the reserve-before-charge **oversell guard** (customers charged for stock that doesn't exist), or
- send repeated negative deltas to grind a rival product to 0 → **denial-of-sale**.

Two more bugs in the same method:
- **Non-atomic read-modify-write**: read `inventory_count` in PHP, then `save()` — concurrent adjustments (or a race with the checkout decrement) lose updates, and the stock write + `InventoryLog` were separate writes (failure between them = stock changed with no audit row).
- **Soft-delete null-deref**: the `exists:products,id` rule ignores the `SoftDeletes` scope, so a trashed product id passed validation; `Product::find()` then returned `null` → `500` on the next line.

## Fixes

- `auth` middleware on the route + inline admin guard `hasRole(['super_admin','admin']) → 403` (matches the `ChatController`/`Shipping` pattern; no `role` middleware alias is registered).
- Wrapped the read-modify-write in `DB::transaction` with `lockForUpdate`; the stock write and `InventoryLog` commit together, and the log now records `old_quantity`/`new_quantity`.
- `Product::findOrFail` — a soft-deleted or unknown id → **404**, not a 500.

Negative-result rejection (400) and the numeric/required validation were already correct and are retained.

## Tests

Found via a read-only audit sweep. +4 (`InventoryAdjustSecurityTest`): auth required (401), non-admin → 403 (stock unchanged), admin adjusts + writes a full log (`old_quantity`/`new_quantity`), soft-deleted product → 404. The existing `InventoryControllerTest` (controller behaviour/validation) now authenticates as an admin in `setUp`. Suite **857 passed / 0 failed**. No migration, no raw SQL (the `lockForUpdate` is a no-op on the sqlite test DB, effective on MySQL).

## Remaining from the sweep — filed, in severity order

1. **CHAT IDOR (most severe)** — `GET /chat/{id}/messages` is unauthenticated and conversations are addressed by **sequential auto-increment id** (the intended token is the random `session_id`). An attacker enumerates ids and dumps **every customer's chat history + name/email** (PII data breach). `sendMessage`/`close` are likewise unscoped.
2. **SiteSettingController** — `index`/`edit`/`update` have no auth: anyone reads or overwrites store-wide config.
3. **ReviewController::approve** — `POST /reviews/approve/{id}` unauthenticated → anyone self-approves any review (full moderation bypass); `vote`/`store`/`ratings.store` are also outside `auth` (guest write → NOT-NULL `user_id` FK 500 on MySQL, masked on sqlite).
4. **WishlistController::share** — writes one `share_token` to every wishlist row (UNIQUE index) → 500 for any user with 2+ items; the share feature is also structurally broken (token belongs on `users`, not per row).
