### PR TITLE
feat(integrations): webhook delivery-log read endpoint

### DIFF
--- a/app/Http/Controllers/Api/WebhookEndpointController.php
+++ b/app/Http/Controllers/Api/WebhookEndpointController.php
@@ -65,6 +65,19 @@ class WebhookEndpointController extends Controller
         return response()->json(['message' => 'Webhook endpoint deleted.']);
     }
 
+    /** Delivery attempt log for an endpoint — newest first, optionally filtered by ?success=0|1. */
+    public function deliveries(Request $request, WebhookEndpoint $webhookEndpoint): JsonResponse
+    {
+        $this->authorizeStaff($request);
+
+        $deliveries = $webhookEndpoint->deliveries()
+            ->when($request->has('success'), fn ($q) => $q->where('success', $request->boolean('success')))
+            ->latest()
+            ->paginate(25);
+
+        return response()->json($deliveries);
+    }
+
     private function authorizeStaff(Request $request): void
     {
         abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);

--- a/routes/api.php
+++ b/routes/api.php
@@ -61,6 +61,7 @@ Route::middleware('auth:sanctum')->prefix('webhook-endpoints')->group(function (
     Route::post('/', [WebhookEndpointController::class, 'store']);
     Route::put('/{webhookEndpoint}', [WebhookEndpointController::class, 'update']);
     Route::delete('/{webhookEndpoint}', [WebhookEndpointController::class, 'destroy']);
+    Route::get('/{webhookEndpoint}/deliveries', [WebhookEndpointController::class, 'deliveries']);
 });
 
 // Returns: customers read their own, staff read/act on all (roles checked in the controller).

--- a/tests/Feature/Api/WebhookDeliveryReadApiTest.php
+++ b/tests/Feature/Api/WebhookDeliveryReadApiTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use App\Models\WebhookDelivery;
+use App\Models\WebhookEndpoint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class WebhookDeliveryReadApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        return User::factory()->create()->assignRole('super_admin');
+    }
+
+    private function endpoint(): WebhookEndpoint
+    {
+        return WebhookEndpoint::create([
+            'url' => 'https://example.test/hook',
+            'secret' => 'whsec_seed',
+            'events' => ['order.paid'],
+            'is_active' => true,
+        ]);
+    }
+
+    private function delivery(WebhookEndpoint $endpoint, bool $success, int $status = 200): WebhookDelivery
+    {
+        return $endpoint->deliveries()->create([
+            'order_id' => 1,
+            'event' => 'order.paid',
+            'status_code' => $status,
+            'success' => $success,
+            'attempt' => 1,
+        ]);
+    }
+
+    public function test_non_admin_cannot_read_deliveries(): void
+    {
+        $endpoint = $this->endpoint();
+        Sanctum::actingAs(User::factory()->create());
+
+        $this->getJson("/api/webhook-endpoints/{$endpoint->id}/deliveries")->assertStatus(403);
+    }
+
+    public function test_admin_reads_deliveries_for_an_endpoint_only(): void
+    {
+        $endpoint = $this->endpoint();
+        $other = $this->endpoint();
+        $this->delivery($endpoint, true);
+        $this->delivery($endpoint, false, 500);
+        $this->delivery($other, true);
+
+        Sanctum::actingAs($this->admin());
+        $response = $this->getJson("/api/webhook-endpoints/{$endpoint->id}/deliveries");
+
+        $response->assertStatus(200)->assertJsonPath('total', 2);
+        $endpointIds = collect($response->json('data'))->pluck('webhook_endpoint_id')->unique()->all();
+        $this->assertSame([$endpoint->id], $endpointIds);
+    }
+
+    public function test_deliveries_can_be_filtered_by_success(): void
+    {
+        $endpoint = $this->endpoint();
+        $this->delivery($endpoint, true);
+        $this->delivery($endpoint, false, 500);
+        $this->delivery($endpoint, false, 502);
+
+        Sanctum::actingAs($this->admin());
+
+        $this->getJson("/api/webhook-endpoints/{$endpoint->id}/deliveries?success=0")
+            ->assertStatus(200)->assertJsonPath('total', 2);
+        $this->getJson("/api/webhook-endpoints/{$endpoint->id}/deliveries?success=1")
+            ->assertStatus(200)->assertJsonPath('total', 1);
+    }
+}


### PR DESCRIPTION
## Webhook delivery-log read endpoint

Completes the outbound-webhook observability story (#734–#736): staff can now inspect an endpoint's delivery history — which events delivered, which failed, and why.

`GET /api/webhook-endpoints/{webhookEndpoint}/deliveries` — `auth:sanctum` + admin role:
- paginated, **newest first**, scoped to that endpoint;
- optional `?success=0|1` filter to isolate failures from successes.

## Tests

+3 (`WebhookDeliveryReadApiTest`): non-admin → 403; admin reads **only that endpoint's** deliveries (not another endpoint's); the `?success` filter splits failures from successes. Suite **947 passed / 0 failed**. No migration (reads the `webhook_deliveries` log from #736).

The outbound-webhook feature is now complete end to end: **configure endpoints (#735) → `transitionTo` fires `order.<status>` → signed per-endpoint delivery with bounded retry (#734/#736) → inspect the delivery log (this PR).**