### PR TITLE
feat(cart): persist the signed-in cart + merge guest cart on login

### DIFF
--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -3,22 +3,32 @@
 namespace App\Http\Controllers;
 
 use App\Models\Product;
+use App\Services\CartService;
 use App\Services\CouponService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 
 class CartController extends Controller
 {
+    /** Mirror the session cart to the signed-in user's persistent cart (no-op for guests). */
+    private function persistCart(): void
+    {
+        if (Auth::check()) {
+            app(CartService::class)->persistForUser(Auth::user(), Session::get('cart', []));
+        }
+    }
+
     public function add(Request $request, Product $product)
     {
         $quantity = $request->input('quantity', 1);
-        
+
         if ($product->inventory_count < $quantity) {
             return redirect()->back()->with('error', 'Not enough inventory available.');
         }
 
         $cart = Session::get('cart', []);
-        
+
         if (isset($cart[$product->id])) {
             $cart[$product->id]['quantity'] += $quantity;
         } else {
@@ -31,7 +41,8 @@ class CartController extends Controller
         }
 
         Session::put('cart', $cart);
-        
+        $this->persistCart();
+
         return redirect()->back()->with('success', 'Product added to cart successfully!');
     }
 
@@ -43,19 +54,19 @@ class CartController extends Controller
     public function update(Request $request, $productId)
     {
         $quantity = $request->input('quantity', 1);
-        
+
         if ($quantity < 1) {
             return redirect()->back()->with('error', 'Quantity must be at least 1.');
         }
 
         $cart = Session::get('cart', []);
-        
-        if (!isset($cart[$productId])) {
+
+        if (! isset($cart[$productId])) {
             return redirect()->back()->with('error', 'Product not found in cart.');
         }
 
         $product = Product::find($productId);
-        if (!$product) {
+        if (! $product) {
             return redirect()->back()->with('error', 'Product not found.');
         }
 
@@ -65,20 +76,23 @@ class CartController extends Controller
 
         $cart[$productId]['quantity'] = $quantity;
         Session::put('cart', $cart);
-        
+        $this->persistCart();
+
         return redirect()->back()->with('success', 'Cart updated successfully!');
     }
 
     public function remove($productId)
     {
         $cart = Session::get('cart', []);
-        
+
         if (isset($cart[$productId])) {
             unset($cart[$productId]);
             Session::put('cart', $cart);
+            $this->persistCart();
+
             return redirect()->back()->with('success', 'Product removed from cart successfully!');
         }
-        
+
         return redirect()->back()->with('error', 'Product not found in cart.');
     }
 
@@ -86,6 +100,8 @@ class CartController extends Controller
     {
         Session::forget('cart');
         Session::forget('coupon');
+        $this->persistCart();
+
         return redirect()->back()->with('success', 'Cart cleared successfully!');
     }
 
@@ -112,6 +128,7 @@ class CartController extends Controller
                 'discount' => $result['discount'],
                 'coupon_id' => $result['coupon']->id,
             ]);
+
             return redirect()->back()->with('success', $result['message']);
         }
 
@@ -121,6 +138,7 @@ class CartController extends Controller
     public function removeCoupon()
     {
         Session::forget('coupon');
+
         return redirect()->back()->with('success', 'Coupon removed successfully!');
     }
 }

