### PR TITLE
fix(dropshipping): make the supplier-dispatch job idempotent + state-machine safe

### DIFF
--- a/app/Jobs/DispatchDropshippingOrder.php
+++ b/app/Jobs/DispatchDropshippingOrder.php
@@ -3,8 +3,8 @@
 namespace App\Jobs;
 
 use App\Models\Order;
-use App\Services\DropshippingService;
 use App\Notifications\SupplierFailureNotification;
+use App\Services\DropshippingService;
 use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -12,12 +12,14 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Notification;
+use Throwable;
 
 class DispatchDropshippingOrder implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public $orderId;
+
     public $supplierId;
 
     /** Number of times the queued job may be attempted. */
@@ -39,13 +41,25 @@ class DispatchDropshippingOrder implements ShouldQueue
     {
         $order = Order::with('items')->find($this->orderId);
 
-        if (!$order) {
+        if (! $order) {
+            return;
+        }
+
+        // At-least-once queue: if this order was already placed with the supplier,
+        // a retry must not place it again (double fulfilment / double cost).
+        if ($order->supplier_order_reference) {
+            return;
+        }
+
+        // The order may have been refunded/cancelled while sitting in the queue —
+        // only dispatch orders still awaiting the supplier.
+        if ($order->status !== Order::STATUS_SUPPLIER_QUEUED) {
             return;
         }
 
         // Build supplier payload
         $orderData = [
-            'reference' => 'order-' . $order->id,
+            'reference' => 'order-'.$order->id,
             'customer_name' => $order->customer_email,
             'customer_email' => $order->customer_email,
             'recipient_name' => $order->recipient_name,
@@ -68,33 +82,58 @@ class DispatchDropshippingOrder implements ShouldQueue
         try {
             $result = $dropshippingService->placeOrder($this->supplierId, $orderData);
 
-            // Persist supplier response for debugging
+            // Persist supplier response (and the reference — its presence is the
+            // idempotency key that stops a retry re-placing the order).
             $order->supplier_id = $this->supplierId;
             $order->supplier_order_reference = $result['data']['reference'] ?? ($result['data']['id'] ?? null);
             $order->supplier_response = $result['data'] ?? ($result['error'] ?? $result);
+            $order->save();
 
             if ($result['success']) {
-                // Supplier accepted the order; it is now being fulfilled.
-                // 'supplier_placed' was not a real Order status (absent from
-                // Order::TRANSITIONS), so nothing downstream understood it.
-                $order->status = Order::STATUS_PROCESSING;
+                $this->transition($order, Order::STATUS_PROCESSING, "Supplier order placed ({$this->supplierId})");
             } else {
-                $order->status = Order::STATUS_SUPPLIER_FAILED;
-                Notification::route('mail', config('mail.from.address'))
-                    ->notify(new SupplierFailureNotification("Dropshipping order placement failed for order {$order->id}: " . ($result['message'] ?? 'Unknown')));
+                $this->transition($order, Order::STATUS_SUPPLIER_FAILED, 'Supplier rejected the order');
+                $this->notifyFailure($order, $result['message'] ?? 'Unknown');
             }
-
-            $order->save();
         } catch (Exception $e) {
-            $order->status = Order::STATUS_SUPPLIER_FAILED;
-            $order->supplier_response = ['exception' => $e->getMessage()];
-            $order->save();
-
-            Notification::route('mail', config('mail.from.address'))
-                ->notify(new SupplierFailureNotification("Error placing dropshipping order for order {$order->id}: " . $e->getMessage()));
-
-            // rethrow to allow queue retry if desired
+            // Transient failure (network/timeout). Do NOT mark supplier_failed here
+            // — that would trip the still-queued guard and skip the retry. Let the
+            // exception propagate so the queue retries; failed() handles exhaustion.
             throw $e;
         }
+    }
+
+    /**
+     * The job's retries are exhausted — record the failure so the order isn't
+     * left stuck in supplier_queued.
+     */
+    public function failed(?Throwable $e): void
+    {
+        $order = Order::find($this->orderId);
+
+        if ($order && ! $order->supplier_order_reference && $order->status === Order::STATUS_SUPPLIER_QUEUED) {
+            $order->supplier_response = ['exception' => $e?->getMessage()];
+            $order->save();
+            $this->transition($order, Order::STATUS_SUPPLIER_FAILED, 'Supplier dispatch failed after retries');
+            $this->notifyFailure($order, $e?->getMessage() ?? 'Unknown error');
+        }
+    }
+
+    /**
+     * Route status changes through the state machine (enforces the transition map
+     * + writes an audit row). Skips silently if the order has since moved to a
+     * state from which the target is illegal (e.g. refunded) rather than throwing.
+     */
+    private function transition(Order $order, string $status, string $notes): void
+    {
+        if (in_array($status, Order::TRANSITIONS[$order->status] ?? [], true)) {
+            $order->transitionTo($status, notes: $notes);
+        }
+    }
+
+    private function notifyFailure(Order $order, string $message): void
+    {
+        Notification::route('mail', config('mail.from.address'))
+            ->notify(new SupplierFailureNotification("Dropshipping order placement failed for order {$order->id}: {$message}"));
     }
 }

--- a/tests/Feature/DispatchDropshippingOrderTest.php
+++ b/tests/Feature/DispatchDropshippingOrderTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\DispatchDropshippingOrder;
+use App\Models\Order;
+use App\Models\Product;
+use App\Services\DropshippingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use RuntimeException;
+use Tests\TestCase;
+
+class DispatchDropshippingOrderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Notification::fake();
+    }
+
+    /** A DropshippingService whose placeOrder() returns a canned result and counts calls. */
+    private function supplier(array $result): DropshippingService
+    {
+        return new class($result) extends DropshippingService
+        {
+            public int $calls = 0;
+
+            public function __construct(public array $result) {}
+
+            public function placeOrder($supplierId, array $orderData)
+            {
+                $this->calls++;
+
+                return $this->result;
+            }
+        };
+    }
+
+    private function throwingSupplier(): DropshippingService
+    {
+        return new class extends DropshippingService
+        {
+            public function __construct() {}
+
+            public function placeOrder($supplierId, array $orderData)
+            {
+                throw new RuntimeException('supplier timeout');
+            }
+        };
+    }
+
+    private function queuedOrder(array $overrides = []): Order
+    {
+        $product = Product::factory()->create(['inventory_count' => 5]);
+        $order = Order::create(array_merge([
+            'customer_email' => 'buyer@example.com',
+            'total_amount' => 20,
+            'status' => Order::STATUS_SUPPLIER_QUEUED,
+            'is_dropshipped' => true,
+        ], $overrides));
+        $order->items()->create(['product_id' => $product->id, 'quantity' => 1, 'price' => 20]);
+
+        return $order;
+    }
+
+    public function test_successful_placement_transitions_to_processing_with_history(): void
+    {
+        $order = $this->queuedOrder();
+
+        (new DispatchDropshippingOrder($order->id))
+            ->handle($this->supplier(['success' => true, 'data' => ['reference' => 'SUP-123']]));
+
+        $order->refresh();
+        $this->assertSame(Order::STATUS_PROCESSING, $order->status);
+        $this->assertSame('SUP-123', $order->supplier_order_reference);
+        $this->assertNotNull(
+            $order->statusHistory()->where('to_status', Order::STATUS_PROCESSING)->first(),
+            'status change must go through the state machine (audit row)'
+        );
+    }
+
+    public function test_supplier_rejection_transitions_to_supplier_failed(): void
+    {
+        $order = $this->queuedOrder();
+
+        (new DispatchDropshippingOrder($order->id))
+            ->handle($this->supplier(['success' => false, 'message' => 'rejected']));
+
+        $this->assertSame(Order::STATUS_SUPPLIER_FAILED, $order->refresh()->status);
+    }
+
+    public function test_already_placed_order_is_not_placed_again(): void
+    {
+        $order = $this->queuedOrder();
+        $order->update(['supplier_order_reference' => 'ALREADY-PLACED']);
+        $supplier = $this->supplier(['success' => true, 'data' => ['reference' => 'SUP-1']]);
+
+        (new DispatchDropshippingOrder($order->id))->handle($supplier);
+
+        $this->assertSame(0, $supplier->calls, 'supplier must not be called twice for one order');
+        $this->assertSame('ALREADY-PLACED', $order->refresh()->supplier_order_reference);
+    }
+
+    public function test_order_no_longer_queued_is_skipped(): void
+    {
+        $order = $this->queuedOrder();
+        $order->update(['status' => Order::STATUS_REFUNDED]); // refunded while queued
+        $supplier = $this->supplier(['success' => true, 'data' => ['reference' => 'SUP-1']]);
+
+        (new DispatchDropshippingOrder($order->id))->handle($supplier);
+
+        $this->assertSame(0, $supplier->calls, 'a refunded order must never be placed with the supplier');
+        $this->assertSame(Order::STATUS_REFUNDED, $order->refresh()->status);
+    }
+
+    public function test_transient_exception_rethrows_and_leaves_order_queued_for_retry(): void
+    {
+        $order = $this->queuedOrder();
+
+        try {
+            (new DispatchDropshippingOrder($order->id))->handle($this->throwingSupplier());
+            $this->fail('expected the exception to propagate for a queue retry');
+        } catch (RuntimeException $e) {
+            // expected
+        }
+
+        // Not marked failed — so the queue's retry can re-attempt.
+        $this->assertSame(Order::STATUS_SUPPLIER_QUEUED, $order->refresh()->status);
+    }
+
+    public function test_failed_hook_marks_supplier_failed_after_retries_exhausted(): void
+    {
+        $order = $this->queuedOrder();
+
+        (new DispatchDropshippingOrder($order->id))->failed(new RuntimeException('gave up'));
+
+        $this->assertSame(Order::STATUS_SUPPLIER_FAILED, $order->refresh()->status);
+    }
+}


