### PR TITLE
feat(refunds): staff API to initiate a refund on an order

### DIFF
--- a/app/Http/Controllers/Api/OrderRefundController.php
+++ b/app/Http/Controllers/Api/OrderRefundController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Order;
+use App\Models\Refund;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class OrderRefundController extends Controller
+{
+    /**
+     * Staff-initiated refund on an order. Creates a Refund (+ RefundItems when
+     * restocking) and runs it through the refund engine (gateway void → restock →
+     * order state transition + customer notification).
+     */
+    public function store(Request $request, Order $order): JsonResponse
+    {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
+        $remaining = round((float) $order->total_amount - (float) $order->refund_total, 2);
+        if ($remaining <= 0) {
+            return response()->json(['message' => 'This order has no refundable balance remaining.'], 422);
+        }
+
+        $validated = $request->validate([
+            'amount' => 'nullable|numeric|min:0.01|max:'.$remaining,
+            'reason' => 'required|string|max:255',
+            'restock' => 'sometimes|boolean',
+        ]);
+
+        $restock = $validated['restock'] ?? false;
+
+        $refund = Refund::create([
+            'order_id' => $order->id,
+            'amount' => $validated['amount'] ?? $remaining,
+            'reason' => $validated['reason'],
+            'status' => 'pending',
+            'refund_method' => 'original_payment',
+            'restock_items' => $restock,
+        ]);
+
+        if ($restock) {
+            foreach ($order->items as $item) {
+                $refund->items()->create([
+                    'order_item_id' => $item->id,
+                    'quantity' => $item->quantity,
+                    'amount' => (float) $item->price * $item->quantity,
+                    'restock' => true,
+                ]);
+            }
+        }
+
+        if (! $refund->process($request->user()->id)) {
+            // process() is a no-op on failure (gateway declined) — nothing moved.
+            $refund->delete();
+
+            return response()->json(['message' => 'The refund could not be processed (the payment gateway declined).'], 422);
+        }
+
+        return response()->json(['message' => 'Refund processed.', 'refund' => $refund->fresh()], 201);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\CollectionController;
 use App\Http\Controllers\Api\DropshippingController;
 use App\Http\Controllers\Api\OrderController;
+use App\Http\Controllers\Api\OrderRefundController;
 use App\Http\Controllers\Api\ProductController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -43,6 +44,8 @@ Route::middleware('auth:sanctum')->prefix('products')->group(function () {
 Route::middleware('auth:sanctum')->prefix('orders')->group(function () {
     Route::get('/', [OrderController::class, 'index']);
     Route::get('/{id}', [OrderController::class, 'show']);
+    // Staff-only (role checked in the controller): initiate a refund on an order.
+    Route::post('/{order}/refund', [OrderRefundController::class, 'store']);
 });
 // Collection API routes
 Route::middleware('auth:sanctum')->prefix('collections')->group(function () {

--- a/tests/Feature/Api/OrderRefundApiTest.php
+++ b/tests/Feature/Api/OrderRefundApiTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Interfaces\PaymentGatewayInterface;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\User;
+use App\Services\PaymentGateways\StripeGateway;
+use Closure;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class OrderRefundApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Notification::fake();
+    }
+
+    private function bindGateway(Closure $refundResult): object
+    {
+        $spy = new class($refundResult) implements PaymentGatewayInterface
+        {
+            public array $refundCalls = [];
+
+            public function __construct(private Closure $refundResult) {}
+
+            public function processPayment(float $amount, array $d): array
+            {
+                return ['success' => true];
+            }
+
+            public function processSubscription(string $p, array $d): array
+            {
+                return ['success' => true];
+            }
+
+            public function refundPayment(string $transactionId, float $amount): array
+            {
+                $this->refundCalls[] = ['transaction_id' => $transactionId, 'amount' => $amount];
+
+                return ($this->refundResult)();
+            }
+        };
+        $this->app->instance(StripeGateway::class, $spy);
+
+        return $spy;
+    }
+
+    private function admin(): User
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        return User::factory()->create()->assignRole('super_admin');
+    }
+
+    private function order(int $stock = 3, float $total = 100, array $overrides = []): Order
+    {
+        $product = Product::factory()->create(['inventory_count' => $stock]);
+        $order = Order::create(array_merge([
+            'customer_email' => 'buyer@example.com',
+            'payment_method' => 'stripe',
+            'transaction_id' => 'ch_test',
+            'total_amount' => $total,
+            'status' => Order::STATUS_PAID,
+        ], $overrides));
+        $order->items()->create(['product_id' => $product->id, 'quantity' => 2, 'price' => 50]);
+
+        return $order;
+    }
+
+    public function test_unauthenticated_cannot_refund(): void
+    {
+        $order = $this->order();
+        $this->postJson("/api/orders/{$order->id}/refund", ['reason' => 'x'])->assertStatus(401);
+    }
+
+    public function test_non_admin_cannot_refund(): void
+    {
+        $order = $this->order();
+        Sanctum::actingAs(User::factory()->create());
+
+        $this->postJson("/api/orders/{$order->id}/refund", ['reason' => 'x'])->assertStatus(403);
+        $this->assertSame(Order::STATUS_PAID, $order->refresh()->status);
+    }
+
+    public function test_admin_full_refund_processes_and_refunds_the_order(): void
+    {
+        $spy = $this->bindGateway(fn () => ['success' => true, 'refund_id' => 're_1']);
+        $order = $this->order(total: 100);
+        Sanctum::actingAs($this->admin());
+
+        $this->postJson("/api/orders/{$order->id}/refund", ['reason' => 'customer request'])
+            ->assertStatus(201);
+
+        $order->refresh();
+        $this->assertSame(Order::STATUS_REFUNDED, $order->status);
+        $this->assertSame(100.0, (float) $order->refund_total);
+        $this->assertSame('ch_test', $spy->refundCalls[0]['transaction_id']);
+    }
+
+    public function test_admin_partial_refund_marks_partially_refunded(): void
+    {
+        $this->bindGateway(fn () => ['success' => true]);
+        $order = $this->order(total: 100);
+        Sanctum::actingAs($this->admin());
+
+        $this->postJson("/api/orders/{$order->id}/refund", ['amount' => 40, 'reason' => 'partial'])
+            ->assertStatus(201);
+
+        $order->refresh();
+        $this->assertSame(Order::STATUS_PARTIALLY_REFUNDED, $order->status);
+        $this->assertSame(40.0, (float) $order->refund_total);
+    }
+
+    public function test_refund_with_restock_restores_inventory(): void
+    {
+        $this->bindGateway(fn () => ['success' => true]);
+        $order = $this->order(stock: 3, total: 100);
+        Sanctum::actingAs($this->admin());
+
+        $this->postJson("/api/orders/{$order->id}/refund", ['reason' => 'x', 'restock' => true])
+            ->assertStatus(201);
+
+        // 3 + 2 (the order line quantity) restocked.
+        $this->assertSame(5, $order->items->first()->product->fresh()->inventory_count);
+    }
+
+    public function test_cannot_refund_more_than_the_remaining_balance(): void
+    {
+        $this->bindGateway(fn () => ['success' => true]);
+        $order = $this->order(total: 100);
+        Sanctum::actingAs($this->admin());
+
+        $this->postJson("/api/orders/{$order->id}/refund", ['amount' => 150, 'reason' => 'x'])
+            ->assertStatus(422);
+    }
+
+    public function test_gateway_decline_returns_422_and_leaves_the_order_paid(): void
+    {
+        $this->bindGateway(fn () => ['success' => false, 'error' => 'declined']);
+        $order = $this->order(total: 100);
+        Sanctum::actingAs($this->admin());
+
+        $this->postJson("/api/orders/{$order->id}/refund", ['reason' => 'x'])->assertStatus(422);
+
+        $order->refresh();
+        $this->assertSame(Order::STATUS_PAID, $order->status);
+        $this->assertSame(0.0, (float) $order->refund_total);
+    }
+
+    public function test_fully_refunded_order_has_no_remaining_balance(): void
+    {
+        $this->bindGateway(fn () => ['success' => true]);
+        $order = $this->order(total: 100, overrides: ['refund_total' => 100, 'status' => Order::STATUS_REFUNDED]);
+        Sanctum::actingAs($this->admin());
+
+        $this->postJson("/api/orders/{$order->id}/refund", ['reason' => 'x'])->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Staff trigger surface for the refund engine

The refund engine has been built up across the session — `Refund::process` (#695) voids the charge, restocks, moves the order through the state machine and emails the customer; it spawns from an approved **return** (#707); and it reconciles **dashboard** refunds via the **webhook** (#728). The one missing piece: staff had **no way to directly initiate a refund on an order**. This adds it.

## Endpoint

`POST /api/orders/{order}/refund` — `auth:sanctum` + admin role (checked inline, matching the app's pattern).

- **Body**: `amount` (optional — defaults to the remaining refundable balance, `total_amount - refund_total`), `reason` (required), `restock` (optional bool).
- **Guards**: `amount` ≤ remaining balance; an order with no refundable balance left → **422**.
- Creates a `Refund` (+ `RefundItem`s when restocking) and runs it through `Refund::process`, which voids the charge via the gateway → restocks → transitions the order (`REFUNDED` / `PARTIALLY_REFUNDED`) → emails the customer.
- A **gateway decline** rolls back cleanly (`process()` is a no-op on failure; the pending `Refund` row is deleted) → **422**, order stays `paid`.

## Tests

+8 (`OrderRefundApiTest`): 401 unauthenticated; 403 non-admin (order unchanged); full refund → `REFUNDED` (gateway called with the charge id, `refund_total` = total); partial → `PARTIALLY_REFUNDED`; `restock: true` restores inventory; refunding more than the remaining balance → 422; gateway decline → 422 + order stays paid + `refund_total` 0; an already-fully-refunded order → 422. Suite **907 passed / 0 failed**. No migration.

This completes the refund loop: **return-approval, webhook reconciliation, and now a direct staff action** all drive the one `Refund::process` engine.
