### PR TITLE
fix(security): stop chat IDOR leaking every customer's conversation + PII

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ChatConversation;
 use App\Services\ChatService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -16,6 +17,21 @@ class ChatController extends Controller
     }
 
     /**
+     * A conversation is addressable by its sequential id, so the customer-facing
+     * endpoints must prove ownership: either the caller is an agent, or the
+     * conversation's (unguessable) session_id was bound to this browser session
+     * when the chat was started. Otherwise a stranger could enumerate ids and read
+     * everyone's chat history + PII.
+     */
+    private function authorizeConversationAccess(ChatConversation $conversation): void
+    {
+        $isAgent = Auth::check() && Auth::user()->hasRole(['super_admin', 'admin']);
+        $ownsSession = in_array($conversation->session_id, session('chat_conversations', []), true);
+
+        abort_unless($isAgent || $ownsSession, 403);
+    }
+
+    /**
      * Start a new chat conversation.
      */
     public function start(Request $request)
@@ -26,6 +42,10 @@ class ChatController extends Controller
         ]);
 
         $conversation = $this->chatService->createConversation($validated);
+
+        // Bind this conversation to the browser session so its later message/read
+        // calls (addressed by sequential id) can be authorized.
+        session()->push('chat_conversations', $conversation->session_id);
 
         return response()->json([
             'success' => true,
@@ -41,6 +61,12 @@ class ChatController extends Controller
         $validated = $request->validate([
             'message' => 'required|string|max:5000',
         ]);
+
+        $conversation = ChatConversation::find($conversationId);
+        if (! $conversation) {
+            return response()->json(['error' => 'Conversation not found'], 404);
+        }
+        $this->authorizeConversationAccess($conversation);
 
         $message = $this->chatService->addMessage($conversationId, [
             'message' => $validated['message'],
@@ -60,9 +86,11 @@ class ChatController extends Controller
     {
         $conversation = $this->chatService->getConversation($conversationId);
 
-        if (!$conversation) {
+        if (! $conversation) {
             return response()->json(['error' => 'Conversation not found'], 404);
         }
+
+        $this->authorizeConversationAccess($conversation);
 
         // Mark messages as read
         $readerType = Auth::check() && Auth::user()->hasRole(['super_admin', 'admin']) ? 'agent' : 'customer';
@@ -92,6 +120,12 @@ class ChatController extends Controller
      */
     public function close($conversationId)
     {
+        $conversation = ChatConversation::find($conversationId);
+        if (! $conversation) {
+            return response()->json(['error' => 'Conversation not found'], 404);
+        }
+        $this->authorizeConversationAccess($conversation);
+
         $conversation = $this->chatService->closeConversation($conversationId);
 
         return response()->json([
@@ -110,6 +144,12 @@ class ChatController extends Controller
             'feedback' => 'nullable|string|max:1000',
         ]);
 
+        $conversation = ChatConversation::find($conversationId);
+        if (! $conversation) {
+            return response()->json(['error' => 'Conversation not found'], 404);
+        }
+        $this->authorizeConversationAccess($conversation);
+
         $this->chatService->addSatisfactionRating(
             $conversationId,
             $validated['rating'],
@@ -127,7 +167,7 @@ class ChatController extends Controller
      */
     public function agentConversations()
     {
-        if (!Auth::check() || !Auth::user()->hasRole(['super_admin', 'admin'])) {
+        if (! Auth::check() || ! Auth::user()->hasRole(['super_admin', 'admin'])) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -144,7 +184,7 @@ class ChatController extends Controller
      */
     public function assignAgent(Request $request, $conversationId)
     {
-        if (!Auth::check() || !Auth::user()->hasRole(['super_admin', 'admin'])) {
+        if (! Auth::check() || ! Auth::user()->hasRole(['super_admin', 'admin'])) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -161,7 +201,7 @@ class ChatController extends Controller
      */
     public function nextQueued()
     {
-        if (!Auth::check() || !Auth::user()->hasRole(['super_admin', 'admin'])) {
+        if (! Auth::check() || ! Auth::user()->hasRole(['super_admin', 'admin'])) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 

--- a/tests/Feature/ChatControllerTest.php
+++ b/tests/Feature/ChatControllerTest.php
@@ -61,9 +61,10 @@ class ChatControllerTest extends TestCase
     {
         $conversation = $this->chatService->createConversation(['session_id' => 'sess_msg_test']);
 
-        $response = $this->postJson(route('chat.message', $conversation->id), [
-            'message' => 'Hello, I need help!',
-        ]);
+        $response = $this->withSession(['chat_conversations' => ['sess_msg_test']])
+            ->postJson(route('chat.message', $conversation->id), [
+                'message' => 'Hello, I need help!',
+            ]);
 
         $response->assertStatus(200);
         $response->assertJsonPath('success', true);
@@ -83,7 +84,8 @@ class ChatControllerTest extends TestCase
     {
         $conversation = $this->chatService->createConversation(['session_id' => 'sess_msgs']);
 
-        $response = $this->get(route('chat.messages', $conversation->id));
+        $response = $this->withSession(['chat_conversations' => ['sess_msgs']])
+            ->get(route('chat.messages', $conversation->id));
 
         $response->assertStatus(200);
         $response->assertJsonPath('success', true);
@@ -100,7 +102,8 @@ class ChatControllerTest extends TestCase
     {
         $conversation = $this->chatService->createConversation(['session_id' => 'sess_close_test']);
 
-        $response = $this->postJson(route('chat.close', $conversation->id));
+        $response = $this->withSession(['chat_conversations' => ['sess_close_test']])
+            ->postJson(route('chat.close', $conversation->id));
 
         $response->assertStatus(200);
         $response->assertJsonPath('success', true);
@@ -111,10 +114,11 @@ class ChatControllerTest extends TestCase
     {
         $conversation = $this->chatService->createConversation(['session_id' => 'sess_rating_test']);
 
-        $response = $this->postJson(route('chat.rating', $conversation->id), [
-            'rating' => 5,
-            'feedback' => 'Excellent!',
-        ]);
+        $response = $this->withSession(['chat_conversations' => ['sess_rating_test']])
+            ->postJson(route('chat.rating', $conversation->id), [
+                'rating' => 5,
+                'feedback' => 'Excellent!',
+            ]);
 
         $response->assertStatus(200);
         $response->assertJsonPath('success', true);

--- a/tests/Feature/ChatIdorTest.php
+++ b/tests/Feature/ChatIdorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ChatConversation;
+use App\Models\User;
+use App\Services\ChatService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class ChatIdorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function conversation(string $sessionId = 'sess_victim'): ChatConversation
+    {
+        return app(ChatService::class)->createConversation([
+            'session_id' => $sessionId,
+            'customer_email' => 'victim@example.com',
+        ]);
+    }
+
+    public function test_cannot_read_another_sessions_conversation(): void
+    {
+        $conv = $this->conversation();
+
+        // No session ownership, not an agent — must not dump the conversation.
+        $this->getJson(route('chat.messages', $conv->id))->assertStatus(403);
+    }
+
+    public function test_cannot_send_message_to_another_sessions_conversation(): void
+    {
+        $conv = $this->conversation();
+
+        $this->postJson(route('chat.message', $conv->id), ['message' => 'hi'])->assertStatus(403);
+    }
+
+    public function test_cannot_close_another_sessions_conversation(): void
+    {
+        $conv = $this->conversation();
+
+        $this->postJson(route('chat.close', $conv->id))->assertStatus(403);
+    }
+
+    public function test_owner_with_session_can_read_own_conversation(): void
+    {
+        $conv = $this->conversation('sess_owner');
+
+        $this->withSession(['chat_conversations' => ['sess_owner']])
+            ->getJson(route('chat.messages', $conv->id))
+            ->assertStatus(200);
+    }
+
+    public function test_admin_can_read_any_conversation(): void
+    {
+        Role::findOrCreate('super_admin', 'web');
+        $admin = User::factory()->create()->assignRole('super_admin');
+        $conv = $this->conversation();
+
+        $this->actingAs($admin)->getJson(route('chat.messages', $conv->id))->assertStatus(200);
+    }
+
+    public function test_starting_a_chat_grants_that_session_access(): void
+    {
+        $id = $this->postJson(route('chat.start'), ['customer_email' => 'me@example.com'])
+            ->json('conversation.id');
+
+        // The start request bound this conversation's session to the browser session.
+        $this->getJson(route('chat.messages', $id))->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Critical: unauthenticated IDOR dumps every customer's chat + PII

Chat conversations are addressed by **sequential auto-increment id**, but the customer-facing endpoints had **no ownership check**. The intended access credential is the random `session_id` (a UUID), used only by `getBySession`. So an **unauthenticated** attacker could:

- `GET /chat/1/messages`, `GET /chat/2/messages`, … → dump **every** customer's full chat history plus `customer_name` / `customer_email` (**PII data breach**),
- `POST /chat/{id}/message` → inject messages into any stranger's conversation,
- `POST /chat/{id}/close` and `/rating` → tamper with any conversation.

The agent routes (`agentConversations`/`assignAgent`/`nextQueued`) were already role-gated; the hole was the four customer endpoints.

## Fix

- When a chat is **started**, bind its `session_id` to the browser session: `session()->push('chat_conversations', $conversation->session_id)`.
- New `authorizeConversationAccess()` on `getMessages`/`sendMessage`/`close`/`submitRating`: allowed only if the caller is an **agent** (`hasRole(['super_admin','admin'])`) **or** the conversation's `session_id` is bound to this browser session; otherwise **403**.
- Ordering: input validation runs first (422 unchanged), then a missing conversation is 404, then the ownership check.
- `getBySession` is unchanged — it already requires the unguessable UUID, which is itself the access token.

This needs **no client change** (the session cookie already rides along on the widget's same-origin requests) and doesn't weaken the agent dashboard.

## Tests

Found via a read-only audit sweep. +6 (`ChatIdorTest`): cross-session read/send/close → 403; the session owner and an agent → 200; and the full start-then-read flow. The existing `ChatControllerTest` happy-path cases now seed session ownership (`withSession`); its validation cases stay 422 (validation is first). Suite **863 passed / 0 failed**. No migration, no raw SQL.

## Remaining security backlog (same sweep — filed)

- **SiteSettingController** — `index`/`edit`/`update` have no auth: anyone reads or overwrites store-wide config.
- **ReviewController::approve** — `POST /reviews/approve/{id}` unauthenticated → anyone self-approves any review (moderation bypass); `vote`/`store`/`ratings.store` are also outside `auth` (guest write → NOT-NULL `user_id` FK 500 on MySQL) and there's no purchase verification.
- **WishlistController::share** — writes one `share_token` to every wishlist row (UNIQUE index) → 500 for any user with 2+ items; the share feature is also structurally broken (token belongs on `users`, not per row).