### PR DESCRIPTION
## Two live-money defects on the dropshipping queue path

`DispatchDropshippingOrder` runs after checkout leaves the order in `supplier_queued`; it POSTs to the supplier (creating a real order) then writes the order status.

**1. Non-idempotent retry → double-place (HIGH).** The queue is at-least-once. `placeOrder()` does a live POST that creates an order at the supplier, but there was **no idempotency guard**. If the worker died (deploy / OOM / SIGKILL) between a successful POST and the DB commit, the retry re-ran `handle()` and placed a **second identical supplier order** → double fulfilment / double cost.

**2. Raw `$order->status = …; save()` bypassed the state machine (HIGH).** Every other status change routes through `Order::transitionTo()` (enforces `TRANSITIONS`, writes an `OrderStatusHistory` audit row). This job wrote `status` directly, so:
- if the order was **refunded** while the job sat queued, the raw write **resurrected it to `processing`** (`transitionTo` would have rejected `refunded → processing`) → a refunded customer still gets shipped;
- no audit row was ever written for the supplier outcome.

## Fixes

- **Idempotency**: bail if `supplier_order_reference` is already set (a retry never re-places), and bail if the order is no longer `supplier_queued` (refunded/cancelled while queued).
- **State machine**: route every status change through a guarded `transition()` helper → `transitionTo()` (audit row + transition-map enforcement), which **skips silently** if the target is illegal from the current state instead of resurrecting the order.
- **Correct retry**: a transient exception now rethrows **without** marking `supplier_failed` (marking it would trip the still-queued guard and skip the retry). A new `failed()` hook records `supplier_failed` once the retry budget is exhausted — so a supplier timeout now actually uses its retries.

## Tests

Found via a read-only audit sweep. +6 (`DispatchDropshippingOrderTest`): success → `processing` **with an audit row**; supplier rejection → `supplier_failed`; already-placed order not placed again; refunded order skipped (supplier never called); transient exception rethrows and leaves the order queued for retry; `failed()` marks `supplier_failed`. Suite **880 passed / 0 failed**. No migration, no raw SQL.

## Residual + filed follow-ups (same sweep)

- The `save`-fails-*after*-a-successful-POST window still allows a double-place; fully closing it needs an idempotency key sent to the supplier (their API dedupes). The reference-guard closes the common worker-killed-after-commit case.
- **`CheckLowStockItems`** queries a non-existent `users.is_admin` column → fatals `inventory:check-low-stock` at the exact moment stock drops to the alert threshold (no try/catch).
- `DropshippingService`'s supplier POST has no `->timeout()` — a hung supplier ties up the worker.
- `products` has no `sku` column, so the supplier payload sends the local numeric id as the SKU.
