### PR TITLE
feat(returns): read endpoints + mark-received (return lifecycle)

### DIFF
--- a/app/Http/Controllers/Api/ReturnRequestController.php
+++ b/app/Http/Controllers/Api/ReturnRequestController.php
@@ -14,6 +14,47 @@ class ReturnRequestController extends Controller
     private const RETURNABLE = [Order::STATUS_PAID, Order::STATUS_COMPLETED];
 
     /**
+     * List returns. Customers see only their own; staff see all (with an optional
+     * ?status filter for working the queue).
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $query = ReturnRequest::with(['items', 'order'])->latest();
+
+        if ($request->user()->hasRole(['super_admin', 'admin'])) {
+            $query->when($request->filled('status'), fn ($q) => $q->where('status', $request->string('status')));
+        } else {
+            $query->where('customer_id', $request->user()->id);
+        }
+
+        return response()->json($query->paginate(15));
+    }
+
+    /**
+     * A single return — the owner's own, or any for staff. A foreign return is
+     * not found (404), so there is no existence leak.
+     */
+    public function show(Request $request, ReturnRequest $returnRequest): JsonResponse
+    {
+        $isStaff = $request->user()->hasRole(['super_admin', 'admin']);
+        abort_unless($isStaff || (int) $returnRequest->customer_id === (int) $request->user()->id, 404);
+
+        return response()->json($returnRequest->load(['items', 'order']));
+    }
+
+    /**
+     * Staff records that the returned goods physically arrived.
+     */
+    public function markReceived(Request $request, ReturnRequest $returnRequest): JsonResponse
+    {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
+        $returnRequest->markAsReceived();
+
+        return response()->json(['message' => 'Return marked as received.', 'return' => $returnRequest->fresh()]);
+    }
+
+    /**
      * A customer requests a return for their own order. Scoped to the
      * authenticated user's orders — a foreign order is not found (404).
      */

--- a/routes/api.php
+++ b/routes/api.php
@@ -51,8 +51,13 @@ Route::middleware('auth:sanctum')->prefix('orders')->group(function () {
     Route::post('/{order}/returns', [ReturnRequestController::class, 'store']);
 });
 
