### PR TITLE
fix(security): stored XSS via product JSON-LD on the public product page

### DIFF
--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -120,32 +120,6 @@
 @endif
 
 
-@isset($product->inventoryLogs)
-<div class="card mt-4">
-    <div class="card-header">Inventory Logs</div>
-    <div class="card-body">
-        <table class="table">
-            <thead>
-                <tr>
-                    <th>Date</th>
-                    <th>Quantity Change</th>
-                    <th>Reason</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach ($product->inventoryLogs as $log)
-                    <tr>
-                        <td>{{ $log->created_at->format('Y-m-d H:i:s') }}</td>
-                        <td>{{ $log->quantity_change }}</td>
-                        <td>{{ $log->reason }}</td>
-                    </tr>
-                @endforeach
-            </tbody>
-        </table>
-    </div>
-</div>
-@endisset
-
 <script type="application/ld+json">
 {!! json_encode([
     '@context' => 'https://schema.org/',
@@ -172,7 +146,7 @@
             'name' => config('app.name'),
         ],
     ],
-], JSON_UNESCAPED_SLASHES|JSON_PRETTY_PRINT) !!}
+], JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT|JSON_PRETTY_PRINT) !!}
 </script>
     
 @endsection

--- a/tests/Feature/ProductShowXssTest.php
+++ b/tests/Feature/ProductShowXssTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductShowXssTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_product_json_ld_neutralizes_a_script_breakout_in_the_name(): void
+    {
+        $product = Product::factory()->create([
+            'name' => 'Evil</script><script>alert(1)</script>',
+            'pricing_type' => 'fixed',
+        ]);
+
+        $response = $this->get(route('products.show', $product));
+
+        $response->assertStatus(200);
+        // The raw JSON-LD echo must not emit a script tag that would execute
+        // (JSON_HEX_TAG escapes < and > so the </script> breakout can't close it).
+        $response->assertDontSee('<script>alert(1)', false);
+    }
+
+    public function test_product_json_ld_neutralizes_a_breakout_in_the_description(): void
+    {
+        $product = Product::factory()->create([
+            'name' => 'Clean name',
+            'description' => 'x</script><script>alert(2)</script>',
+            'pricing_type' => 'fixed',
+        ]);
+
+        $response = $this->get(route('products.show', $product));
+
+        $response->assertStatus(200);
+        $response->assertDontSee('<script>alert(2)', false);
+    }
+}


### PR DESCRIPTION
## Stored XSS via the product JSON-LD block

`resources/views/products/show.blade.php` raw-echoes the product **name** and **description** into a `<script type="application/ld+json">` block:

```blade
{!! json_encode([ ... 'name' => $product->name, 'description' => $product->description ... ],
    JSON_UNESCAPED_SLASHES|JSON_PRETTY_PRINT) !!}
```

`name`/`description` are seller/admin-fillable and passed straight through by `ProductController::show`. `json_encode` does **not** escape `<`/`>` by default, and the one thing that normally neutralizes a `</script>` inside a `<script>` block — the default `/`→`\/` escaping — is **disabled by `JSON_UNESCAPED_SLASHES`**.

**Exploit:** a seller sets a product name (or description) to `</script><script>alert(document.cookie)</script>`. On the public product page the encoder emits the literal `</script>`, closing the ld+json block, and the injected `<script>` runs for **every visitor** — stored XSS on the highest-traffic public page.

## Fix

Changed the encode flags to `JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT|JSON_PRETTY_PRINT` (dropping `JSON_UNESCAPED_SLASHES`), so `<`, `>`, `&`, `'`, `"` are emitted as `\uXXXX` escapes and can't close the script tag or break out.

Also removed the dead **"Inventory Logs"** block that sat just above it: `Product` has no `inventoryLogs` relation, so `@isset($product->inventoryLogs)` was always false and it never rendered — but it was a latent info-disclosure landmine (internal stock-change history + reasons shown to anonymous visitors) if that relation were ever added.

## Tests

Found via a read-only storefront-view audit (the rest of the public views are clean — everything uses auto-escaped `{{ }}`; the reflected search echo is escaped; chat messages are escaped in JS). +2 (`ProductShowXssTest`): a `</script><script>alert(1)</script>` breakout in the **name** and in the **description** are both neutralized (the literal `<script>alert(...)` no longer appears in the response). Suite **885 passed / 0 failed**. No migration, no raw SQL.
