### PR TITLE
feat(orders): staff API to advance an order's fulfilment status

### DIFF
--- a/app/Http/Controllers/Api/OrderStatusController.php
+++ b/app/Http/Controllers/Api/OrderStatusController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Exceptions\InvalidOrderTransitionException;
+use App\Http\Controllers\Controller;
+use App\Models\Order;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class OrderStatusController extends Controller
+{
+    /**
+     * Staff moves an order through its FULFILMENT lifecycle. Payment outcomes
+     * (paid/failed) and money states (refunded/partially_refunded) are excluded —
+     * those are driven by checkout and the refund flow, not a manual status set.
+     * The state machine enforces which moves are legal from the current status.
+     */
+    public function update(Request $request, Order $order): JsonResponse
+    {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
+        $validated = $request->validate([
+            'status' => 'required|in:processing,supplier_queued,supplier_failed,completed,cancelled',
+            'notes' => 'nullable|string|max:500',
+        ]);
+
+        try {
+            $order->transitionTo($validated['status'], $request->user()->id, $validated['notes'] ?? null);
+        } catch (InvalidOrderTransitionException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        return response()->json(['message' => 'Order status updated.', 'order' => $order->fresh()]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Api\CollectionController;
 use App\Http\Controllers\Api\DropshippingController;
 use App\Http\Controllers\Api\OrderController;
 use App\Http\Controllers\Api\OrderRefundController;
+use App\Http\Controllers\Api\OrderStatusController;
 use App\Http\Controllers\Api\ProductController;
 use App\Http\Controllers\Api\ReturnRequestController;
 use Illuminate\Http\Request;
@@ -49,6 +50,8 @@ Route::middleware('auth:sanctum')->prefix('orders')->group(function () {
     Route::post('/{order}/refund', [OrderRefundController::class, 'store']);
     // Customer requests a return for their own order.
     Route::post('/{order}/returns', [ReturnRequestController::class, 'store']);
+    // Staff-only (role checked in the controller): advance the order's fulfilment status.
+    Route::post('/{order}/status', [OrderStatusController::class, 'update']);
 });
 
 // Returns: customers read their own, staff read/act on all (roles checked in the controller).

--- a/tests/Feature/Api/OrderStatusApiTest.php
+++ b/tests/Feature/Api/OrderStatusApiTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Order;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class OrderStatusApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        return User::factory()->create()->assignRole('super_admin');
+    }
+
+    private function order(string $status = 'paid'): Order
+    {
+        return Order::create([
+            'customer_email' => 'buyer@example.com',
+            'total_amount' => 50,
+            'status' => $status,
+        ]);
+    }
+
+    public function test_unauthenticated_cannot_change_status(): void
+    {
+        $order = $this->order();
+        $this->postJson("/api/orders/{$order->id}/status", ['status' => 'processing'])->assertStatus(401);
+    }
+
+    public function test_non_admin_cannot_change_status(): void
+    {
+        $order = $this->order();
+        Sanctum::actingAs(User::factory()->create());
+
+        $this->postJson("/api/orders/{$order->id}/status", ['status' => 'processing'])->assertStatus(403);
+        $this->assertSame('paid', $order->refresh()->status);
+    }
+
+    public function test_admin_advances_a_paid_order_to_processing_with_audit_history(): void
+    {
+        $order = $this->order('paid');
+        Sanctum::actingAs($this->admin());
+
+        $this->postJson("/api/orders/{$order->id}/status", ['status' => 'processing', 'notes' => 'picking'])
+            ->assertStatus(200);
+
+        $order->refresh();
+        $this->assertSame(Order::STATUS_PROCESSING, $order->status);
+        $this->assertNotNull($order->statusHistory()->where('to_status', 'processing')->first());
+    }
+
+    public function test_admin_completes_a_processing_order(): void
+    {
+        $order = $this->order('processing');
+        Sanctum::actingAs($this->admin());
+
+        $this->postJson("/api/orders/{$order->id}/status", ['status' => 'completed'])->assertStatus(200);
+
+        $this->assertSame(Order::STATUS_COMPLETED, $order->refresh()->status);
+    }
+
+    public function test_admin_cancels_a_paid_order(): void
+    {
+        $order = $this->order('paid');
+        Sanctum::actingAs($this->admin());
+
+        $this->postJson("/api/orders/{$order->id}/status", ['status' => 'cancelled'])->assertStatus(200);
+
+        $this->assertSame(Order::STATUS_CANCELLED, $order->refresh()->status);
+    }
+
+    public function test_illegal_transition_is_rejected_and_leaves_the_order_unchanged(): void
+    {
+        $order = $this->order('completed');
+        Sanctum::actingAs($this->admin());
+
+        // completed -> processing is not a legal transition.
+        $this->postJson("/api/orders/{$order->id}/status", ['status' => 'processing'])->assertStatus(422);
+
+        $this->assertSame(Order::STATUS_COMPLETED, $order->refresh()->status);
+    }
+
+    public function test_money_statuses_are_not_settable_via_this_endpoint(): void
+    {
+        $order = $this->order('paid');
+        Sanctum::actingAs($this->admin());
+
+        // refunded is a money outcome — must go through the refund flow, not here.
+        $this->postJson("/api/orders/{$order->id}/status", ['status' => 'refunded'])->assertStatus(422);
+
+        $this->assertSame('paid', $order->refresh()->status);
+    }
+}


### PR DESCRIPTION
## Staff API to advance an order's fulfilment status

Parity with the staff **refund** (#730) and **return-approve** (#731) actions: staff can now drive an order through its **fulfilment lifecycle** over the API, safely exposing the `Order` state machine.

## Endpoint

`POST /api/orders/{order}/status` — `auth:sanctum` + admin role.

- **Target whitelisted to fulfilment states only**: `processing` / `supplier_queued` / `supplier_failed` / `completed` / `cancelled`. Payment outcomes (`paid`/`failed`) and money states (`refunded`/`partially_refunded`) are **rejected (422)** — those are driven by checkout and the refund flow, not a manual status set.
- Routes through `Order::transitionTo`, so the **transition map is enforced** and an `OrderStatusHistory` **audit row** is written. An illegal move (e.g. `completed → processing`) is caught and returned as **422** with the order unchanged — never a 500.

## Tests

+7 (`OrderStatusApiTest`): 401 unauthenticated; 403 non-admin (order unchanged); `paid → processing` (with the audit row); `processing → completed`; cancel a paid order; illegal transition → 422 + unchanged; a money status (`refunded`) → 422. Suite **930 passed / 0 failed**. No migration.

The order admin surface now covers the two staff-driven concerns end to end: **fulfilment status** (this PR) and **refunds/returns** (#730–#732).
