### PR TITLE
fix(segments): match last_order_date by most-recent order + fail-closed unknown fields

### DIFF
--- a/app/Models/CustomerSegment.php
+++ b/app/Models/CustomerSegment.php
@@ -39,7 +39,7 @@ class CustomerSegment extends Model
      */
     public function calculateMembers(): void
     {
-        if (!$this->is_active) {
+        if (! $this->is_active) {
             return;
         }
 
@@ -56,10 +56,10 @@ class CustomerSegment extends Model
         }
 
         $userIds = $query->pluck('id');
-        
+
         // Sync members
         $this->members()->sync($userIds);
-        
+
         // Update count and timestamp
         $this->update([
             'customer_count' => $userIds->count(),
@@ -76,27 +76,40 @@ class CustomerSegment extends Model
         $operator = $condition['operator'] ?? '=';
         $value = $condition['value'] ?? null;
 
-        if (!$field) {
+        if (! $field) {
             return;
         }
 
         // Handle different condition types
-        match($field) {
+        match ($field) {
             // has() builds a correlated `(select count(*) ...) <op> <value>` predicate.
             // The old havingRaw()-in-whereHas produced invalid SQL ("HAVING on a non-aggregate query").
             'total_orders' => $query->has('orders', $operator, (int) $value),
-            'lifetime_value' => $query->whereHas('customerMetric', function($q) use ($operator, $value) {
+            'lifetime_value' => $query->whereHas('customerMetric', function ($q) use ($operator, $value) {
                 $q->where('lifetime_value', $operator, $value);
             }),
-            'last_order_date' => $query->whereHas('orders', function($q) use ($operator, $value) {
-                $q->latest()->limit(1)->where('created_at', $operator, $value);
-            }),
-            'has_purchased_product' => $query->whereHas('orders.items', function($q) use ($value) {
+            // Compare the user's MOST RECENT order date. whereHas() compiles to an
+            // EXISTS subquery where latest()/limit() are inert — it would match a
+            // user with ANY qualifying order, which is wrong for <=/</=. Use a
+            // correlated MAX() so the comparison is against the last order only.
+            'last_order_date' => $query->whereRaw(
+                '(select max(created_at) from orders where orders.user_id = users.id) '.$this->safeOperator($operator).' ?',
+                [$value]
+            ),
+            'has_purchased_product' => $query->whereHas('orders.items', function ($q) use ($value) {
                 $q->where('product_id', $value);
             }),
             'in_customer_group' => $query->where('customer_group_id', $value),
-            default => null
+            // Fail closed: an unrecognised field must not silently drop the filter
+            // (which would match EVERY user under match_type=all) — match no one.
+            default => $query->whereRaw('1 = 0'),
         };
+    }
+
+    /** Whitelist comparison operators — condition config must never reach raw SQL unchecked. */
+    private function safeOperator(string $operator): string
+    {
+        return in_array($operator, ['=', '!=', '<', '<=', '>', '>='], true) ? $operator : '=';
     }
 
     public function scopeActive($query)

--- a/tests/Unit/CustomerSegmentTest.php
+++ b/tests/Unit/CustomerSegmentTest.php
@@ -67,8 +67,8 @@ class CustomerSegmentTest extends TestCase
                 [
                     'field' => 'lifetime_value',
                     'operator' => '>=',
-                    'value' => 1000
-                ]
+                    'value' => 1000,
+                ],
             ],
             'match_type' => 'all',
         ]);
@@ -103,7 +103,7 @@ class CustomerSegmentTest extends TestCase
     {
         $rich = $this->userWithLtv(2000);
         $poor = $this->userWithLtv(5);
-        $mid  = $this->userWithLtv(500);
+        $mid = $this->userWithLtv(500);
 
         $segment = $this->makeSegment([
             ['field' => 'lifetime_value', 'operator' => '>=', 'value' => 1000],
@@ -121,7 +121,7 @@ class CustomerSegmentTest extends TestCase
 
     public function test_match_type_all_requires_every_condition(): void
     {
-        $mid  = $this->userWithLtv(500);
+        $mid = $this->userWithLtv(500);
         $rich = $this->userWithLtv(2000);
         $poor = $this->userWithLtv(5);
 
@@ -141,7 +141,7 @@ class CustomerSegmentTest extends TestCase
     public function test_total_orders_condition_matches_at_boundary_without_fataling(): void
     {
         $twoOrders = $this->userWithOrderCount(2);
-        $oneOrder  = $this->userWithOrderCount(1);
+        $oneOrder = $this->userWithOrderCount(1);
 
         $matched = function (string $operator, int $value): array {
             $segment = $this->makeSegment(
@@ -162,5 +162,71 @@ class CustomerSegmentTest extends TestCase
 
         // The single-order user must never match a >= 2 threshold
         $this->assertNotContains($oneOrder->id, $matched('>=', 2));
+    }
+
+    private function userWithOrdersOn(array $datetimes): User
+    {
+        $user = User::factory()->create();
+        foreach ($datetimes as $dt) {
+            $order = Order::create([
+                'user_id' => $user->id,
+                'customer_email' => uniqid().'@x.com',
+                'total_amount' => 50,
+                'status' => 'paid',
+            ]);
+            // Raw update so we control created_at without the timestamp helpers.
+            Order::whereKey($order->id)->update(['created_at' => $dt]);
+        }
+
+        return $user;
+    }
+
+    public function test_last_order_date_matches_by_most_recent_order_not_any_order(): void
+    {
+        $userOld = $this->userWithOrdersOn(['2024-01-01 00:00:00']);
+        $userMixed = $this->userWithOrdersOn(['2024-01-01 00:00:00', '2026-01-01 00:00:00']);
+
+        $segment = $this->makeSegment(
+            [['field' => 'last_order_date', 'operator' => '<=', 'value' => '2025-01-01 00:00:00']],
+            'all'
+        );
+        $segment->calculateMembers();
+        $ids = $segment->members()->pluck('users.id')->all();
+
+        $this->assertContains($userOld->id, $ids, 'user whose last order is old should match');
+        $this->assertNotContains(
+            $userMixed->id,
+            $ids,
+            'user whose MOST RECENT order is recent must not match — an older order should not count'
+        );
+    }
+
+    public function test_last_order_date_ge_matches_recent_buyers_only(): void
+    {
+        $recent = $this->userWithOrdersOn(['2026-01-01 00:00:00']);
+        $old = $this->userWithOrdersOn(['2024-01-01 00:00:00']);
+
+        $segment = $this->makeSegment(
+            [['field' => 'last_order_date', 'operator' => '>=', 'value' => '2025-01-01 00:00:00']],
+            'all'
+        );
+        $segment->calculateMembers();
+        $ids = $segment->members()->pluck('users.id')->all();
+
+        $this->assertContains($recent->id, $ids);
+        $this->assertNotContains($old->id, $ids);
+    }
+
+    public function test_unknown_condition_field_matches_no_one(): void
+    {
+        $this->userWithLtv(500); // a user who would match a fail-open (empty) filter
+
+        $segment = $this->makeSegment(
+            [['field' => 'bogus_field', 'operator' => '=', 'value' => 1]],
+            'all'
+        );
+        $segment->calculateMembers();
+
+        $this->assertEquals(0, $segment->customer_count);
     }
 }


### PR DESCRIPTION
## Two silently-wrong bugs in customer-segment matching

`CustomerSegment::applyCondition()` builds the query that decides who lands in a marketing/targeting segment. Two condition branches produced **wrong membership without ever erroring** (so the per-segment try/catch never fired):

**1. `last_order_date` matched by *any* order, not the most recent.**
```php
'last_order_date' => $query->whereHas('orders', fn ($q) =>
    $q->latest()->limit(1)->where('created_at', $operator, $value)),
```
`whereHas` compiles to an `EXISTS` subquery — `latest()`/`limit(1)` inside it are **inert**. So it matched a user with **any** order satisfying the operator. For `<=`/`<`/`=` that's wrong: a user who ordered long ago **and** recently wrongly matched `last_order_date <= X` (their most recent order is *after* X). This silently mis-targets win-back / lapsed-customer campaigns.

Replaced with a **correlated `MAX()` subquery** so the comparison is against the last order only:
```php
'last_order_date' => $query->whereRaw(
    '(select max(created_at) from orders where orders.user_id = users.id) '.$this->safeOperator($operator).' ?',
    [$value]),
```
The operator is **whitelisted** (`safeOperator`) before it reaches `whereRaw` — condition config can't inject SQL.

**2. Unknown condition field silently matched everyone.**
An unrecognised `field` hit `default => null`, adding an empty nested group → **no filter** → under `match_type = all` the segment matched **every** user (a misconfigured rule silently blasts the whole customer base). Now **fails closed** (`whereRaw('1 = 0')`) — an unknown field matches no one.

## Tests

Found via a read-only segmentation audit. +3 (`CustomerSegmentTest`): `last_order_date <=` matches by most-recent order (a mixed old+recent buyer is excluded), `>=` matches recent buyers only, unknown field matches no one. **RED verified** against the old model (both key tests fail without the fix). The correlated subquery was also run on **MySQL 8.4** (standard ANSI scalar subquery — no MySQL/sqlite-specific constructs; returns the correct rows). Suite **888 passed / 0 failed**.

## Still filed (not fixed — needs a design decision)

`in_customer_group` queries a non-existent `users.customer_group_id`. Group membership is keyed on `customers.id` via the `customer_group_memberships` pivot, and there is **no `User → groups` relation** — so fixing it means resolving the `users` ↔ `customers` identity split (the segment query runs over `users`, but `customer_segment_members` and the pivot disagree on which id-space). Left for a dedicated PR.
