### PR TITLE
fix(wishlist): move share_token to users so sharing 2+ items works

### DIFF
--- a/app/Http/Controllers/WishlistController.php
+++ b/app/Http/Controllers/WishlistController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Wishlist;
 use App\Models\Product;
-use Illuminate\Http\Request;
+use App\Models\User;
+use App\Models\Wishlist;
 use Illuminate\Support\Str;
 
 class WishlistController extends Controller
@@ -12,6 +12,7 @@ class WishlistController extends Controller
     public function index()
     {
         $wishlist = auth()->user()->wishlist()->with('product')->get();
+
         return view('wishlist.index', compact('wishlist'));
     }
 
@@ -28,19 +29,26 @@ class WishlistController extends Controller
     public function remove(Product $product)
     {
         auth()->user()->wishlist()->where('product_id', $product->id)->delete();
+
         return redirect()->back()->with('success', 'Product removed from wishlist');
     }
 
     public function share()
     {
-        $shareToken = Str::random(32);
-        auth()->user()->wishlist()->update(['share_token' => $shareToken]);
-        return redirect()->route('wishlist.index')->with('share_url', route('wishlist.shared', $shareToken));
+        // One token per user — the shared link exposes that user's whole wishlist.
+        $user = auth()->user();
+        $user->wishlist_share_token = Str::random(32);
+        $user->save();
+
+        return redirect()->route('wishlist.index')
+            ->with('share_url', route('wishlist.shared', $user->wishlist_share_token));
     }
 
     public function sharedWishlist($shareToken)
     {
-        $wishlist = Wishlist::where('share_token', $shareToken)->with('product')->get();
+        $owner = User::where('wishlist_share_token', $shareToken)->first();
+        $wishlist = $owner ? $owner->wishlist()->with('product')->get() : collect();
+
         return view('wishlist.shared', compact('wishlist'));
     }
 }

--- a/app/Models/Wishlist.php
+++ b/app/Models/Wishlist.php
@@ -9,7 +9,7 @@ class Wishlist extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['user_id', 'product_id', 'share_token'];
+    protected $fillable = ['user_id', 'product_id'];
 
     public function user()
     {

--- a/database/migrations/2026_07_15_000000_move_wishlist_share_token_to_users.php
+++ b/database/migrations/2026_07_15_000000_move_wishlist_share_token_to_users.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * A shared wishlist is per-user (all of that user's items), but share_token
+     * lived on each wishlist row with a UNIQUE index — so sharing 2+ items wrote
+     * the same token to every row and hit the unique constraint. Move the token
+     * to the owning user.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('wishlist_share_token')->nullable()->unique();
+        });
+
+        Schema::table('wishlists', function (Blueprint $table) {
+            $table->dropUnique(['share_token']);
+            $table->dropColumn('share_token');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('wishlists', function (Blueprint $table) {
+            $table->string('share_token')->nullable()->unique();
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique(['wishlist_share_token']);
+            $table->dropColumn('wishlist_share_token');
+        });
+    }
+};

