### PR TITLE
fix(security): require auth for review/rating writes + admin-gate approve

### DIFF
--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -2,19 +2,19 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\JsonResponse;
-use App\Models\Review;
-use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\ReviewRequest;
 use App\Models\Order;
+use App\Models\Review;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class ReviewController extends Controller
 {
     /**
      * Handles the request to store a new review.
      *
-     * @param ReviewRequest $request The request object containing review details.
+     * @param  ReviewRequest  $request  The request object containing review details.
      * @return JsonResponse A JSON response indicating success and the saved review.
      */
     public function store(ReviewRequest $request)
@@ -29,7 +29,7 @@ class ReviewController extends Controller
             return response()->json(['message' => 'You have already reviewed this product'], 409);
         }
 
-        $review = new Review();
+        $review = new Review;
         $review->user_id = Auth::id();
         $review->product_id = $validatedData['product_id'];
         $review->rating = $validatedData['rating'];
@@ -51,13 +51,17 @@ class ReviewController extends Controller
 
     public function approve($id)
     {
+        // Publishing a review is moderation — staff only (route is already behind auth).
+        abort_unless(Auth::user()->hasRole(['super_admin', 'admin']), 403);
+
         $review = Review::find($id);
-        if (!$review) {
+        if (! $review) {
             return response()->json(['message' => 'Review not found'], 404);
         }
 
         $review->approved = true;
         $review->save();
+
         return response()->json(['message' => 'Review approved successfully']);
     }
 
@@ -67,13 +71,14 @@ class ReviewController extends Controller
             ->where('approved', true)
             ->with('user')
             ->get();
+
         return response()->json($reviews);
     }
 
     public function vote(Request $request, $id)
     {
         $review = Review::find($id);
-        if (!$review) {
+        if (! $review) {
             return response()->json(['message' => 'Review not found'], 404);
         }
 
@@ -86,8 +91,7 @@ class ReviewController extends Controller
         }
 
         $review->save();
+
         return response()->json(['message' => 'Vote recorded successfully']);
     }
-
-
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -130,14 +130,16 @@ Route::delete('/cart/clear', [CartController::class, 'clear'])->name('cart.clear
 Route::post('/cart/apply-coupon', [CartController::class, 'applyCoupon'])->name('cart.apply-coupon');
 Route::delete('/cart/remove-coupon', [CartController::class, 'removeCoupon'])->name('cart.remove-coupon');
 
-// Ratings and reviews
+// Ratings and reviews — reads are public; writes require login (approve is admin-only, gated in the controller)
 Route::get('/product/{product}/reviews', [ReviewController::class, 'show'])->name('reviews.show');
-Route::post('/reviews', [ReviewController::class, 'store'])->name('reviews.store');
-Route::post('/reviews/approve/{id}', [ReviewController::class, 'approve'])->name('reviews.approve');
-Route::post('/reviews/{id}/vote', [ReviewController::class, 'vote'])->name('reviews.vote');
+Route::middleware('auth')->group(function () {
+    Route::post('/reviews', [ReviewController::class, 'store'])->name('reviews.store');
+    Route::post('/reviews/approve/{id}', [ReviewController::class, 'approve'])->name('reviews.approve');
+    Route::post('/reviews/{id}/vote', [ReviewController::class, 'vote'])->name('reviews.vote');
+});
 
 Route::get('/product/{product}/ratings/average', [RatingController::class, 'calculateAverageRating'])->name('ratings.average');
-Route::post('/ratings', [RatingController::class, 'store'])->name('ratings.store');
+Route::post('/ratings', [RatingController::class, 'store'])->middleware('auth')->name('ratings.store');
 
 // New comparison routes
 Route::post('/product/{category}/{product}/compare', [ProductController::class, 'addToCompare'])->name('products.addToCompare');

--- a/tests/Feature/ReviewControllerTest.php
+++ b/tests/Feature/ReviewControllerTest.php
@@ -2,28 +2,34 @@
 
 namespace Tests\Feature;
 
-use App\Http\Requests\ReviewRequest;
 use App\Models\Product;
 use App\Models\Review;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Auth;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class ReviewControllerTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function testStore()
+    private function admin(): User
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        return User::factory()->create()->assignRole('super_admin');
+    }
+
+    public function test_store()
     {
         $user = User::factory()->create();
         $product = Product::factory()->create();
 
         $response = $this->actingAs($user)
             ->post(route('reviews.store'), [
-                "product_id" => $product->id,
-                "rating" => 5,
-                "review" => 'Great product!',
+                'product_id' => $product->id,
+                'rating' => 5,
+                'review' => 'Great product!',
             ]);
 
         $response->assertStatus(201);
@@ -36,7 +42,7 @@ class ReviewControllerTest extends TestCase
         ]);
     }
 
