### PR TITLE
feat(returns): customer return-request API + staff approval endpoint

### DIFF
--- a/app/Http/Controllers/Api/ReturnRequestController.php
+++ b/app/Http/Controllers/Api/ReturnRequestController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Order;
+use App\Models\ReturnRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ReturnRequestController extends Controller
+{
+    /** States an order can be returned from. */
+    private const RETURNABLE = [Order::STATUS_PAID, Order::STATUS_COMPLETED];
+
+    /**
+     * A customer requests a return for their own order. Scoped to the
+     * authenticated user's orders — a foreign order is not found (404).
+     */
+    public function store(Request $request, $orderId): JsonResponse
+    {
+        $order = $request->user()->orders()->with('items')->findOrFail($orderId);
+
+        if (! in_array($order->status, self::RETURNABLE, true)) {
+            return response()->json(['message' => 'This order is not eligible for a return.'], 422);
+        }
+
+        $validated = $request->validate([
+            'reason' => 'required|string|max:255',
+            'description' => 'nullable|string|max:2000',
+            'items' => 'required|array|min:1',
+            'items.*.order_item_id' => 'required|integer',
+            'items.*.quantity' => 'required|integer|min:1',
+            'items.*.condition' => 'nullable|in:unopened,opened,damaged',
+        ]);
+
+        foreach ($validated['items'] as $line) {
+            $orderItem = $order->items->firstWhere('id', $line['order_item_id']);
+            if (! $orderItem) {
+                return response()->json(['message' => 'A returned item does not belong to this order.'], 422);
+            }
+            if ($line['quantity'] > $orderItem->quantity) {
+                return response()->json(['message' => 'A return quantity exceeds the quantity purchased.'], 422);
+            }
+        }
+
+        $return = ReturnRequest::create([
+            'order_id' => $order->id,
+            'customer_id' => $request->user()->id,
+            'reason' => $validated['reason'],
+            'description' => $validated['description'] ?? null,
+            'status' => 'pending',
+        ]);
+
+        foreach ($validated['items'] as $line) {
+            $return->items()->create([
+                'order_item_id' => $line['order_item_id'],
+                'quantity' => $line['quantity'],
+                'condition' => $line['condition'] ?? null,
+            ]);
+        }
+
+        return response()->json([
+            'message' => 'Return request submitted.',
+            'return' => $return->fresh()->load('items'),
+        ], 201);
+    }
+
+    /**
+     * Staff approves a return, which spawns and processes the refund (gateway
+     * void → restock → order state transition → customer notification).
+     */
+    public function approve(Request $request, ReturnRequest $returnRequest): JsonResponse
+    {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
+        $refund = $returnRequest->approve($request->user()->id);
+
+        return response()->json([
+            'message' => 'Return approved.',
+            'return' => $returnRequest->fresh(),
+            'refund' => $refund, // null when the return was already approved / nothing itemized
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\DropshippingController;
 use App\Http\Controllers\Api\OrderController;
 use App\Http\Controllers\Api\OrderRefundController;
 use App\Http\Controllers\Api\ProductController;
+use App\Http\Controllers\Api\ReturnRequestController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -46,7 +47,12 @@ Route::middleware('auth:sanctum')->prefix('orders')->group(function () {
     Route::get('/{id}', [OrderController::class, 'show']);
     // Staff-only (role checked in the controller): initiate a refund on an order.
     Route::post('/{order}/refund', [OrderRefundController::class, 'store']);
+    // Customer requests a return for their own order.
+    Route::post('/{order}/returns', [ReturnRequestController::class, 'store']);
 });
+
+// Return approval (staff-only, role checked in the controller) — spawns the refund.
+Route::middleware('auth:sanctum')->post('/returns/{returnRequest}/approve', [ReturnRequestController::class, 'approve']);
 // Collection API routes
 Route::middleware('auth:sanctum')->prefix('collections')->group(function () {
     Route::get('/', [CollectionController::class, 'index']);

--- a/tests/Feature/Api/ReturnRequestApiTest.php
+++ b/tests/Feature/Api/ReturnRequestApiTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Interfaces\PaymentGatewayInterface;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\ReturnRequest;
+use App\Models\User;
+use App\Services\PaymentGateways\StripeGateway;
+use Closure;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class ReturnRequestApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Notification::fake();
+    }
+
+    private function bindGateway(Closure $result): void
+    {
+        $this->app->instance(StripeGateway::class, new class($result) implements PaymentGatewayInterface
+        {
+            public function __construct(private Closure $result) {}
+
+            public function processPayment(float $a, array $d): array
+            {
+                return ['success' => true];
+            }
+
+            public function processSubscription(string $p, array $d): array
+            {
+                return ['success' => true];
+            }
+
+            public function refundPayment(string $t, float $a): array
+            {
+                return ($this->result)();
+            }
+        });
+    }
+
+    private function admin(): User
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        return User::factory()->create()->assignRole('super_admin');
+    }
+
+    /** @return array{0: Order, 1: OrderItem} */
+    private function order(User $user, string $status = 'paid'): array
+    {
+        $product = Product::factory()->create(['inventory_count' => 3]);
+        $order = Order::create([
+            'user_id' => $user->id,
+            'customer_email' => $user->email,
+            'payment_method' => 'stripe',
+            'transaction_id' => 'ch_test',
+            'total_amount' => 100,
+            'status' => $status,
+        ]);
+        $item = $order->items()->create(['product_id' => $product->id, 'quantity' => 2, 'price' => 50]);
+
+        return [$order, $item];
+    }
+
+    // --- customer creates a return -------------------------------------------
+
+    public function test_unauthenticated_cannot_create_a_return(): void
+    {
+        $this->postJson('/api/orders/1/returns', ['reason' => 'x'])->assertStatus(401);
+    }
+
+    public function test_customer_creates_a_return_for_their_order(): void
+    {
+        $user = User::factory()->create();
+        [$order, $item] = $this->order($user);
+        Sanctum::actingAs($user);
+
+        $this->postJson("/api/orders/{$order->id}/returns", [
+            'reason' => 'defective',
+            'items' => [['order_item_id' => $item->id, 'quantity' => 1, 'condition' => 'damaged']],
+        ])->assertStatus(201);
+
+        $this->assertDatabaseHas('return_requests', ['order_id' => $order->id, 'customer_id' => $user->id, 'status' => 'pending']);
+        $this->assertSame(1, ReturnRequest::first()->items()->count());
+    }
+
+    public function test_cannot_create_a_return_for_another_users_order(): void
+    {
+        $me = User::factory()->create();
+        $other = User::factory()->create();
+        [$order, $item] = $this->order($other);
+        Sanctum::actingAs($me);
+
+        $this->postJson("/api/orders/{$order->id}/returns", [
+            'reason' => 'x', 'items' => [['order_item_id' => $item->id, 'quantity' => 1]],
+        ])->assertStatus(404);
+    }
+
+    public function test_cannot_return_an_ineligible_order(): void
+    {
+        $user = User::factory()->create();
+        [$order, $item] = $this->order($user, status: 'pending');
+        Sanctum::actingAs($user);
+
+        $this->postJson("/api/orders/{$order->id}/returns", [
+            'reason' => 'x', 'items' => [['order_item_id' => $item->id, 'quantity' => 1]],
+        ])->assertStatus(422);
+    }
+
+    public function test_cannot_return_an_item_not_on_the_order(): void
+    {
+        $user = User::factory()->create();
+        [$order] = $this->order($user);
+        Sanctum::actingAs($user);
+
+        $this->postJson("/api/orders/{$order->id}/returns", [
+            'reason' => 'x', 'items' => [['order_item_id' => 99999, 'quantity' => 1]],
+        ])->assertStatus(422);
+    }
+
+    public function test_cannot_return_more_than_purchased(): void
+    {
+        $user = User::factory()->create();
+        [$order, $item] = $this->order($user);
+        Sanctum::actingAs($user);
+
+        $this->postJson("/api/orders/{$order->id}/returns", [
+            'reason' => 'x', 'items' => [['order_item_id' => $item->id, 'quantity' => 5]], // bought 2
+        ])->assertStatus(422);
+    }
+
+    // --- staff approves a return (spawns the refund) -------------------------
+
+    public function test_non_admin_cannot_approve_a_return(): void
+    {
+        $user = User::factory()->create();
+        [$order, $item] = $this->order($user);
+        $return = ReturnRequest::create(['order_id' => $order->id, 'customer_id' => $user->id, 'reason' => 'x', 'status' => 'pending']);
+        $return->items()->create(['order_item_id' => $item->id, 'quantity' => 1]);
+
+        Sanctum::actingAs(User::factory()->create());
+        $this->postJson("/api/returns/{$return->id}/approve")->assertStatus(403);
+    }
+
+    public function test_admin_approves_a_return_and_it_spawns_a_refund(): void
+    {
+        $this->bindGateway(fn () => ['success' => true, 'refund_id' => 're_1']);
+        $buyer = User::factory()->create();
+        [$order, $item] = $this->order($buyer);
+        $return = ReturnRequest::create(['order_id' => $order->id, 'customer_id' => $buyer->id, 'reason' => 'x', 'status' => 'pending']);
+        $return->items()->create(['order_item_id' => $item->id, 'quantity' => 2, 'condition' => 'unopened']);
+
+        Sanctum::actingAs($this->admin());
+        $this->postJson("/api/returns/{$return->id}/approve")->assertStatus(200);
+
+        $this->assertSame('approved', $return->fresh()->status);
+        // 2 items * $50 = $100 refunded -> order fully refunded.
+        $order->refresh();
+        $this->assertSame(Order::STATUS_REFUNDED, $order->status);
+        $this->assertSame(100.0, (float) $order->refund_total);
+    }
+}


### PR DESCRIPTION
## Complete the return → refund loop

The engine that turns an approved return into a refund already existed — `ReturnRequest::approve()` spawns and processes a `Refund` (#707). What was missing: a customer had **no way to request a return**, and there was **no endpoint** for staff to approve one. This adds both.

## Endpoints

**Customer — `POST /api/orders/{order}/returns`** (`auth:sanctum`, scoped to the user's own orders → a foreign order **404s**):
- validates the order is **returnable** (`paid`/`completed`), each returned item **belongs to the order**, and `quantity ≤ purchased`;
- creates a `ReturnRequest` (status `pending`, auto-generated RMA number) + `ReturnRequestItem`s (with optional `condition`).

**Staff — `POST /api/returns/{returnRequest}/approve`** (`auth:sanctum` + admin role):
- calls `approve()`, which spawns and processes the refund (gateway void → restock → order state transition → customer email).

## Tests

+8 (`ReturnRequestApiTest`): 401 unauthenticated; customer creates a return for their order; **can't** return another user's order (404); ineligible order → 422; item not on the order → 422; quantity > purchased → 422; non-admin approve → 403; admin approve → return `approved` **and refund spawned** (order `REFUNDED`, `refund_total` = returned value). Suite **915 passed / 0 failed**. No migration.

## The refund/return picture is now end-to-end

One `Refund::process` engine, driven by three surfaces:
- **customer requests a return → staff approves** (this PR + #707),
- **Stripe webhook** reconciles a dashboard-issued refund (#728/#729),
- **direct staff refund** on an order (#730).
