### PR TITLE
feat(payments): notify the customer when the Stripe webhook reconciles state

### DIFF
--- a/app/Http/Controllers/StripeWebhookController.php
+++ b/app/Http/Controllers/StripeWebhookController.php
@@ -3,8 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\Order;
+use App\Notifications\OrderConfirmationNotification;
+use App\Notifications\OrderRefundedNotification;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Notification;
 use Stripe\Exception\SignatureVerificationException;
 use Stripe\Webhook;
 use UnexpectedValueException;
@@ -47,7 +50,14 @@ class StripeWebhookController extends Controller
 
     private function markPaid($charge): void
     {
-        $this->transition($this->orderForCharge($charge), Order::STATUS_PAID, 'Stripe webhook: charge.succeeded');
+        $order = $this->orderForCharge($charge);
+
+        // Only when the webhook itself moves the order to paid (an async capture
+        // the synchronous checkout didn't already confirm) do we email — otherwise
+        // we'd double-send the confirmation the checkout already sent.
+        if ($this->transition($order, Order::STATUS_PAID, 'Stripe webhook: charge.succeeded')) {
+            Notification::route('mail', $order->customer_email)->notify(new OrderConfirmationNotification($order));
+        }
     }
 
     private function markFailed($charge): void
@@ -74,18 +84,30 @@ class StripeWebhookController extends Controller
             'partially_refunded' => ! $fully && $refunded > 0,
         ]);
 
-        $this->transition($order, $fully ? Order::STATUS_REFUNDED : Order::STATUS_PARTIALLY_REFUNDED, 'Stripe webhook: charge.refunded');
+        $target = $fully ? Order::STATUS_REFUNDED : Order::STATUS_PARTIALLY_REFUNDED;
+
+        // Notify only when this is a newly-recognised refund (e.g. issued from the
+        // Stripe dashboard). An in-app refund already emailed and already moved the
+        // order, so the transition is skipped here and no second email is sent.
+        if ($this->transition($order, $target, 'Stripe webhook: charge.refunded')) {
+            Notification::route('mail', $order->customer_email)->notify(new OrderRefundedNotification($order, $refunded));
+        }
     }
 
     /**
      * Move the order through the state machine only if the transition is legal —
      * webhooks are at-least-once and may arrive for an order already in the target
      * (or a later) state, so an illegal transition is silently skipped, never thrown.
+     * Returns whether the transition actually happened.
      */
-    private function transition(?Order $order, string $status, string $notes): void
+    private function transition(?Order $order, string $status, string $notes): bool
     {
         if ($order && in_array($status, Order::TRANSITIONS[$order->status] ?? [], true)) {
             $order->transitionTo($status, notes: $notes);
+
+            return true;
         }
+
+        return false;
     }
 }

--- a/tests/Feature/StripeWebhookTest.php
+++ b/tests/Feature/StripeWebhookTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\Order;
+use App\Notifications\OrderConfirmationNotification;
+use App\Notifications\OrderRefundedNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Testing\TestResponse;
@@ -116,5 +118,51 @@ class StripeWebhookTest extends TestCase
         $this->postWebhook(['type' => 'customer.created', 'data' => ['object' => ['id' => 'cus_1', 'object' => 'customer']]])
             ->assertStatus(200)
             ->assertJsonPath('received', true);
+    }
+
+    public function test_dashboard_refund_emails_the_customer(): void
+    {
+        $this->order(Order::STATUS_PAID, total: 100);
+
+        $this->postWebhook(['type' => 'charge.refunded', 'data' => ['object' => $this->charge(['amount_refunded' => 10000])]])
+            ->assertStatus(200);
+
+        Notification::assertSentOnDemand(
+            OrderRefundedNotification::class,
+            fn ($n, $channels, $notifiable) => $notifiable->routes['mail'] === 'buyer@example.com'
+                && (float) $n->refundAmount === 100.0
+        );
+    }
+
+    public function test_refund_replay_does_not_double_notify(): void
+    {
+        $this->order(Order::STATUS_PAID, total: 100);
+        $event = ['type' => 'charge.refunded', 'data' => ['object' => $this->charge(['amount_refunded' => 10000])]];
+
+        $this->postWebhook($event)->assertStatus(200);
+        $this->postWebhook($event)->assertStatus(200); // replay — order already refunded
+
+        Notification::assertSentOnDemandTimes(OrderRefundedNotification::class, 1);
+    }
+
+    public function test_async_capture_of_a_pending_order_sends_confirmation(): void
+    {
+        $this->order(Order::STATUS_PENDING);
+
+        $this->postWebhook(['type' => 'charge.succeeded', 'data' => ['object' => $this->charge()]])
+            ->assertStatus(200);
+
+        Notification::assertSentOnDemand(OrderConfirmationNotification::class);
+    }
+
+    public function test_charge_succeeded_on_already_paid_order_sends_no_confirmation(): void
+    {
+        // The synchronous checkout already emailed; the webhook must not double-send.
+        $this->order(Order::STATUS_PAID);
+
+        $this->postWebhook(['type' => 'charge.succeeded', 'data' => ['object' => $this->charge()]])
+            ->assertStatus(200);
+
+        Notification::assertNothingSent();
     }
 }


### PR DESCRIPTION
## Notify the customer when the webhook reconciles state

The Stripe webhook (#728) reconciled order **state** but did it **silently**. So a refund issued from the **Stripe dashboard** moved the order to `refunded` and returned the money — with **no email to the customer**. An async capture likewise sent no confirmation.

## Change

The handlers now notify, but **only when the webhook itself performs the transition** — which is exactly what keeps it from double-sending on the normal flow:

- **`charge.refunded`** that actually moves the order to `(partially_)refunded` → `OrderRefundedNotification` to the customer. An **in-app refund** already emailed and already moved the order, so its transition is skipped here → no double email. A webhook **replay** is likewise a no-op.
- **`charge.succeeded`** that actually moves a still-**pending** order to paid → `OrderConfirmationNotification`. The normal **synchronous checkout** already sent the confirmation and already set the order paid, so the webhook's transition is skipped and it does **not** double-send.

`transition()` now returns whether it fired; the notifications are gated on that boolean.

## Tests

+4 (`StripeWebhookTest`, now 11): a dashboard refund emails the customer (on-demand mail, correct amount); a refund **replay** notifies exactly once; an async capture of a pending order sends the confirmation; `charge.succeeded` on an **already-paid** order sends **nothing**. Suite **899 passed / 0 failed**. No migration.