-// Return approval (staff-only, role checked in the controller) — spawns the refund.
-Route::middleware('auth:sanctum')->post('/returns/{returnRequest}/approve', [ReturnRequestController::class, 'approve']);
+// Returns: customers read their own, staff read/act on all (roles checked in the controller).
+Route::middleware('auth:sanctum')->prefix('returns')->group(function () {
+    Route::get('/', [ReturnRequestController::class, 'index']);
+    Route::get('/{returnRequest}', [ReturnRequestController::class, 'show']);
+    Route::post('/{returnRequest}/approve', [ReturnRequestController::class, 'approve']);
+    Route::post('/{returnRequest}/received', [ReturnRequestController::class, 'markReceived']);
+});
 // Collection API routes
 Route::middleware('auth:sanctum')->prefix('collections')->group(function () {
     Route::get('/', [CollectionController::class, 'index']);

--- a/tests/Feature/Api/ReturnRequestReadApiTest.php
+++ b/tests/Feature/Api/ReturnRequestReadApiTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Order;
+use App\Models\ReturnRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class ReturnRequestReadApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        return User::factory()->create()->assignRole('super_admin');
+    }
+
+    private function returnFor(User $user, string $status = 'pending'): ReturnRequest
+    {
+        $order = Order::create([
+            'user_id' => $user->id,
+            'customer_email' => $user->email,
+            'total_amount' => 50,
+            'status' => Order::STATUS_PAID,
+        ]);
+
+        return ReturnRequest::create([
+            'order_id' => $order->id,
+            'customer_id' => $user->id,
+            'reason' => 'defective',
+            'status' => $status,
+        ]);
+    }
+
+    public function test_index_requires_authentication(): void
+    {
+        $this->getJson('/api/returns')->assertStatus(401);
+    }
+
+    public function test_customer_lists_only_their_own_returns(): void
+    {
+        $me = User::factory()->create();
+        $other = User::factory()->create();
+        $this->returnFor($me);
+        $this->returnFor($me);
+        $this->returnFor($other);
+
+        Sanctum::actingAs($me);
+        $response = $this->getJson('/api/returns');
+
+        $response->assertStatus(200);
+        $this->assertSame(2, $response->json('total'));
+        $customerIds = collect($response->json('data'))->pluck('customer_id')->unique()->values()->all();
+        $this->assertSame([$me->id], $customerIds);
+    }
+
+    public function test_admin_lists_all_returns_and_can_filter_by_status(): void
+    {
+        $this->returnFor(User::factory()->create(), 'pending');
+        $this->returnFor(User::factory()->create(), 'approved');
+
+        Sanctum::actingAs($this->admin());
+
+        $this->getJson('/api/returns')->assertStatus(200)->assertJsonPath('total', 2);
+        $this->getJson('/api/returns?status=approved')->assertStatus(200)->assertJsonPath('total', 1);
+    }
+
+    public function test_customer_can_view_own_return(): void
+    {
+        $me = User::factory()->create();
+        $return = $this->returnFor($me);
+        Sanctum::actingAs($me);
+
+        $this->getJson("/api/returns/{$return->id}")->assertStatus(200)->assertJsonPath('id', $return->id);
+    }
+
+    public function test_customer_cannot_view_another_users_return(): void
+    {
+        $me = User::factory()->create();
+        $return = $this->returnFor(User::factory()->create());
+        Sanctum::actingAs($me);
+
+        $this->getJson("/api/returns/{$return->id}")->assertStatus(404);
+    }
+
+    public function test_admin_can_view_any_return(): void
+    {
+        $return = $this->returnFor(User::factory()->create());
+        Sanctum::actingAs($this->admin());
+
+        $this->getJson("/api/returns/{$return->id}")->assertStatus(200);
+    }
+
+    public function test_admin_marks_a_return_received(): void
+    {
+        $return = $this->returnFor(User::factory()->create(), 'approved');
+        Sanctum::actingAs($this->admin());
+
+        $this->postJson("/api/returns/{$return->id}/received")->assertStatus(200);
+
+        $this->assertSame('received', $return->fresh()->status);
+        $this->assertNotNull($return->fresh()->received_at);
+    }
+
+    public function test_non_admin_cannot_mark_a_return_received(): void
+    {
+        $return = $this->returnFor(User::factory()->create(), 'approved');
+        Sanctum::actingAs(User::factory()->create());
+
+        $this->postJson("/api/returns/{$return->id}/received")->assertStatus(403);
+        $this->assertSame('approved', $return->fresh()->status);
+    }
+}


### PR DESCRIPTION
## Return read endpoints + mark-received

Complements the return create/approve API (#731) with the **read side** and the **`received`** lifecycle step, all on the same controller and a `/returns` route group.

- **`GET /api/returns`** — customers see only their **own** returns; staff see **all**, with an optional `?status` filter for working the queue. Paginated, eager-loading items + order.
- **`GET /api/returns/{id}`** — the owner's own return, or any for staff; a foreign return is **404** (no existence leak; `customer_id` is compared as an int to avoid the MySQL string-vs-int pitfall that bit order-history earlier).
- **`POST /api/returns/{id}/received`** — staff (admin) records that the goods physically arrived (`ReturnRequest::markAsReceived`); non-admin → 403.

`approve` was moved into the same `/returns` group — same URL, unchanged behaviour.

## Tests

+8 (`ReturnRequestReadApiTest`): index requires auth; a customer lists only their own; an admin lists all **and** can filter by status; view own → 200 / foreign → 404 / admin any → 200; admin marks a return received (status → `received`, `received_at` set); non-admin mark → 403. Existing create/approve tests still green. Suite **923 passed / 0 failed**. No migration.

The return API is now full CRUD-read + lifecycle: **request → list/view → approve (→ refund) → received**.
