### PR TITLE
fix(inventory): low-stock alert queried a non-existent users.is_admin column

### DIFF
--- a/app/Console/Commands/CheckLowStockItems.php
+++ b/app/Console/Commands/CheckLowStockItems.php
@@ -2,11 +2,11 @@
 
 namespace App\Console\Commands;
 
-use DB;
-use Illuminate\Console\Command;
 use App\Models\Product;
 use App\Models\User;
 use App\Notifications\LowStockNotification;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
 
 class CheckLowStockItems extends Command
@@ -20,7 +20,11 @@ class CheckLowStockItems extends Command
         $lowStockProducts = Product::where('inventory_count', '<=', DB::raw('low_stock_threshold'))->get();
 
         if ($lowStockProducts->isNotEmpty()) {
-            $admins = User::where('is_admin', true)->get();
+            // Admins are identified by role (there is no users.is_admin column).
+            // whereHas (not the role() scope) so a not-yet-seeded role can't throw.
+            $admins = User::whereHas('roles', function ($query) {
+                $query->whereIn('name', ['super_admin', 'admin']);
+            })->get();
 
             foreach ($lowStockProducts as $product) {
                 Notification::send($admins, new LowStockNotification($product));

--- a/tests/Feature/CheckLowStockItemsTest.php
+++ b/tests/Feature/CheckLowStockItemsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\User;
+use App\Notifications\LowStockNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class CheckLowStockItemsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        return User::factory()->create()->assignRole('super_admin');
+    }
+
+    public function test_notifies_admins_when_a_product_is_low_on_stock(): void
+    {
+        Notification::fake();
+        $admin = $this->admin();
+        Product::factory()->create(['inventory_count' => 1, 'low_stock_threshold' => 5]);
+
+        $this->artisan('inventory:check-low-stock')->assertExitCode(0);
+
+        Notification::assertSentTo($admin, LowStockNotification::class);
+    }
+
+    public function test_no_notifications_when_stock_is_healthy(): void
+    {
+        Notification::fake();
+        $this->admin();
+        Product::factory()->create(['inventory_count' => 50, 'low_stock_threshold' => 5]);
+
+        $this->artisan('inventory:check-low-stock')->assertExitCode(0);
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_non_admins_are_not_notified(): void
+    {
+        Notification::fake();
+        $admin = $this->admin();
+        $customer = User::factory()->create(); // no role
+        Product::factory()->create(['inventory_count' => 0, 'low_stock_threshold' => 5]);
+
+        $this->artisan('inventory:check-low-stock')->assertExitCode(0);
+
+        Notification::assertSentTo($admin, LowStockNotification::class);
+        Notification::assertNotSentTo($customer, LowStockNotification::class);
+    }
+}


### PR DESCRIPTION
## Bug

`CheckLowStockItems` (`inventory:check-low-stock`) resolved its notification recipients with:

```php
$admins = User::where('is_admin', true)->get();
```

There is **no `is_admin` column** on `users` — admins are identified by their Spatie role, and this was the only `is_admin` reference in the codebase. The command runs fine while stock is healthy (the line sits inside `if ($lowStockProducts->isNotEmpty())`), then throws `Unknown column 'is_admin'` **at the exact moment inventory drops to the threshold** and it tries to send the alert — and `handle()` has no try/catch, so the whole command dies without notifying anyone.

## Fix

Select admins by role via `whereHas` on the roles relation:

```php
$admins = User::whereHas('roles', fn ($q) => $q->whereIn('name', ['super_admin', 'admin']))->get();
```

`whereHas` (not Spatie's `role()` scope) so a role that hasn't been seeded yet can't throw `RoleDoesNotExist`. Also replaced the fragile global `use DB;` alias with the proper `Illuminate\\Support\\Facades\\DB` import.

## Tests

Found via a read-only audit sweep of the scheduled commands (the others — `segments:calculate`, `recommendations:generate`, `metrics:update-customers` — were verified clean). +3 (`CheckLowStockItemsTest`): admins are notified when a product is low on stock, nothing is sent when stock is healthy, non-admins are excluded. Suite **883 passed / 0 failed**. No migration, no raw SQL.

_(Note: the schedule itself is currently commented out in `Console/Kernel.php`, so this was latent until the command is scheduled or run manually — but it was a guaranteed fatal on the alert path.)_