### PR TITLE
fix(security): close five verified authorization / IDOR holes

### DIFF
--- a/app/Http/Controllers/Api/CollectionController.php
+++ b/app/Http/Controllers/Api/CollectionController.php
@@ -16,9 +16,6 @@ class CollectionController extends Controller
 {
     /**
      * Display a listing of collections.
-     *
-     * @param Request $request
-     * @return JsonResponse
      */
     public function index(Request $request): JsonResponse
     {
@@ -61,12 +58,11 @@ class CollectionController extends Controller
 
     /**
      * Store a newly created collection.
-     *
-     * @param Request $request
-     * @return JsonResponse
      */
     public function store(Request $request): JsonResponse
     {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255',
             'slug' => 'nullable|string|max:255|unique:collections,slug',
@@ -77,12 +73,12 @@ class CollectionController extends Controller
         if ($validator->fails()) {
             return response()->json([
                 'success' => false,
-                'errors' => $validator->errors()
+                'errors' => $validator->errors(),
             ], 422);
         }
 
         $data = $validator->validated();
-        
+
         // Auto-generate slug if not provided
         if (empty($data['slug'])) {
             $data['slug'] = Str::slug($data['name']);
@@ -93,15 +89,12 @@ class CollectionController extends Controller
         return response()->json([
             'success' => true,
             'message' => 'Collection created successfully',
-            'data' => $collection
+            'data' => $collection,
         ], 201);
     }
 
     /**
      * Display the specified collection.
-     *
-     * @param string $idOrSlug
-     * @return JsonResponse
      */
     public function show(string $idOrSlug): JsonResponse
     {
@@ -110,34 +103,32 @@ class CollectionController extends Controller
             ? ProductCollection::with('products')->find($idOrSlug)
             : ProductCollection::with('products')->where('slug', $idOrSlug)->first();
 
-        if (!$collection) {
+        if (! $collection) {
             return response()->json([
                 'success' => false,
-                'message' => 'Collection not found'
+                'message' => 'Collection not found',
             ], 404);
         }
 
         return response()->json([
             'success' => true,
-            'data' => $collection
+            'data' => $collection,
         ]);
     }
 
     /**
      * Update the specified collection.
-     *
-     * @param Request $request
-     * @param int $id
-     * @return JsonResponse
      */
     public function update(Request $request, int $id): JsonResponse
     {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
         $collection = ProductCollection::find($id);
 
-        if (!$collection) {
+        if (! $collection) {
             return response()->json([
                 'success' => false,
-                'message' => 'Collection not found'
+                'message' => 'Collection not found',
             ], 404);
         }
 
@@ -151,14 +142,14 @@ class CollectionController extends Controller
         if ($validator->fails()) {
             return response()->json([
                 'success' => false,
-                'errors' => $validator->errors()
+                'errors' => $validator->errors(),
             ], 422);
         }
 
         $data = $validator->validated();
-        
+
         // Auto-generate slug if name is updated but slug is not provided
-        if (isset($data['name']) && !isset($data['slug'])) {
+        if (isset($data['name']) && ! isset($data['slug'])) {
             $data['slug'] = Str::slug($data['name']);
         }
 
@@ -167,25 +158,23 @@ class CollectionController extends Controller
         return response()->json([
             'success' => true,
             'message' => 'Collection updated successfully',
-            'data' => $collection->fresh()
+            'data' => $collection->fresh(),
         ]);
     }
 
     /**
      * Add products to a collection.
-     *
-     * @param Request $request
-     * @param int $id
-     * @return JsonResponse
      */
     public function addProducts(Request $request, int $id): JsonResponse
     {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
         $collection = ProductCollection::find($id);
 
-        if (!$collection) {
+        if (! $collection) {
             return response()->json([
                 'success' => false,
-                'message' => 'Collection not found'
+                'message' => 'Collection not found',
             ], 404);
         }
 
@@ -199,7 +188,7 @@ class CollectionController extends Controller
         if ($validator->fails()) {
             return response()->json([
                 'success' => false,
-                'errors' => $validator->errors()
+                'errors' => $validator->errors(),
             ], 422);
         }
 
@@ -210,7 +199,7 @@ class CollectionController extends Controller
         $syncData = [];
         foreach ($productIds as $index => $productId) {
             $syncData[$productId] = [
-                'quantity' => $quantities[$index] ?? 1
+                'quantity' => $quantities[$index] ?? 1,
             ];
         }
 
@@ -220,25 +209,23 @@ class CollectionController extends Controller
         return response()->json([
             'success' => true,
             'message' => 'Products added to collection successfully',
-            'data' => $collection->load('products')
+            'data' => $collection->load('products'),
         ]);
     }
 
     /**
      * Remove products from a collection.
-     *
-     * @param Request $request
-     * @param int $id
-     * @return JsonResponse
      */
     public function removeProducts(Request $request, int $id): JsonResponse
     {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
         $collection = ProductCollection::find($id);
 
-        if (!$collection) {
+        if (! $collection) {
             return response()->json([
                 'success' => false,
-                'message' => 'Collection not found'
+                'message' => 'Collection not found',
             ], 404);
         }
 
@@ -250,7 +237,7 @@ class CollectionController extends Controller
         if ($validator->fails()) {
             return response()->json([
                 'success' => false,
-                'errors' => $validator->errors()
+                'errors' => $validator->errors(),
             ], 422);
         }
 
@@ -262,24 +249,23 @@ class CollectionController extends Controller
         return response()->json([
             'success' => true,
             'message' => 'Products removed from collection successfully',
-            'data' => $collection->load('products')
+            'data' => $collection->load('products'),
         ]);
     }
 
     /**
      * Soft delete the specified collection.
-     *
-     * @param int $id
-     * @return JsonResponse
      */
-    public function destroy(int $id): JsonResponse
+    public function destroy(Request $request, int $id): JsonResponse
     {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
         $collection = ProductCollection::find($id);
 
-        if (!$collection) {
+        if (! $collection) {
             return response()->json([
                 'success' => false,
-                'message' => 'Collection not found'
+                'message' => 'Collection not found',
             ], 404);
         }
 
@@ -287,7 +273,7 @@ class CollectionController extends Controller
 
         return response()->json([
             'success' => true,
-            'message' => 'Collection deleted successfully'
+            'message' => 'Collection deleted successfully',
         ]);
     }
 }

--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -93,6 +93,8 @@ class ProductController extends Controller
      */
     public function store(Request $request): JsonResponse
     {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255',
             'description' => 'nullable|string',
@@ -136,6 +138,8 @@ class ProductController extends Controller
      */
     public function update(Request $request, int $id): JsonResponse
     {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
         $product = Product::find($id);
 
         if (! $product) {
@@ -186,8 +190,10 @@ class ProductController extends Controller
     /**
      * Soft delete the specified product.
      */
-    public function destroy(int $id): JsonResponse
+    public function destroy(Request $request, int $id): JsonResponse
     {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
         $product = Product::find($id);
 
         if (! $product) {

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -273,6 +273,11 @@ class CheckoutController extends Controller
 
         $order->transitionTo(Order::STATUS_PAID, notes: 'Payment captured');
 
+        // Authorize the (possibly guest) buyer to view this order's confirmation page.
+        // showConfirmation checks this session list so the confirmation is not an open
+        // IDOR — both the normal and the dropship-error redirect below run after this.
+        Session::push('recent_order_ids', $order->id);
+
         // Send order confirmation email
         Notification::route('mail', $order->customer_email)
             ->notify(new OrderConfirmationNotification($order));
@@ -333,8 +338,16 @@ class CheckoutController extends Controller
             ->with('success', 'Order placed successfully!');
     }
 
-    public function showConfirmation(Order $order)
+    public function showConfirmation(Request $request, Order $order)
     {
+        // The confirmation page exposes full order PII, so it must not be an open
+        // IDOR. Allow the order's owner, or a (possibly guest) buyer who placed it
+        // this session — nobody else can enumerate arbitrary order ids.
+        $ownsOrder = $order->user_id !== null && $request->user()?->id === $order->user_id;
+        $justPlaced = in_array($order->id, Session::get('recent_order_ids', []), true);
+
+        abort_unless($ownsOrder || $justPlaced, 403);
+
         return view('checkout.confirmation', [
             'order' => $order,
         ]);

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -2,11 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Coupon;
 use App\Models\Invoice;
 use App\Models\Order;
 use Illuminate\Http\Request;
-use Illuminate\Http\JsonResponse;
 use Illuminate\View\View;
 
 class InvoiceController extends Controller
@@ -27,12 +25,19 @@ class InvoiceController extends Controller
                 'price' => $product->price,
             ]);
         }
+
         return $invoice;
     }
 
     public function index(Request $request): View
     {
         $query = Invoice::query();
+
+        // Customers see only their own invoices (via the owning order); staff see all.
+        if (! $request->user()?->hasRole(['super_admin', 'admin'])) {
+            $query->whereHas('order', fn ($q) => $q->where('user_id', $request->user()->id));
+        }
+
         if ($request->has('date')) {
             $query->whereDate('invoice_date', $request->date);
         }
@@ -40,12 +45,21 @@ class InvoiceController extends Controller
             $query->where('payment_status', $request->status);
         }
         $invoices = $query->latest()->paginate(10);
+
         return view('invoices.index', compact('invoices'));
     }
 
-    public function show(int $id): View
+    public function show(Request $request, int $id): View
     {
-        $invoice = Invoice::with(['order', 'order.items'])->findOrFail($id);
+        $query = Invoice::with(['order', 'order.items']);
+
+        // Scope to the owner unless staff — a foreign id 404s instead of leaking PII.
+        if (! $request->user()?->hasRole(['super_admin', 'admin'])) {
+            $query->whereHas('order', fn ($q) => $q->where('user_id', $request->user()->id));
+        }
+
+        $invoice = $query->findOrFail($id);
+
         return view('invoices.show', compact('invoice'));
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -121,9 +121,17 @@ Route::patch('/subscription/change', [SubscriptionController::class, 'changePlan
 Route::delete('/subscription/cancel', [SubscriptionController::class, 'cancelSubscription'])->name('subscription.cancel');
 
 Route::post('/paypal/payment', [PaypalPaymentController::class, 'createOneTimePayment'])->name('paypal.payment.create');
-Route::post('/paypal/subscription', [PaypalPaymentController::class, 'createSubscription'])->name('paypal.subscription.create');
-Route::patch('/paypal/subscription/update', [PaypalPaymentController::class, 'updateSubscription'])->name('paypal.subscription.update');
-Route::delete('/paypal/subscription/cancel', [PaypalPaymentController::class, 'cancelSubscription'])->name('paypal.subscription.cancel');
+
+// PayPal subscription mutations act on a caller-supplied subscriptionId — require
+// auth so an anonymous request can't update/cancel someone else's subscription.
+// ponytail: real per-user ownership scoping must come when the PayPal integration is
+// actually built; SubscriptionService is a stub today with no persisted
+// subscription↔user link to check against.
+Route::middleware('auth')->group(function () {
+    Route::post('/paypal/subscription', [PaypalPaymentController::class, 'createSubscription'])->name('paypal.subscription.create');
+    Route::patch('/paypal/subscription/update', [PaypalPaymentController::class, 'updateSubscription'])->name('paypal.subscription.update');
+    Route::delete('/paypal/subscription/cancel', [PaypalPaymentController::class, 'cancelSubscription'])->name('paypal.subscription.cancel');
+});
 
 // Cart routes
 Route::get('/cart', [CartController::class, 'index'])->name('cart.index');

--- a/tests/Feature/Api/CollectionControllerTest.php
+++ b/tests/Feature/Api/CollectionControllerTest.php
@@ -7,6 +7,7 @@ use App\Models\ProductCollection;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class CollectionControllerTest extends TestCase
@@ -18,7 +19,9 @@ class CollectionControllerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        // Collection write endpoints are admin-gated; these tests act as an admin.
+        Role::findOrCreate('super_admin', 'web');
+        $this->user = User::factory()->create()->assignRole('super_admin');
         Sanctum::actingAs($this->user);
     }
 
@@ -42,7 +45,7 @@ class CollectionControllerTest extends TestCase
             ->assertJsonStructure([
                 'data',
                 'links',
-                'meta'
+                'meta',
             ])
             ->assertJsonCount(10, 'data');
     }
@@ -60,10 +63,10 @@ class CollectionControllerTest extends TestCase
         $response->assertStatus(201)
             ->assertJson([
                 'success' => true,
-                'message' => 'Collection created successfully'
+                'message' => 'Collection created successfully',
             ])
             ->assertJsonStructure([
-                'data' => ['id', 'name', 'slug', 'description', 'price']
+                'data' => ['id', 'name', 'slug', 'description', 'price'],
             ]);
 
         $this->assertDatabaseHas('collections', [
@@ -100,7 +103,7 @@ class CollectionControllerTest extends TestCase
 
         $response->assertStatus(422)
             ->assertJson([
-                'success' => false
+                'success' => false,
             ])
             ->assertJsonValidationErrors(['name']);
     }
@@ -121,14 +124,14 @@ class CollectionControllerTest extends TestCase
                 'data' => [
                     'id' => $collection->id,
                     'name' => 'Test Collection',
-                ]
+                ],
             ])
             ->assertJsonStructure([
                 'data' => [
                     'id',
                     'name',
-                    'products'
-                ]
+                    'products',
+                ],
             ])
             ->assertJsonCount(3, 'data.products');
     }
@@ -140,7 +143,7 @@ class CollectionControllerTest extends TestCase
             'slug' => 'test-collection',
         ]);
 
-        $response = $this->getJson("/api/collections/test-collection");
+        $response = $this->getJson('/api/collections/test-collection');
 
         $response->assertStatus(200)
             ->assertJson([
@@ -148,7 +151,7 @@ class CollectionControllerTest extends TestCase
                 'data' => [
                     'id' => $collection->id,
                     'slug' => 'test-collection',
-                ]
+                ],
             ]);
     }
 
@@ -159,7 +162,7 @@ class CollectionControllerTest extends TestCase
         $response->assertStatus(404)
             ->assertJson([
                 'success' => false,
-                'message' => 'Collection not found'
+                'message' => 'Collection not found',
             ]);
     }
 
