### PR TITLE
feat(integrations): outbound-webhook delivery log + bounded retry

### DIFF
--- a/app/Jobs/DispatchOutboundWebhook.php
+++ b/app/Jobs/DispatchOutboundWebhook.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Http;
 
 class DispatchOutboundWebhook implements ShouldQueue
 {
@@ -17,35 +16,18 @@ class DispatchOutboundWebhook implements ShouldQueue
 
     public function __construct(public int $orderId, public string $event) {}
 
+    /**
+     * Fan out one independent delivery job per subscribed active endpoint, so a
+     * slow or failing receiver retries on its own without affecting the others.
+     */
     public function handle(): void
     {
-        $order = Order::find($this->orderId);
-        if (! $order) {
+        if (! Order::whereKey($this->orderId)->exists()) {
             return;
         }
 
-        $body = json_encode([
-            'event' => $this->event,
-            'data' => [
-                'id' => $order->id,
-                'status' => $order->status,
-                'total_amount' => (float) $order->total_amount,
-                'refund_total' => (float) $order->refund_total,
-                'customer_email' => $order->customer_email,
-            ],
-        ]);
-
-        foreach (WebhookEndpoint::where('is_active', true)->get() as $endpoint) {
-            if (! $endpoint->subscribesTo($this->event)) {
-                continue;
-            }
-
-            // HMAC-SHA256 over the raw body with the endpoint's secret — the same
-            // scheme we verify on inbound Stripe webhooks.
-            Http::withHeaders([
-                'Content-Type' => 'application/json',
-                'X-Webhook-Signature' => hash_hmac('sha256', $body, $endpoint->secret),
-            ])->timeout(10)->withBody($body, 'application/json')->post($endpoint->url);
-        }
+        WebhookEndpoint::where('is_active', true)->get()
+            ->filter(fn (WebhookEndpoint $endpoint) => $endpoint->subscribesTo($this->event))
+            ->each(fn (WebhookEndpoint $endpoint) => SendWebhookDelivery::dispatch($endpoint->id, $this->orderId, $this->event));
     }
 }

--- a/app/Jobs/SendWebhookDelivery.php
+++ b/app/Jobs/SendWebhookDelivery.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Order;
+use App\Models\WebhookEndpoint;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+class SendWebhookDelivery implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /** Total delivery attempts before giving up. */
+    private const MAX_ATTEMPTS = 3;
+
+    public function __construct(
+        public int $endpointId,
+        public int $orderId,
+        public string $event,
+        public int $attempt = 1,
+    ) {}
+
+    public function handle(): void
+    {
+        $endpoint = WebhookEndpoint::find($this->endpointId);
+        $order = Order::find($this->orderId);
+        if (! $endpoint || ! $endpoint->is_active || ! $order) {
+            return;
+        }
+
+        $body = json_encode([
+            'event' => $this->event,
+            'data' => [
+                'id' => $order->id,
+                'status' => $order->status,
+                'total_amount' => (float) $order->total_amount,
+                'refund_total' => (float) $order->refund_total,
+                'customer_email' => $order->customer_email,
+            ],
+        ]);
+
+        $statusCode = null;
+        $success = false;
+        $error = null;
+
+        try {
+            $response = Http::withHeaders([
+                'Content-Type' => 'application/json',
+                'X-Webhook-Signature' => hash_hmac('sha256', $body, $endpoint->secret),
+            ])->timeout(10)->withBody($body, 'application/json')->post($endpoint->url);
+
+            $statusCode = $response->status();
+            $success = $response->successful();
+        } catch (Throwable $e) {
+            $error = substr($e->getMessage(), 0, 500);
+        }
+
+        $endpoint->deliveries()->create([
+            'order_id' => $order->id,
+            'event' => $this->event,
+            'status_code' => $statusCode,
+            'success' => $success,
+            'attempt' => $this->attempt,
+            'error' => $error,
+        ]);
+
+        // Bounded retry WITHOUT throwing: re-queue a later attempt so a failing
+        // (or down) receiver can never bubble an exception up into the order
+        // transition that triggered it. On a real queue the delay backs off; on
+        // the sync queue it runs immediately, still bounded by MAX_ATTEMPTS.
+        if (! $success && $this->attempt < self::MAX_ATTEMPTS) {
+            self::dispatch($this->endpointId, $this->orderId, $this->event, $this->attempt + 1)
+                ->delay(now()->addSeconds(30 * $this->attempt));
+        }
+    }
+}

--- a/app/Models/WebhookDelivery.php
+++ b/app/Models/WebhookDelivery.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WebhookDelivery extends Model
+{
+    protected $fillable = [
+        'webhook_endpoint_id',
+        'order_id',
+        'event',
+        'status_code',
+        'success',
+        'attempt',
+        'error',
+    ];
+
+    protected $casts = [
+        'success' => 'boolean',
+        'status_code' => 'integer',
+        'attempt' => 'integer',
+    ];
+
+    public function endpoint(): BelongsTo
+    {
+        return $this->belongsTo(WebhookEndpoint::class, 'webhook_endpoint_id');
+    }
+}

--- a/app/Models/WebhookEndpoint.php
+++ b/app/Models/WebhookEndpoint.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class WebhookEndpoint extends Model
 {
@@ -20,5 +21,10 @@ class WebhookEndpoint extends Model
     public function subscribesTo(string $event): bool
     {
         return in_array($event, (array) $this->events, true);
+    }
+
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
     }
 }

