### PR TITLE
feat(payments): signed Stripe webhook to reconcile order state

### DIFF
--- a/app/Http/Controllers/StripeWebhookController.php
+++ b/app/Http/Controllers/StripeWebhookController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Order;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Stripe\Exception\SignatureVerificationException;
+use Stripe\Webhook;
+use UnexpectedValueException;
+
+class StripeWebhookController extends Controller
+{
+    /**
+     * Verified Stripe webhook. Reconciles order state with Stripe for events that
+     * may happen out of band with our synchronous checkout — a charge captured
+     * async, or (most usefully) a refund issued from the Stripe dashboard.
+     */
+    public function handle(Request $request): JsonResponse
+    {
+        try {
+            $event = Webhook::constructEvent(
+                $request->getContent(),
+                $request->header('Stripe-Signature') ?? '',
+                (string) config('services.stripe.webhook.secret')
+            );
+        } catch (SignatureVerificationException|UnexpectedValueException $e) {
+            return response()->json(['error' => 'Invalid signature'], 400);
+        }
+
+        $charge = $event->data->object;
+
+        match ($event->type) {
+            'charge.succeeded' => $this->markPaid($charge),
+            'charge.failed' => $this->markFailed($charge),
+            'charge.refunded' => $this->reconcileRefund($charge),
+            default => null, // acknowledge and ignore everything else
+        };
+
+        return response()->json(['received' => true]);
+    }
+
+    private function orderForCharge($charge): ?Order
+    {
+        return isset($charge->id) ? Order::where('transaction_id', $charge->id)->first() : null;
+    }
+
+    private function markPaid($charge): void
+    {
+        $this->transition($this->orderForCharge($charge), Order::STATUS_PAID, 'Stripe webhook: charge.succeeded');
+    }
+
+    private function markFailed($charge): void
+    {
+        $this->transition($this->orderForCharge($charge), Order::STATUS_FAILED, 'Stripe webhook: charge.failed');
+    }
+
+    private function reconcileRefund($charge): void
+    {
+        $order = $this->orderForCharge($charge);
+        if (! $order) {
+            return;
+        }
+
+        // Stripe's amount_refunded (in cents) is authoritative. Setting it (rather
+        // than incrementing) keeps this idempotent across webhook retries and
+        // refunds already recorded in-app.
+        $refunded = (float) (($charge->amount_refunded ?? 0) / 100);
+        $fully = $refunded >= (float) $order->total_amount;
+
+        $order->update([
+            'refund_total' => $refunded,
+            'fully_refunded' => $fully,
+            'partially_refunded' => ! $fully && $refunded > 0,
+        ]);
+
+        $this->transition($order, $fully ? Order::STATUS_REFUNDED : Order::STATUS_PARTIALLY_REFUNDED, 'Stripe webhook: charge.refunded');
+    }
+
+    /**
+     * Move the order through the state machine only if the transition is legal —
+     * webhooks are at-least-once and may arrive for an order already in the target
+     * (or a later) state, so an illegal transition is silently skipped, never thrown.
+     */
+    private function transition(?Order $order, string $status, string $notes): void
+    {
+        if ($order && in_array($status, Order::TRANSITIONS[$order->status] ?? [], true)) {
+            $order->transitionTo($status, notes: $notes);
+        }
+    }
+}

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,6 +12,6 @@ class VerifyCsrfToken extends Middleware
      * @var array<int, string>
      */
     protected $except = [
-        //
+        'stripe/webhook',
     ];
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,7 +20,8 @@ use App\Http\Controllers\ShippingController;
 use App\Http\Controllers\SitemapController;
 use App\Http\Controllers\SiteSettingController;
 use App\Http\Controllers\StripePaymentController;
-use App\Http\Controllers\SubscriptionController; // New controller for cart
+use App\Http\Controllers\StripeWebhookController; // New controller for cart
+use App\Http\Controllers\SubscriptionController;
 use App\Http\Controllers\WishlistController;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
@@ -104,6 +105,9 @@ Route::middleware('auth')->prefix('payment_methods')->group(function () {
     Route::delete('/destroy/{id}', [PaymentMethodController::class, 'deletePaymentMethod'])->name('payment_methods.destroy');
     Route::post('/set_default/{id}', [PaymentMethodController::class, 'setDefaultPaymentMethod'])->name('payment_methods.setDefault');
 });
+
+// Stripe webhook — unauthenticated + CSRF-exempt (verified by signature in the controller)
+Route::post('/stripe/webhook', [StripeWebhookController::class, 'handle'])->name('stripe.webhook');
 
 Route::post('/payment', [StripePaymentController::class, 'createOneTimePayment'])->name('payment.create');
 Route::post('/stripe/payment', [StripePaymentController::class, 'createOneTimePayment'])->name('stripe.payment.create');