@@ -183,7 +186,7 @@ class CollectionControllerTest extends TestCase
                 'data' => [
                     'name' => 'Updated Name',
                     'description' => 'Updated description',
-                ]
+                ],
             ]);
 
         $this->assertDatabaseHas('collections', [
@@ -201,7 +204,7 @@ class CollectionControllerTest extends TestCase
         $response->assertStatus(404)
             ->assertJson([
                 'success' => false,
-                'message' => 'Collection not found'
+                'message' => 'Collection not found',
             ]);
     }
 
@@ -266,7 +269,7 @@ class CollectionControllerTest extends TestCase
         $response->assertStatus(404)
             ->assertJson([
                 'success' => false,
-                'message' => 'Collection not found'
+                'message' => 'Collection not found',
             ]);
     }
 
@@ -307,7 +310,7 @@ class CollectionControllerTest extends TestCase
         $response->assertStatus(404)
             ->assertJson([
                 'success' => false,
-                'message' => 'Collection not found'
+                'message' => 'Collection not found',
             ]);
     }
 
@@ -320,7 +323,7 @@ class CollectionControllerTest extends TestCase
         $response->assertStatus(200)
             ->assertJson([
                 'success' => true,
-                'message' => 'Collection deleted successfully'
+                'message' => 'Collection deleted successfully',
             ]);
 
         $this->assertSoftDeleted('collections', [
@@ -335,7 +338,7 @@ class CollectionControllerTest extends TestCase
         $response->assertStatus(404)
             ->assertJson([
                 'success' => false,
-                'message' => 'Collection not found'
+                'message' => 'Collection not found',
             ]);
     }
 }