--- a/database/migrations/2026_07_17_000000_create_webhook_deliveries_table.php
+++ b/database/migrations/2026_07_17_000000_create_webhook_deliveries_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhook_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('webhook_endpoint_id')->constrained()->cascadeOnDelete();
+            $table->unsignedBigInteger('order_id')->nullable();
+            $table->string('event');
+            $table->unsignedSmallInteger('status_code')->nullable();
+            $table->boolean('success')->default(false);
+            $table->unsignedTinyInteger('attempt')->default(1);
+            $table->text('error')->nullable();
+            $table->timestamps();
+
+            $table->index(['webhook_endpoint_id', 'success']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_deliveries');
+    }
+};

--- a/tests/Feature/WebhookDeliveryLogTest.php
+++ b/tests/Feature/WebhookDeliveryLogTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Order;
+use App\Models\WebhookDelivery;
+use App\Models\WebhookEndpoint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class WebhookDeliveryLogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function endpoint(): WebhookEndpoint
+    {
+        return WebhookEndpoint::create([
+            'url' => 'https://example.test/hook',
+            'secret' => 'whsec_local',
+            'events' => ['order.paid'],
+            'is_active' => true,
+        ]);
+    }
+
+    private function pendingOrder(): Order
+    {
+        return Order::create(['customer_email' => 'b@example.com', 'total_amount' => 50, 'status' => 'pending']);
+    }
+
+    public function test_a_successful_delivery_is_logged(): void
+    {
+        Http::fake(['*' => Http::response('', 200)]);
+        $endpoint = $this->endpoint();
+
+        $this->pendingOrder()->transitionTo(Order::STATUS_PAID);
+
+        $this->assertDatabaseHas('webhook_deliveries', [
+            'webhook_endpoint_id' => $endpoint->id,
+            'event' => 'order.paid',
+            'success' => true,
+            'status_code' => 200,
+            'attempt' => 1,
+        ]);
+        $this->assertSame(1, WebhookDelivery::count());
+    }
+
+    public function test_a_failing_delivery_is_retried_a_bounded_number_of_times_and_logged(): void
+    {
+        Http::fake(['*' => Http::response('nope', 500)]);
+        $endpoint = $this->endpoint();
+
+        // Must NOT throw out of the transition even though every attempt fails.
+        $this->pendingOrder()->transitionTo(Order::STATUS_PAID);
+
+        // 3 bounded attempts, all logged as failures.
+        $this->assertSame(3, WebhookDelivery::where('webhook_endpoint_id', $endpoint->id)->count());
+        $this->assertSame(0, WebhookDelivery::where('success', true)->count());
+        $this->assertEqualsCanonicalizing([1, 2, 3], WebhookDelivery::pluck('attempt')->all());
+    }
+
+    public function test_a_connection_error_is_recorded_not_fatal(): void
+    {
+        Http::fake(fn () => throw new ConnectionException('connection refused'));
+        $endpoint = $this->endpoint();
+
+        $this->pendingOrder()->transitionTo(Order::STATUS_PAID);
+
+        $delivery = WebhookDelivery::where('webhook_endpoint_id', $endpoint->id)->first();
+        $this->assertNotNull($delivery);
+        $this->assertFalse($delivery->success);
+        $this->assertNull($delivery->status_code);
+        $this->assertStringContainsString('connection refused', $delivery->error);
+    }
+}


### PR DESCRIPTION
## Outbound-webhook delivery log + bounded retry

Hardens the outbound webhooks (#734/#735) toward **at-least-once + observability**. Previously a delivery was fire-and-forget: a down receiver silently dropped the event with no record.

## Change

- **`webhook_deliveries` table + `WebhookDelivery` model + `WebhookEndpoint::deliveries()`** — one row per delivery **attempt**: endpoint, order, event, `status_code`, `success`, `attempt`, `error`.
- **`DispatchOutboundWebhook` is now a fan-out planner** — it dispatches one **independent `SendWebhookDelivery` job per subscribed active endpoint**, so a slow or failing receiver retries on its own without blocking the others.
- **`SendWebhookDelivery`** POSTs the signed payload, records the outcome, and on failure **re-dispatches a later attempt (up to 3) WITHOUT throwing**. Not throwing is deliberate: a down/failing partner endpoint can never bubble an exception up into the **order transition** that triggered it — safe even under the sync queue. On a real queue the delay backs off (`30s * attempt`); on sync it runs immediately, still bounded by `MAX_ATTEMPTS = 3`. Connection errors are caught and recorded (`status_code` null + `error`), not fatal.

Existing #734 behaviour is unchanged — the same signed POST goes to subscribers, and those tests still pass after the fan-out refactor.

## Tests

+3 (`WebhookDeliveryLogTest`): a successful delivery is logged (`success`, `status_code` 200, `attempt` 1); a persistently-failing endpoint logs **exactly 3 bounded attempts** (all failures, and the transition does **not** throw); a connection error is recorded (no status code, error text) and is not fatal. Migration **MySQL 8.4-verified** (FK to `webhook_endpoints`, cascade delete). Suite **944 passed / 0 failed**.

## Follow-up

A `webhooks:retry-failed` scheduled command (re-queue deliveries still failing after the in-band attempts) and a deliveries read endpoint for the dashboard are the natural next steps for full at-least-once + visibility.