-    public function testApprove()
+    public function test_approve()
     {
 
         $review = Review::factory()->create([
@@ -45,7 +51,7 @@ class ReviewControllerTest extends TestCase
             'approved' => false,
         ]);
 
-        $this->post(route('reviews.approve', ["id" => $review->id]));
+        $this->actingAs($this->admin())->post(route('reviews.approve', ['id' => $review->id]));
 
         $this->assertDatabaseHas('reviews', [
             'id' => $review->id,
@@ -55,7 +61,7 @@ class ReviewControllerTest extends TestCase
 
     public function test_approve_returns_404_for_missing_review(): void
     {
-        $response = $this->postJson('/reviews/approve/9999');
+        $response = $this->actingAs($this->admin())->postJson('/reviews/approve/9999');
 
         $response->assertStatus(404);
     }
@@ -84,7 +90,7 @@ class ReviewControllerTest extends TestCase
     {
         $review = Review::factory()->create(['helpful_votes' => 0]);
 
-        $response = $this->postJson("/reviews/{$review->id}/vote", ['vote' => 'helpful']);
+        $response = $this->actingAs(User::factory()->create())->postJson("/reviews/{$review->id}/vote", ['vote' => 'helpful']);
 
         $response->assertStatus(200);
         $this->assertEquals(1, $review->fresh()->helpful_votes);
@@ -94,7 +100,7 @@ class ReviewControllerTest extends TestCase
     {
         $review = Review::factory()->create(['unhelpful_votes' => 0]);
 
-        $response = $this->postJson("/reviews/{$review->id}/vote", ['vote' => 'unhelpful']);
+        $response = $this->actingAs(User::factory()->create())->postJson("/reviews/{$review->id}/vote", ['vote' => 'unhelpful']);
 
         $response->assertStatus(200);
         $this->assertEquals(1, $review->fresh()->unhelpful_votes);
@@ -104,14 +110,14 @@ class ReviewControllerTest extends TestCase
     {
         $review = Review::factory()->create();
 
-        $response = $this->postJson("/reviews/{$review->id}/vote", ['vote' => 'bogus']);
+        $response = $this->actingAs(User::factory()->create())->postJson("/reviews/{$review->id}/vote", ['vote' => 'bogus']);
 
         $response->assertStatus(400);
     }
 
     public function test_vote_returns_404_for_missing_review(): void
     {
-        $response = $this->postJson('/reviews/9999/vote', ['vote' => 'helpful']);
+        $response = $this->actingAs(User::factory()->create())->postJson('/reviews/9999/vote', ['vote' => 'helpful']);
 
         $response->assertStatus(404);
     }

--- a/tests/Feature/ReviewRatingAuthTest.php
+++ b/tests/Feature/ReviewRatingAuthTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\Review;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class ReviewRatingAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        return User::factory()->create()->assignRole('super_admin');
+    }
+
+    public function test_guest_cannot_store_review(): void
+    {
+        $product = Product::factory()->create();
+
+        $this->postJson('/reviews', ['product_id' => $product->id, 'rating' => 5, 'review' => 'x'])
+            ->assertStatus(401);
+    }
+
+    public function test_guest_cannot_store_rating(): void
+    {
+        $product = Product::factory()->create();
+
+        $this->postJson('/ratings', [
+            'product_id' => $product->id, 'overall_rating' => 4,
+            'quality_rating' => 4, 'value_rating' => 3, 'price_rating' => 5,
+        ])->assertStatus(401);
+    }
+
+    public function test_guest_cannot_vote(): void
+    {
+        $review = Review::factory()->create();
+
+        $this->postJson("/reviews/{$review->id}/vote", ['vote' => 'helpful'])->assertStatus(401);
+    }
+
+    public function test_non_admin_cannot_approve_review(): void
+    {
+        $review = Review::factory()->create(['approved' => false]);
+
+        $this->actingAs(User::factory()->create())
+            ->postJson("/reviews/approve/{$review->id}")->assertStatus(403);
+
+        $this->assertFalse((bool) $review->fresh()->approved);
+    }
+
+    public function test_admin_can_approve_review(): void
+    {
+        $review = Review::factory()->create(['approved' => false]);
+
+        $this->actingAs($this->admin())
+            ->postJson("/reviews/approve/{$review->id}")->assertStatus(200);
+
+        $this->assertTrue((bool) $review->fresh()->approved);
+    }
+
+    public function test_review_and_rating_reads_stay_public(): void
+    {
+        $product = Product::factory()->create();
+
+        $this->getJson("/product/{$product->id}/reviews")->assertStatus(200);
+        $this->getJson("/product/{$product->id}/ratings/average")->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Unauthenticated review/rating writes + moderation bypass

The review/rating **write** routes sat outside the `auth` group:

- **`POST /reviews/approve/{id}`** — no auth, no role check. Reviews are stored `approved=false` and `show()` only returns approved ones, so `approve()` **is** the moderation control. Anyone (even a guest) could publish any review → **fake/spam reviews self-published on the storefront**.
- **`POST /reviews`, `/reviews/{id}/vote`, `/ratings`** were public. `store()`/`ratings` derive `user_id` from `Auth::id()`, so a guest wrote `user_id=null`: the duplicate guard `where('user_id', null)` matched nothing and the NOT-NULL `user_id` FK insert **500'd on MySQL** (masked on the sqlite test DB). Voting was anonymous + unbounded.

## Fix

- **Reads stay public**: `GET /product/{id}/reviews`, `GET /product/{id}/ratings/average`.
- **Writes require login**: `store`, `vote`, `ratings.store` moved under `auth`.
- **`approve` requires auth AND an admin role**: inline `abort_unless(Auth::user()->hasRole(['super_admin','admin']), 403)`, matching the app's `ChatController`/Shipping pattern.

Author identity was already safe (`Auth::id()`, not request body), and rating values were already bounded (1–5) — the holes were purely authorization.

## Tests

Found via a read-only audit sweep. +6 (`ReviewRatingAuthTest`): guest store/rating/vote → 401; non-admin approve → 403 (review stays unapproved); admin approve → 200; reads stay public. Existing `ReviewControllerTest` updated to the authenticated/admin contract; `RatingControllerTest` already authenticated. Suite **869 passed / 0 failed**. No migration, no raw SQL.

## Not fixed here (needs schema/design — filed)

- Per-user vote dedup (a `review_votes` table) — voting is authenticated now but a user can still vote repeatedly.
- Purchase verification (`is_verified_purchase`) — the check is commented out and the column doesn't exist.

## Remaining security backlog (same sweep)

- **SiteSettingController** — `index`/`edit`/`update` have no auth: anyone reads or overwrites store-wide config.
- **WishlistController::share** — writes one `share_token` to every wishlist row (UNIQUE index) → 500 for any user with 2+ items; share is also structurally broken (token belongs on `users`, not per row).