--- a/tests/Feature/Api/ProductApiTest.php
+++ b/tests/Feature/Api/ProductApiTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Product;
+use App\Models\ProductCategory;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class ProductApiTest extends TestCase
@@ -17,7 +19,9 @@ class ProductApiTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        // Product write endpoints are admin-gated; the CRUD tests below act as an admin.
+        Role::findOrCreate('super_admin', 'web');
+        $this->user = User::factory()->create()->assignRole('super_admin');
     }
 
     public function test_unauthenticated_cannot_list_products(): void
@@ -66,7 +70,7 @@ class ProductApiTest extends TestCase
     public function test_can_create_product(): void
     {
         Sanctum::actingAs($this->user);
-        $category = \App\Models\ProductCategory::factory()->create();
+        $category = ProductCategory::factory()->create();
 
         $payload = [
             'name' => 'New Product',

--- a/tests/Feature/Api/ProductControllerTest.php
+++ b/tests/Feature/Api/ProductControllerTest.php
@@ -6,6 +6,7 @@ use App\Models\Product;
 use App\Models\ProductCategory;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class ProductControllerTest extends TestCase
@@ -17,7 +18,9 @@ class ProductControllerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        // Product write endpoints are admin-gated; these CRUD tests act as an admin.
+        Role::findOrCreate('super_admin', 'web');
+        $this->user = User::factory()->create()->assignRole('super_admin');
     }
 
     /**
@@ -43,7 +46,7 @@ class ProductControllerTest extends TestCase
                         'featured_image',
                         'created_at',
                         'updated_at',
-                    ]
+                    ],
                 ],
                 'current_page',
                 'per_page',
@@ -150,7 +153,7 @@ class ProductControllerTest extends TestCase
                     'id' => $product->id,
                     'name' => 'Test Product',
                     'price' => '99.99',
-                ]
+                ],
             ]);
     }
 
@@ -172,7 +175,7 @@ class ProductControllerTest extends TestCase
                 'data' => [
                     'id' => $product->id,
                     'name' => 'Test Product Name',
-                ]
+                ],
             ]);
     }
 
@@ -229,7 +232,7 @@ class ProductControllerTest extends TestCase
                 'data' => [
                     'name' => 'New Product',
                     'price' => '149.99',
-                ]
+                ],
             ]);
 
         $this->assertDatabaseHas('products', [
@@ -306,7 +309,7 @@ class ProductControllerTest extends TestCase
                 'data' => [
                     'name' => 'Updated Name',
                     'price' => '200.00',
-                ]
+                ],
             ]);
 
         $this->assertDatabaseHas('products', [
@@ -442,7 +445,7 @@ class ProductControllerTest extends TestCase
     {
         $product1 = Product::factory()->create(['name' => 'Active Product']);
         $product2 = Product::factory()->create(['name' => 'Deleted Product']);
-        
+
         $product2->delete();
 
         $response = $this->actingAs($this->user, 'sanctum')

--- a/tests/Feature/AuthorizationHardeningTest.php
+++ b/tests/Feature/AuthorizationHardeningTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\ProductCollection;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Locks down five verified authorization holes surfaced by an audit sweep:
+ *  1. Api\ProductController writes — admin-only, were auth-only.
+ *  2. Api\CollectionController writes — admin-only, were auth-only.
+ *  3. checkout.confirmation — was an unauthenticated order-PII IDOR.
+ *  4. InvoiceController index/show — was readable across all users.
+ *  5. PaypalPaymentController subscription mutations — were unauthenticated.
+ */
+class AuthorizationHardeningTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        return User::factory()->create()->assignRole('super_admin');
+    }
+
+    private function order(?int $userId): Order
+    {
+        return Order::create([
+            'user_id' => $userId,
+            'customer_email' => 'buyer@example.com',
+            'total_amount' => 10,
+            'status' => 'pending',
+        ]);
+    }
+
+    // ---- 1. Product API is admin-only -------------------------------------
+
+    public function test_non_admin_cannot_create_a_product(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->postJson('/api/products', ['name' => 'x', 'short_description' => 'x', 'price' => 1, 'category_id' => 1])
+            ->assertForbidden();
+    }
+
+    public function test_non_admin_cannot_update_or_delete_a_product(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create(['price' => 10]);
+
+        $this->actingAs($user)->putJson("/api/products/{$product->id}", ['price' => 0])->assertForbidden();
+        $this->actingAs($user)->deleteJson("/api/products/{$product->id}")->assertForbidden();
+
+        $this->assertNotNull($product->fresh(), 'Product must survive a non-admin delete attempt');
+        $this->assertEquals(10, $product->fresh()->price);
+    }
+
+    public function test_admin_can_delete_a_product(): void
+    {
+        $product = Product::factory()->create();
+
+        $this->actingAs($this->admin())->deleteJson("/api/products/{$product->id}")->assertOk();
+    }
+
+    // ---- 2. Collection API is admin-only ----------------------------------
+
+    public function test_non_admin_cannot_write_collections(): void
+    {
+        $user = User::factory()->create();
+        $collection = ProductCollection::factory()->create();
+
+        $this->actingAs($user)->postJson('/api/collections', ['name' => 'x'])->assertForbidden();
+        $this->actingAs($user)->putJson("/api/collections/{$collection->id}", ['name' => 'y'])->assertForbidden();
+        $this->actingAs($user)->deleteJson("/api/collections/{$collection->id}")->assertForbidden();
+
+        $this->assertNotNull($collection->fresh());
+    }
+
+    public function test_admin_can_delete_a_collection(): void
+    {
+        $collection = ProductCollection::factory()->create();
+
+        $this->actingAs($this->admin())->deleteJson("/api/collections/{$collection->id}")->assertOk();
+    }
+
+    // ---- 3. Order confirmation is not an open IDOR ------------------------
+
+    public function test_guest_cannot_view_an_arbitrary_order_confirmation(): void
+    {
+        $order = $this->order(User::factory()->create()->id);
+
+        $this->get(route('checkout.confirmation', $order))->assertForbidden();
+    }
+
+    public function test_user_cannot_view_another_users_order_confirmation(): void
+    {
+        $order = $this->order(User::factory()->create()->id);
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('checkout.confirmation', $order))
+            ->assertForbidden();
+    }
+
+    public function test_user_can_view_their_own_order_confirmation(): void
+    {
+        $user = User::factory()->create();
+        $order = $this->order($user->id);
+
+        $this->actingAs($user)->get(route('checkout.confirmation', $order))->assertOk();
+    }
+
+    public function test_guest_can_view_the_order_they_just_placed(): void
+    {
+        $order = $this->order(null);
+
+        $this->withSession(['recent_order_ids' => [$order->id]])
+            ->get(route('checkout.confirmation', $order))
+            ->assertOk();
+    }
+
+    // ---- 4. Invoices are scoped to their owner ----------------------------
+
+    private function invoiceForUser(User $user): Invoice
+    {
+        $order = $this->order($user->id);
+        $customer = Customer::forceCreate([
+            'first_name' => 'Test', 'last_name' => 'Buyer', 'email' => 'inv@example.com',
+            'phone_number' => 1234567890, 'address' => '1 St', 'city' => 'Town',
+            'state' => 'CA', 'postal_code' => '90001',
+        ]);
+
+        return Invoice::forceCreate([
+            'order_id' => $order->id, 'customer_id' => $customer->id,
+            'invoice_date' => now(), 'total_amount' => 42, 'payment_status' => 'paid',
+        ]);
+    }
+
+    public function test_user_cannot_view_another_users_invoice(): void
+    {
+        $victim = $this->invoiceForUser(User::factory()->create());
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('invoices.show', $victim->id))
+            ->assertNotFound();
+    }
+
+    public function test_user_can_view_their_own_invoice(): void
+    {
+        $user = User::factory()->create();
+        $invoice = $this->invoiceForUser($user);
+
+        $this->actingAs($user)->get(route('invoices.show', $invoice->id))->assertOk();
+    }
+
+    public function test_invoice_index_lists_only_the_users_own_invoices(): void
+    {
+        $user = User::factory()->create();
+        $this->invoiceForUser($user);
+        $this->invoiceForUser(User::factory()->create()); // someone else's
+
+        $response = $this->actingAs($user)->get(route('invoices.index'))->assertOk();
+        $this->assertCount(1, $response->viewData('invoices'));
+    }
+
+    public function test_admin_can_view_any_invoice(): void
+    {
+        $invoice = $this->invoiceForUser(User::factory()->create());
+
+        $this->actingAs($this->admin())->get(route('invoices.show', $invoice->id))->assertOk();
+    }
+
+    // ---- 5. PayPal subscription mutations require auth --------------------
+
+    public function test_guest_cannot_update_or_cancel_a_paypal_subscription(): void
+    {
+        // Unauthenticated → redirected to login, never a 200 success.
+        $this->patch(route('paypal.subscription.update'), ['subscriptionId' => 'I-VICTIM', 'planId' => 'P-2'])
+            ->assertRedirect(route('login'));
+        $this->delete(route('paypal.subscription.cancel'), ['subscriptionId' => 'I-VICTIM'])
+            ->assertRedirect(route('login'));
+    }
+}

