### PR TITLE
fix(security): gate site-settings behind admin auth + fix update 500

### DIFF
--- a/app/Http/Controllers/SiteSettingController.php
+++ b/app/Http/Controllers/SiteSettingController.php
@@ -8,22 +8,36 @@ use Illuminate\Support\Facades\Validator;
 
 class SiteSettingController extends Controller
 {
+    /** Site settings are store-wide config — staff only. */
+    private function ensureAdmin(): void
+    {
+        abort_unless(auth()->user()?->hasRole(['super_admin', 'admin']), 403);
+    }
+
     public function index()
     {
+        $this->ensureAdmin();
+
         $settings = SiteSetting::all();
+
         return response()->json($settings);
     }
 
     public function edit($id)
     {
+        $this->ensureAdmin();
+
         $setting = SiteSetting::findOrFail($id);
+
         return response()->json($setting);
     }
 
     public function update(Request $request, $id)
     {
+        $this->ensureAdmin();
+
         $validator = Validator::make($request->all(), [
-            'name' => 'required|string|max:255',
+            'name' => 'required|string|max:255|unique:site_settings,name,'.$id,
             'value' => 'required|string',
             'description' => 'nullable|string',
         ]);
@@ -34,11 +48,14 @@ class SiteSettingController extends Controller
 
         $setting = SiteSetting::findOrFail($id);
         $setting->update($request->all());
+
         return response()->json($setting);
     }
 
     public function store(Request $request)
     {
+        $this->ensureAdmin();
+
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255|unique:site_settings',
             'value' => 'required|string',
@@ -50,6 +67,7 @@ class SiteSettingController extends Controller
         }
 
         $setting = SiteSetting::create($request->all());
+
         return response()->json($setting, 201);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -156,9 +156,12 @@ Route::middleware('auth')->group(function () {
     Route::get('/invoices/{id}', [InvoiceController::class, 'show'])->name('invoices.show');
 });
 
-Route::get('/site-settings', [SiteSettingController::class, 'index'])->name('site_settings.index');
-Route::get('/site-settings/{id}/edit', [SiteSettingController::class, 'edit'])->name('site_settings.edit');
-Route::post('/site-settings/{id}', [SiteSettingController::class, 'update'])->name('site_settings.update');
+// Site settings are store-wide config, admin-only (auth here, role checked in the controller)
+Route::middleware('auth')->group(function () {
+    Route::get('/site-settings', [SiteSettingController::class, 'index'])->name('site_settings.index');
+    Route::get('/site-settings/{id}/edit', [SiteSettingController::class, 'edit'])->name('site_settings.edit');
+    Route::post('/site-settings/{id}', [SiteSettingController::class, 'update'])->name('site_settings.update');
+});
 
 Route::get('/sitemap.xml', [SitemapController::class, 'index'])->name('sitemap.xml');
 

--- a/tests/Feature/SiteSettingControllerTest.php
+++ b/tests/Feature/SiteSettingControllerTest.php
@@ -3,12 +3,24 @@
 namespace Tests\Feature;
 
 use App\Models\SiteSetting;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class SiteSettingControllerTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Site settings are admin-only; these cover controller behaviour, so
+        // authenticate as an admin (authorization is covered in
+        // SiteSettingSecurityTest).
+        Role::findOrCreate('super_admin', 'web');
+        $this->actingAs(User::factory()->create()->assignRole('super_admin'));
+    }
 
     private function makeSetting(array $overrides = []): SiteSetting
     {

--- a/tests/Feature/SiteSettingSecurityTest.php
+++ b/tests/Feature/SiteSettingSecurityTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SiteSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class SiteSettingSecurityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        return User::factory()->create()->assignRole('super_admin');
+    }
+
+    private function setting(): SiteSetting
+    {
+        return SiteSetting::create(['name' => 'site_name', 'value' => 'Shop', 'description' => 'x']);
+    }
+
+    public function test_guest_cannot_read_settings(): void
+    {
+        $this->getJson(route('site_settings.index'))->assertStatus(401);
+    }
+
+    public function test_non_admin_cannot_read_settings(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->getJson(route('site_settings.index'))->assertStatus(403);
+    }
+
+    public function test_non_admin_cannot_update_setting(): void
+    {
+        $setting = $this->setting();
+
+        $this->actingAs(User::factory()->create())
+            ->postJson(route('site_settings.update', $setting->id), ['name' => 'site_name', 'value' => 'HACKED'])
+            ->assertStatus(403);
+
+        $this->assertSame('Shop', $setting->fresh()->value);
+    }
+
+    public function test_admin_can_read_and_update(): void
+    {
+        $admin = $this->admin();
+        $setting = $this->setting();
+
+        $this->actingAs($admin)->getJson(route('site_settings.index'))->assertStatus(200);
+        $this->actingAs($admin)->postJson(route('site_settings.update', $setting->id), [
+            'name' => 'site_name', 'value' => 'New Value',
+        ])->assertStatus(200);
+
+        $this->assertSame('New Value', $setting->fresh()->value);
+    }
+
+    public function test_update_rejects_duplicate_name_cleanly(): void
+    {
+        $admin = $this->admin();
+        SiteSetting::create(['name' => 'site_name', 'value' => 'A']);
+        $b = SiteSetting::create(['name' => 'site_logo', 'value' => 'B']);
+
+        // Renaming b onto a's name must be a clean 422, not a unique-constraint 500.
+        $this->actingAs($admin)->postJson(route('site_settings.update', $b->id), [
+            'name' => 'site_name', 'value' => 'B',
+        ])->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Unauthenticated read/overwrite of store-wide settings

The `/site-settings` routes (`index`, `edit`, `update`) had **no `auth` middleware**. Any anonymous visitor could:

- **enumerate every store-wide config value** — `index`/`edit` return the raw `SiteSetting` rows as JSON,
- **overwrite any setting's value** — `POST /site-settings/{id}`.

Same missing-gate class as the shipping and inventory fixes.

## Fixes

- Wrapped the routes in `Route::middleware('auth')` and added an inline admin guard `abort_unless(auth()->user()?->hasRole(['super_admin','admin']), 403)` on `index`/`edit`/`update` (and the unrouted `store`, for defence in depth) — matching the `ChatController`/Shipping pattern.
- **`update()` 500 fix**: it validated `name` as non-unique, then pushed `$request->all()` into a column with a UNIQUE index — renaming one setting onto another's `name` threw an unhandled `QueryException` (500). Added `unique:site_settings,name,{id}` (ignore-self) for a clean 422.

## Tests

Found via a read-only audit sweep. +5 (`SiteSettingSecurityTest`): guest → 401, non-admin read/update → 403 (value unchanged), admin read + update → 200, duplicate-name update → 422. The existing `SiteSettingControllerTest` now authenticates as an admin in `setUp`. Suite **874 passed / 0 failed**. No migration, no raw SQL.

## Last item in this sweep's backlog

- **WishlistController::share** — writes one `share_token` to **every** wishlist row (the column has a UNIQUE index) → 500 for any user with 2+ items; the share feature is also structurally broken (a shared wishlist is per-user, but the token is per-row, so a shared view can only ever show one product). Proper fix moves `share_token` to `users` (or a share table) — needs a migration, so it's a separate PR.