--- a/app/Listeners/MergeGuestCartOnLogin.php
+++ b/app/Listeners/MergeGuestCartOnLogin.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Models\User;
+use App\Services\CartService;
+use Illuminate\Auth\Events\Login;
+
+class MergeGuestCartOnLogin
+{
+    public function __construct(private CartService $cartService) {}
+
+    public function handle(Login $event): void
+    {
+        if ($event->user instanceof User) {
+            $this->cartService->mergeIntoSession($event->user);
+        }
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Listeners\MergeGuestCartOnLogin;
+use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -17,6 +19,9 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Registered::class => [
             SendEmailVerificationNotification::class,
+        ],
+        Login::class => [
+            MergeGuestCartOnLogin::class,
         ],
     ];
 

--- a/app/Services/CartService.php
+++ b/app/Services/CartService.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\CartItem;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Session;
+
+/**
+ * Bridges the session cart (the live path used by checkout) with a persistent
+ * cart_items store so a signed-in shopper's cart survives logout / another device.
+ */
+class CartService
+{
+    /**
+     * Replace the user's stored cart with the current session cart. Guests have
+     * no user_id, so nothing is stored for them.
+     */
+    public function persistForUser(User $user, array $sessionCart): void
+    {
+        DB::transaction(function () use ($user, $sessionCart) {
+            CartItem::where('user_id', $user->id)->delete();
+
+            $sessionId = Session::getId();
+            foreach ($sessionCart as $productId => $line) {
+                CartItem::create([
+                    'user_id' => $user->id,
+                    'session_id' => $sessionId,
+                    'product_id' => $productId,
+                    'quantity' => $line['quantity'],
+                    'price' => $line['price'],
+                ]);
+            }
+        });
+    }
+
+    /**
+     * On login, fold the user's stored cart into their current (guest) session
+     * cart — quantities for the same product are combined — then re-persist the
+     * merged result so it stays saved.
+     */
+    public function mergeIntoSession(User $user): void
+    {
+        $cart = Session::get('cart', []);
+
+        foreach (CartItem::where('user_id', $user->id)->with('products')->get() as $item) {
+            $productId = $item->product_id;
+
+            if (isset($cart[$productId])) {
+                $cart[$productId]['quantity'] += $item->quantity;
+            } else {
+                $product = $item->products;
+                $cart[$productId] = [
+                    'name' => $product?->name,
+                    'price' => (float) $item->price,
+                    'quantity' => $item->quantity,
+                    'is_downloadable' => (bool) ($product?->is_downloadable),
+                ];
+            }
+        }
+
+        Session::put('cart', $cart);
+        $this->persistForUser($user, $cart);
+    }
+}

--- a/tests/Feature/CartPersistenceTest.php
+++ b/tests/Feature/CartPersistenceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\CartItem;
+use App\Models\Product;
+use App\Models\User;
+use App\Services\CartService;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Session;
+use Tests\TestCase;
+
+class CartPersistenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function saved(User $user, Product $product, int $qty, float $price = 10): CartItem
+    {
+        return CartItem::create([
+            'user_id' => $user->id,
+            'session_id' => 'old-session',
+            'product_id' => $product->id,
+            'quantity' => $qty,
+            'price' => $price,
+        ]);
+    }
+
+    public function test_merge_combines_saved_and_session_carts(): void
+    {
+        $user = User::factory()->create();
+        $saved = Product::factory()->create();
+        $guest = Product::factory()->create();
+        $this->saved($user, $saved, 2);
+        Session::put('cart', [$guest->id => ['name' => $guest->name, 'price' => 5, 'quantity' => 1, 'is_downloadable' => false]]);
+
+        app(CartService::class)->mergeIntoSession($user);
+
+        $cart = Session::get('cart');
+        $this->assertEquals(2, $cart[$saved->id]['quantity']);
+        $this->assertEquals(1, $cart[$guest->id]['quantity']);
+    }
+
+    public function test_merge_sums_quantities_for_the_same_product(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create();
+        $this->saved($user, $product, 2);
+        Session::put('cart', [$product->id => ['name' => $product->name, 'price' => 10, 'quantity' => 3, 'is_downloadable' => false]]);
+
+        app(CartService::class)->mergeIntoSession($user);
+
+        $this->assertEquals(5, Session::get('cart')[$product->id]['quantity']);
+    }
+
+    public function test_login_event_merges_the_saved_cart_into_the_session(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create();
+        $this->saved($user, $product, 4);
+
+        event(new Login('web', $user, false));
+
+        $this->assertEquals(4, Session::get('cart')[$product->id]['quantity']);
+    }
+
+    public function test_authenticated_add_persists_the_cart(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create(['inventory_count' => 10]);
+
+        $this->actingAs($user)->post(route('cart.add', $product), ['quantity' => 2]);
+
+        $this->assertDatabaseHas('cart_items', [
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+            'quantity' => 2,
+        ]);
+    }
+
+    public function test_guest_add_does_not_persist(): void
+    {
+        $product = Product::factory()->create(['inventory_count' => 10]);
+
+        $this->post(route('cart.add', $product), ['quantity' => 1]);
+
+        $this->assertDatabaseCount('cart_items', 0);
+    }
+}


### PR DESCRIPTION
## Cart persistence + guest→user merge (TASKS 1.2)

The cart lived **only in the session**, so a shopper who added items as a guest **lost them on login**, and a saved cart never followed them to another device. The `cart_items` table + `CartItem` model existed but were unused.

This wires `cart_items` in as a **persistence layer without disturbing the session cart that checkout reads**.

## Change

- **`CartService::persistForUser`** — mirrors the session cart into `cart_items` for the signed-in user (replace-on-write). Guests have no `user_id`, so nothing is stored for them.
- **`CartService::mergeIntoSession`** — on login, folds the user's **stored** cart into their current **guest** session cart (quantities for the same product are **combined**), then re-persists the merged result.
- **`MergeGuestCartOnLogin`** listener on `Illuminate\Auth\Events\Login` runs the merge.
- **`CartController`** `add`/`update`/`remove`/`clear` now persist after mutating the session cart (no-op for guests).

**Checkout is untouched** — it still reads the session cart, which now simply carries the merged/restored items.

## Tests

+5 (`CartPersistenceTest`): merge combines a saved cart with a guest session cart; merge **sums** quantities for the same product; the `Login` event triggers the merge; an authenticated `add` persists to `cart_items`; a guest `add` persists nothing. Full suite **955 passed / 0 failed** (the login-event listener fires on every login — no existing auth test regressed). No migration (`cart_items` already existed).

## Notes / follow-ups

- Persistence is authenticated-only (the `cart_items` schema requires `user_id`). A cookie-token guest cart would be a separate step.
- A "restore my saved cart" read endpoint / cross-device sync UI is a natural follow-up now that the store is populated.