--- a/tests/Feature/CheckoutControllerTest.php
+++ b/tests/Feature/CheckoutControllerTest.php
@@ -18,12 +18,12 @@ class CheckoutControllerTest extends TestCase
     {
         $category = ProductCategory::create([
             'name' => 'Checkout Category',
-            'slug' => 'checkout-cat-' . uniqid(),
+            'slug' => 'checkout-cat-'.uniqid(),
         ]);
 
         return Product::create(array_merge([
             'name' => 'Checkout Product',
-            'slug' => 'checkout-prod-' . uniqid(),
+            'slug' => 'checkout-prod-'.uniqid(),
             'price' => 50.00,
             'category_id' => $category->id,
             'inventory_count' => 20,
@@ -126,7 +126,10 @@ class CheckoutControllerTest extends TestCase
             'status' => 'paid',
         ]);
 
-        $response = $this->get(route('checkout.confirmation', ['order' => $order->id]));
+        // A guest is authorized to view the order they just placed via the session
+        // marker the checkout flow sets — the confirmation is no longer an open IDOR.
+        $response = $this->withSession(['recent_order_ids' => [$order->id]])
+            ->get(route('checkout.confirmation', ['order' => $order->id]));
 
         $response->assertStatus(200);
         $response->assertViewHas('order');

--- a/tests/Feature/InvoiceControllerTest.php
+++ b/tests/Feature/InvoiceControllerTest.php
@@ -31,7 +31,9 @@ class InvoiceControllerTest extends TestCase
             'state' => 'IL',
             'postal_code' => '60601',
         ]);