--- a/tests/Feature/WishlistControllerTest.php
+++ b/tests/Feature/WishlistControllerTest.php
@@ -17,12 +17,12 @@ class WishlistControllerTest extends TestCase
     {
         $category = ProductCategory::create([
             'name' => 'Wishlist Category',
-            'slug' => 'wish-cat-' . uniqid(),
+            'slug' => 'wish-cat-'.uniqid(),
         ]);
 
         return Product::create(array_merge([
             'name' => 'Wishlist Product',
-            'slug' => 'wish-prod-' . uniqid(),
+            'slug' => 'wish-prod-'.uniqid(),
             'price' => 49.99,
             'category_id' => $category->id,
             'inventory_count' => 10,
@@ -104,24 +104,38 @@ class WishlistControllerTest extends TestCase
         $response = $this->actingAs($user)->post(route('wishlist.share'));
 
         $response->assertRedirect(route('wishlist.index'));
-        $this->assertDatabaseHas('wishlists', [
-            'user_id' => $user->id,
-        ]);
-        $this->assertNotNull(
-            Wishlist::where('user_id', $user->id)->value('share_token')
-        );
+        // The token now lives on the user (one shared link per user), not per row.
+        $this->assertNotNull($user->fresh()->wishlist_share_token);
+    }
+
+    public function test_share_wishlist_with_multiple_items_works_and_shows_all(): void
+    {
+        $user = User::factory()->create();
+        $p1 = $this->makeProduct();
+        $p2 = $this->makeProduct();
+        Wishlist::create(['user_id' => $user->id, 'product_id' => $p1->id]);
+        Wishlist::create(['user_id' => $user->id, 'product_id' => $p2->id]);
+
+        // Previously threw a unique-constraint 500 (same token written to every row).
+        $this->actingAs($user)->post(route('wishlist.share'))
+            ->assertRedirect(route('wishlist.index'));
+
+        $token = $user->fresh()->wishlist_share_token;
+        $this->assertNotNull($token);
+
+        // The shared view exposes the user's WHOLE wishlist, not a single item.
+        $this->get(route('wishlist.shared', $token))
+            ->assertStatus(200)
+            ->assertViewHas('wishlist', fn ($wishlist) => $wishlist->count() === 2);
     }
 
     public function test_shared_wishlist_is_accessible_without_auth(): void
     {
         $user = User::factory()->create();
+        $user->wishlist_share_token = 'public-share-token';
+        $user->save();
         $product = $this->makeProduct();
-
-        Wishlist::create([
-            'user_id' => $user->id,
-            'product_id' => $product->id,
-            'share_token' => 'public-share-token',
-        ]);
+        Wishlist::create(['user_id' => $user->id, 'product_id' => $product->id]);
 
         $response = $this->get(route('wishlist.shared', 'public-share-token'));
 

--- a/tests/Unit/WishlistModelTest.php
+++ b/tests/Unit/WishlistModelTest.php
@@ -70,18 +70,4 @@ class WishlistModelTest extends TestCase
         $this->assertInstanceOf(Product::class, $item->product);
         $this->assertEquals($product->id, $item->product->id);
     }
-
-    public function test_share_token_can_be_set(): void
-    {
-        $user = User::factory()->create();
-        $product = $this->makeProduct();
-
-        $item = Wishlist::create([
-            'user_id' => $user->id,
-            'product_id' => $product->id,
-            'share_token' => 'unique-share-token-123',
-        ]);
-
-        $this->assertEquals('unique-share-token-123', $item->share_token);
-    }
 }


### PR DESCRIPTION
## Sharing a wishlist with 2+ items 500'd — and only ever showed one product

`WishlistController::share()` wrote the same `Str::random(32)` token to **every** one of the user's wishlist rows:

```php
auth()->user()->wishlist()->update(['share_token' => $shareToken]);
```

But `wishlists.share_token` carries a **UNIQUE** index — so any user with **2+ items** hit a duplicate-key `QueryException` (500) the moment they clicked *Share*. And even if it hadn't thrown, `sharedWishlist()` looked up by the per-row token, so a shared view could only ever contain a **single** product.

Root cause: a shared wishlist is **per-user** (all of that user's items), but the token was **per-row**.

## Fix

Move the token to the owning user:
- **Migration** — drop `wishlists.share_token`, add `users.wishlist_share_token` (unique, nullable). Verified up **and** down on MySQL 8.4 (`dropUnique` + `dropColumn` + add-unique-column all apply cleanly; sqlite masks these).
- `share()` sets the token on the user.
- `sharedWishlist()` resolves the user by token and returns **their whole wishlist**.

## Tests

Found via a read-only audit sweep. +1 (`test_share_wishlist_with_multiple_items_works_and_shows_all`): sharing two items redirects (no 500) and the shared view exposes **both**. Updated the existing share tests to assert the user token; removed the now-obsolete `WishlistModelTest::test_share_token_can_be_set` (that column no longer exists). Suite **874 passed / 0 failed**.

This clears the last item in the controller-security/robustness sweep backlog.
