### PR TITLE
feat(cart): headless cart API over the persistent cart_items store

### DIFF
--- a/app/Http/Controllers/Api/CartController.php
+++ b/app/Http/Controllers/Api/CartController.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\CartItem;
+use App\Models\Product;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Headless cart for API clients, backed by the persistent cart_items store.
+ * Every query is scoped by user_id — that scoping is the IDOR guard, so a
+ * client can only ever see or mutate its own cart.
+ */
+class CartController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $items = CartItem::where('user_id', $request->user()->id)
+            ->with('products')
+            ->get();
+
+        return response()->json([
+            'data' => $items,
+            'subtotal' => (float) $items->sum(fn (CartItem $i) => $i->price * $i->quantity),
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'product_id' => ['required', 'integer', 'exists:products,id'],
+            'quantity' => ['required', 'integer', 'min:1'],
+        ]);
+
+        $product = Product::findOrFail($data['product_id']);
+
+        $item = CartItem::firstOrNew([
+            'user_id' => $request->user()->id,
+            'product_id' => $product->id,
+        ]);
+        $quantity = ($item->quantity ?? 0) + $data['quantity'];
+
+        if ($product->inventory_count < $quantity) {
+            return $this->outOfStock($product->inventory_count);
+        }
+
+        $item->fill([
+            'session_id' => $item->session_id ?? 'api',
+            'quantity' => $quantity,
+            'price' => $product->price,
+        ])->save();
+
+        return response()->json(['data' => $item->load('products')], 201);
+    }
+
+    public function update(Request $request, int $product): JsonResponse
+    {
+        $data = $request->validate([
+            'quantity' => ['required', 'integer', 'min:1'],
+        ]);
+
+        $product = Product::findOrFail($product);
+
+        if ($product->inventory_count < $data['quantity']) {
+            return $this->outOfStock($product->inventory_count);
+        }
+
+        $item = CartItem::where('user_id', $request->user()->id)
+            ->where('product_id', $product->id)
+            ->firstOrFail();
+
+        $item->update(['quantity' => $data['quantity']]);
+
+        return response()->json(['data' => $item->load('products')]);
+    }
+
+    public function destroy(Request $request, int $product): JsonResponse
+    {
+        CartItem::where('user_id', $request->user()->id)
+            ->where('product_id', $product)
+            ->delete();
+
+        return response()->json(['message' => 'Item removed from cart.']);
+    }
+
+    public function clear(Request $request): JsonResponse
+    {
+        CartItem::where('user_id', $request->user()->id)->delete();
+
+        return response()->json(['message' => 'Cart cleared.']);
+    }
+
+    private function outOfStock(int $available): JsonResponse
+    {
+        return response()->json([
+            'message' => 'Requested quantity exceeds available stock.',
+            'available' => $available,
+        ], 422);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\CartController;
 use App\Http\Controllers\Api\CollectionController;
 use App\Http\Controllers\Api\DropshippingController;
 use App\Http\Controllers\Api\OrderController;
@@ -71,6 +72,15 @@ Route::middleware('auth:sanctum')->prefix('returns')->group(function () {
     Route::post('/{returnRequest}/approve', [ReturnRequestController::class, 'approve']);
     Route::post('/{returnRequest}/received', [ReturnRequestController::class, 'markReceived']);
 });
+// Cart API routes (headless: read/manage the authenticated user's persistent cart).
+Route::middleware('auth:sanctum')->prefix('cart')->group(function () {
+    Route::get('/', [CartController::class, 'index']);
+    Route::post('/', [CartController::class, 'store']);
+    Route::put('/{product}', [CartController::class, 'update']);
+    Route::delete('/{product}', [CartController::class, 'destroy']);
+    Route::delete('/', [CartController::class, 'clear']);
+});
+
 // Collection API routes
 Route::middleware('auth:sanctum')->prefix('collections')->group(function () {
     Route::get('/', [CollectionController::class, 'index']);

--- a/tests/Feature/Api/CartApiTest.php
+++ b/tests/Feature/Api/CartApiTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\CartItem;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CartApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function product(int $stock = 10, float $price = 25): Product
+    {
+        return Product::factory()->create(['inventory_count' => $stock, 'price' => $price]);
+    }
+
+    public function test_cart_endpoints_require_authentication(): void
+    {
+        $this->getJson('/api/cart')->assertUnauthorized();
+        $this->postJson('/api/cart', [])->assertUnauthorized();
+    }
+
+    public function test_index_returns_only_the_users_own_items_with_subtotal(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+        $p1 = $this->product(price: 10);
+        $p2 = $this->product(price: 5);
+        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $p1->id, 'quantity' => 2, 'price' => 10]);
+        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $p2->id, 'quantity' => 1, 'price' => 5]);
+        CartItem::create(['user_id' => $other->id, 'session_id' => 'api', 'product_id' => $p1->id, 'quantity' => 9, 'price' => 10]);
+
+        $this->actingAs($user)->getJson('/api/cart')
+            ->assertOk()
+            ->assertJsonCount(2, 'data')
+            ->assertJsonPath('subtotal', 25);
+    }
+
+    public function test_store_adds_an_item(): void
+    {
+        $user = User::factory()->create();
+        $product = $this->product(price: 12);
+
+        $this->actingAs($user)->postJson('/api/cart', ['product_id' => $product->id, 'quantity' => 2])
+            ->assertCreated();
+
+        $this->assertDatabaseHas('cart_items', [
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+            'quantity' => 2,
+            'price' => 12,
+        ]);
+    }
+
+    public function test_store_increments_quantity_for_an_existing_line(): void
+    {
+        $user = User::factory()->create();
+        $product = $this->product();
+        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+
+        $this->actingAs($user)->postJson('/api/cart', ['product_id' => $product->id, 'quantity' => 3])
+            ->assertCreated();
+
+        $this->assertDatabaseCount('cart_items', 1);
+        $this->assertDatabaseHas('cart_items', ['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 4]);
+    }
+
+    public function test_store_rejects_quantity_beyond_available_stock(): void
+    {
+        $user = User::factory()->create();
+        $product = $this->product(stock: 3);
+
+        $this->actingAs($user)->postJson('/api/cart', ['product_id' => $product->id, 'quantity' => 5])
+            ->assertStatus(422);
+
+        $this->assertDatabaseCount('cart_items', 0);
+    }
+
+    public function test_update_sets_the_quantity(): void
+    {
+        $user = User::factory()->create();
+        $product = $this->product(stock: 10);
+        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+
+        $this->actingAs($user)->putJson("/api/cart/{$product->id}", ['quantity' => 6])
+            ->assertOk();
+
+        $this->assertDatabaseHas('cart_items', ['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 6]);
+    }
+
+    public function test_update_rejects_quantity_beyond_stock(): void
+    {
+        $user = User::factory()->create();
+        $product = $this->product(stock: 2);
+        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+
+        $this->actingAs($user)->putJson("/api/cart/{$product->id}", ['quantity' => 9])
+            ->assertStatus(422);
+    }
+
+    public function test_update_404s_for_an_item_not_in_the_users_cart(): void
+    {
+        $user = User::factory()->create();
+        $product = $this->product();
+
+        $this->actingAs($user)->putJson("/api/cart/{$product->id}", ['quantity' => 2])
+            ->assertNotFound();
+    }
+
+    public function test_destroy_removes_the_users_line(): void
+    {
+        $user = User::factory()->create();
+        $product = $this->product();
+        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+
+        $this->actingAs($user)->deleteJson("/api/cart/{$product->id}")->assertOk();
+
+        $this->assertDatabaseCount('cart_items', 0);
+    }
+
+    public function test_destroy_cannot_touch_another_users_line(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+        $product = $this->product();
+        CartItem::create(['user_id' => $other->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+
+        $this->actingAs($user)->deleteJson("/api/cart/{$product->id}")->assertOk();
+
+        // The other user's line is untouched — scoping prevents cross-user deletes.
+        $this->assertDatabaseHas('cart_items', ['user_id' => $other->id, 'product_id' => $product->id]);
+    }
+
+    public function test_clear_empties_only_the_users_cart(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+        $product = $this->product();
+        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+        CartItem::create(['user_id' => $other->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+
+        $this->actingAs($user)->deleteJson('/api/cart')->assertOk();
+
+        $this->assertDatabaseMissing('cart_items', ['user_id' => $user->id]);
+        $this->assertDatabaseHas('cart_items', ['user_id' => $other->id]);
+    }
+}


### PR DESCRIPTION
## What

Customer-facing REST cart (parity with the orders API), backed by the `cart_items` store that #739 began persisting. Lets headless / mobile clients read and manage the signed-in shopper's cart.

| Method | Route | Action |
|---|---|---|
| GET | `/api/cart` | list the user's items + `subtotal` |
| POST | `/api/cart` | add an item (increments an existing line), stock-checked |
| PUT | `/api/cart/{product}` | set quantity, stock-checked |
| DELETE | `/api/cart/{product}` | remove a line |
| DELETE | `/api/cart` | clear the cart |

## Why

#739 made the signed-in cart persist in `cart_items` but only the session (web) path could touch it. This exposes it over the API so a mobile/headless client has real cart management, not just checkout.

## Guardrails

- `auth:sanctum` on every route.
- **IDOR guard:** every query scoped by `user_id` — a client can only see/mutate its own cart. Cross-user delete is a no-op; cross-user read never returns another cart.
- **Stock check** on add and update — 422 when requested qty exceeds `inventory_count` (add accounts for the existing line qty).
- Product resolved by id via `findOrFail` — Product's route key is `slug`, so numeric model-binding would 404 (same reason `ProductController` looks up manually).
- No migration — `cart_items` already exists.

## Tests

+11 (`tests/Feature/Api/CartApiTest.php`): auth required, user-scoped index + subtotal, add, increment-existing, stock-reject on add/update, update-404 for a foreign line, remove, cross-user isolation on delete + clear.

Full suite **966 passed / 0 failed**.