+
         return Order::create([
+            'user_id' => $user->id,
             'customer_id' => $customer->id,
             'customer_email' => $user->email,
             'total_amount' => 150.00,
@@ -112,7 +114,7 @@ class InvoiceControllerTest extends TestCase
         $order = $this->makeOrder($user);
         $this->makeInvoice($order);
 
-        $response = $this->actingAs($user)->get('/invoices?date=' . today()->toDateString());
+        $response = $this->actingAs($user)->get('/invoices?date='.today()->toDateString());
 
         $response->assertStatus(200);
         $response->assertViewHas('invoices');


### PR DESCRIPTION
## Summary

An audit sweep surfaced five endpoints missing an authorization check. Each was confirmed by reading the action body **plus** its route middleware. This PR closes all five and locks them in with tests.

| # | Endpoint | Hole | Fix |
|---|---|---|---|
| 1 | `Api/ProductController` store/update/destroy | `auth:sanctum` only — any customer sets any price to \$0 / wipes the catalog | `abort_unless(hasRole([super_admin, admin]))` |
| 2 | `Api/CollectionController` store/update/addProducts/removeProducts/destroy | same auth-only gap | same admin gate |
| 3 | `GET /checkout/confirmation/{order}` | **no middleware** — enumerate `/1..N`, read every orders PII | owner, or guest who placed it this session (`recent_order_ids`) |
| 4 | `InvoiceController` index/show | auth but **unscoped** — any user reads all invoices | scoped to the owning orders user; staff see all |
| 5 | `PaypalPaymentController` subscription create/update/cancel | **no auth**, acts on request-supplied `subscriptionId` | routes moved under `auth` |

## Notes on each

- **1 & 2** match the existing gate idiom used by `OrderRefundController` / `OrderStatusController` / `WebhookEndpointController`.
- **3** — checkout now records the placed order id in a `recent_order_ids` session list (set once, after the `PAID` transition, covering both the normal and dropship-error redirects). `showConfirmation` authorizes the order owner **or** a session-holder, so a guest still sees their own confirmation but nobody can enumerate others.
- **4** — customers are scoped via `whereHas(order → user_id)`; `super_admin`/`admin` bypass the scope. A foreign id now `404`s instead of leaking.
- **5** — real per-user ownership scoping isnt possible yet: `SubscriptionService` is a stub (canned returns, no PayPal SDK) and `Subscription` has no persisted PayPal-subscription→user link. Requiring auth is the correct minimal fix; a `ponytail:` comment at the route marks the upgrade path for when the integration is actually built.

## Tests

**+14** in `AuthorizationHardeningTest` — non-admin blocked / admin allowed on both APIs; confirmation IDOR incl. the just-placed-guest allow-case; invoice owner-scoping incl. admin-sees-all; PayPal guest-blocked.

Existing Product/Collection API + confirmation + invoice tests were updated to the **secured** contract (authenticate as admin / establish ownership) — the behavior change is intentional, so those tests now encode the secure expectation rather than the old open one.

Full suite **986 passed / 0 failed**. (Provenance: this batch came from the same audit sweep that produced the #741 coupon money-bug fix.)