--- a/tests/Feature/StripeWebhookTest.php
+++ b/tests/Feature/StripeWebhookTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Order;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+class StripeWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $secret = 'whsec_test_secret';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Notification::fake();
+        config(['services.stripe.webhook.secret' => $this->secret]);
+    }
+
+    private function order(string $status, string $charge = 'ch_1', float $total = 100): Order
+    {
+        return Order::create([
+            'customer_email' => 'buyer@example.com',
+            'payment_method' => 'stripe',
+            'transaction_id' => $charge,
+            'total_amount' => $total,
+            'status' => $status,
+        ]);
+    }
+
+    private function postWebhook(array $event, ?string $secret = null): TestResponse
+    {
+        $payload = json_encode(array_merge(['id' => 'evt_1', 'object' => 'event', 'created' => time()], $event));
+        $ts = time();
+        $sig = 't='.$ts.',v1='.hash_hmac('sha256', $ts.'.'.$payload, $secret ?? $this->secret);
+
+        return $this->call('POST', '/stripe/webhook', [], [], [], ['HTTP_STRIPE_SIGNATURE' => $sig], $payload);
+    }
+
+    private function charge(array $overrides = []): array
+    {
+        return array_merge(['id' => 'ch_1', 'object' => 'charge', 'amount' => 10000, 'amount_refunded' => 0], $overrides);
+    }
+
+    public function test_invalid_signature_is_rejected(): void
+    {
+        $response = $this->postWebhook(
+            ['type' => 'charge.succeeded', 'data' => ['object' => $this->charge()]],
+            secret: 'wrong_secret'
+        );
+
+        $response->assertStatus(400);
+    }
+
+    public function test_charge_succeeded_marks_a_pending_order_paid(): void
+    {
+        $order = $this->order(Order::STATUS_PENDING);
+
+        $this->postWebhook(['type' => 'charge.succeeded', 'data' => ['object' => $this->charge()]])
+            ->assertStatus(200);
+
+        $this->assertSame(Order::STATUS_PAID, $order->refresh()->status);
+    }
+
+    public function test_charge_succeeded_is_idempotent_for_an_already_paid_order(): void
+    {
+        $order = $this->order(Order::STATUS_PAID);
+
+        $this->postWebhook(['type' => 'charge.succeeded', 'data' => ['object' => $this->charge()]])
+            ->assertStatus(200);
+
+        $this->assertSame(Order::STATUS_PAID, $order->refresh()->status);
+    }
+
+    public function test_charge_refunded_fully_reconciles_the_order(): void
+    {
+        $order = $this->order(Order::STATUS_PAID, total: 100);
+
+        $this->postWebhook(['type' => 'charge.refunded', 'data' => ['object' => $this->charge(['amount_refunded' => 10000])]])
+            ->assertStatus(200);
+
+        $order->refresh();
+        $this->assertSame(Order::STATUS_REFUNDED, $order->status);
+        $this->assertSame(100.0, (float) $order->refund_total);
+        $this->assertTrue((bool) $order->fully_refunded);
+    }
+
+    public function test_charge_refunded_partially_reconciles_the_order(): void
+    {
+        $order = $this->order(Order::STATUS_PAID, total: 100);
+
+        $this->postWebhook(['type' => 'charge.refunded', 'data' => ['object' => $this->charge(['amount_refunded' => 4000])]])
+            ->assertStatus(200);
+
+        $order->refresh();
+        $this->assertSame(Order::STATUS_PARTIALLY_REFUNDED, $order->status);
+        $this->assertSame(40.0, (float) $order->refund_total);
+    }
+
+    public function test_charge_failed_marks_a_pending_order_failed(): void
+    {
+        $order = $this->order(Order::STATUS_PENDING);
+
+        $this->postWebhook(['type' => 'charge.failed', 'data' => ['object' => $this->charge()]])
+            ->assertStatus(200);
+
+        $this->assertSame(Order::STATUS_FAILED, $order->refresh()->status);
+    }
+
+    public function test_unknown_event_is_acknowledged(): void
+    {
+        $this->postWebhook(['type' => 'customer.created', 'data' => ['object' => ['id' => 'cus_1', 'object' => 'customer']]])
+            ->assertStatus(200)
+            ->assertJsonPath('received', true);
+    }
+}


### PR DESCRIPTION
## Signed Stripe webhook to reconcile order state

TASKS 0.4 flagged "no webhook verification for either provider" — and in fact there was **no webhook handling at all**. Anything that happens to a charge **out of band** with our synchronous checkout never reached the order:

- a **refund issued from the Stripe dashboard** left the order stuck at `paid` (the in-app refund flow was the only thing that moved order state),
- an async capture or a later failure was never reflected.

## What this adds

`POST /stripe/webhook` — unauthenticated, **CSRF-exempt**, verified by the Stripe signature via `Webhook::constructEvent($payload, $sigHeader, config('services.stripe.webhook.secret'))`. An invalid or absent signature → **400**.

Orders are matched by charge id (`orders.transaction_id`, the id checkout persists). Handled events:

| event | action |
|---|---|
| `charge.succeeded` | `transitionTo(PAID)` — safety net for an async capture |
| `charge.failed` | `transitionTo(FAILED)` |
| `charge.refunded` | reconcile: set `refund_total` from Stripe's authoritative `amount_refunded` (**set, not increment → idempotent**), set `partially_/fully_refunded`, `transitionTo(REFUNDED\|PARTIALLY_REFUNDED)` |
| anything else | `200` acknowledged, ignored |

Every status change routes through the **state machine** and is **skipped if the transition is illegal** — webhooks are at-least-once and may arrive for an order already in the target (or a later) state, so **replays are safe** and never throw.

## Tests

+7 (`StripeWebhookTest`, with **real HMAC-SHA256 signatures**): invalid signature → 400; `charge.succeeded` marks a pending order paid **and** is idempotent when already paid; `charge.refunded` reconciles full and partial refunds; `charge.failed` marks a pending order failed; an unknown event is acknowledged. Suite **895 passed / 0 failed**. No migration.

## Activation

The config key already exists (`services.stripe.webhook.secret` = `STRIPE_WEBHOOK_SECRET`). Set that env var and register the endpoint URL in the Stripe dashboard (subscribe to `charge.succeeded`, `charge.failed`, `charge.refunded`) to turn it on. Uses the legacy Charges API to match the existing `StripeGateway` (charge ids, not PaymentIntents).
