### PR TITLE
fix(security): require auth on Stripe payment + subscription routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -109,16 +109,25 @@ Route::middleware('auth')->prefix('payment_methods')->group(function () {
 // Stripe webhook — unauthenticated + CSRF-exempt (verified by signature in the controller)
 Route::post('/stripe/webhook', [StripeWebhookController::class, 'handle'])->name('stripe.webhook');
 
-Route::post('/payment', [StripePaymentController::class, 'createOneTimePayment'])->name('payment.create');
-Route::post('/stripe/payment', [StripePaymentController::class, 'createOneTimePayment'])->name('stripe.payment.create');
-Route::post('/stripe/subscription', [StripePaymentController::class, 'createSubscription'])->name('stripe.subscription.create');
-Route::patch('/stripe/subscription', [StripePaymentController::class, 'updateSubscription'])->name('stripe.subscription.update');
-Route::delete('/stripe/subscription', [StripePaymentController::class, 'cancelSubscription'])->name('stripe.subscription.cancel');
+// Stripe payment + subscription mutations act only on the current user
+// ($request->user()), so an anonymous request would deref null and 500. Require auth.
+Route::middleware('auth')->group(function () {
+    Route::post('/payment', [StripePaymentController::class, 'createOneTimePayment'])->name('payment.create');
+    Route::post('/stripe/payment', [StripePaymentController::class, 'createOneTimePayment'])->name('stripe.payment.create');
+    Route::post('/stripe/subscription', [StripePaymentController::class, 'createSubscription'])->name('stripe.subscription.create');
+    Route::patch('/stripe/subscription', [StripePaymentController::class, 'updateSubscription'])->name('stripe.subscription.update');
+    Route::delete('/stripe/subscription', [StripePaymentController::class, 'cancelSubscription'])->name('stripe.subscription.cancel');
+});
 
+// Plan listing touches no user data — stays public (pricing page).
 Route::get('/subscriptions', [SubscriptionController::class, 'viewAvailableSubscriptions'])->name('subscriptions.view');
-Route::post('/subscription', [SubscriptionController::class, 'subscribeToPlan'])->name('subscription.create');
-Route::patch('/subscription/change', [SubscriptionController::class, 'changePlan'])->name('subscription.change-plan');
-Route::delete('/subscription/cancel', [SubscriptionController::class, 'cancelSubscription'])->name('subscription.cancel');
+
+// Subscription management all runs on Auth::user() — same null-deref risk, require auth.
+Route::middleware('auth')->group(function () {
+    Route::post('/subscription', [SubscriptionController::class, 'subscribeToPlan'])->name('subscription.create');
+    Route::patch('/subscription/change', [SubscriptionController::class, 'changePlan'])->name('subscription.change-plan');
+    Route::delete('/subscription/cancel', [SubscriptionController::class, 'cancelSubscription'])->name('subscription.cancel');
+});
 
 Route::post('/paypal/payment', [PaypalPaymentController::class, 'createOneTimePayment'])->name('paypal.payment.create');
 

--- a/tests/Feature/PaymentRouteAuthTest.php
+++ b/tests/Feature/PaymentRouteAuthTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The Stripe payment and subscription routes act exclusively on the current user
+ * ($request->user() / Auth::user()), so an unauthenticated request would deref
+ * null and 500. They must require auth (a guest is redirected to login), matching
+ * the PayPal subscription routes hardened alongside them.
+ */
+class PaymentRouteAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_stripe_payment_and_subscription_routes_require_auth(): void
+    {
+        $this->post(route('payment.create'))->assertRedirect(route('login'));
+        $this->post(route('stripe.payment.create'))->assertRedirect(route('login'));
+        $this->post(route('stripe.subscription.create'))->assertRedirect(route('login'));
+        $this->patch(route('stripe.subscription.update'))->assertRedirect(route('login'));
+        $this->delete(route('stripe.subscription.cancel'))->assertRedirect(route('login'));
+    }
+
+    public function test_subscription_management_routes_require_auth(): void
+    {
+        $this->post(route('subscription.create'))->assertRedirect(route('login'));
+        $this->patch(route('subscription.change-plan'))->assertRedirect(route('login'));
+        $this->delete(route('subscription.cancel'))->assertRedirect(route('login'));
+    }
+
+    public function test_auth_gate_is_transparent_to_a_logged_in_user(): void
+    {
+        // With auth satisfied the gate is a no-op: an empty body now reaches the
+        // controller's own validation (422) instead of being blocked at the door.
+        $this->actingAs(User::factory()->create())
+            ->postJson(route('stripe.subscription.create'), [])
+            ->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Summary

Completes the authorization sweep from #742. `StripePaymentController` and `SubscriptionController` operate **exclusively** on the current user (`$request->user()` / `Auth::user()`) — but their routes carried **no auth middleware**. An unauthenticated request dereferenced a null user and **500**ed instead of being turned away.

Gated the user-scoped mutation routes behind `auth`:

- `POST /payment`, `POST /stripe/payment` — `createOneTimePayment`
- `POST|PATCH|DELETE /stripe/subscription` — create/update/cancel
- `POST /subscription`, `PATCH /subscription/change`, `DELETE /subscription/cancel`

`GET /subscriptions` (plan listing, touches no user data) stays **public**.

## Tests

**+3** in `PaymentRouteAuthTest`: a guest is redirected to login on every gated route; the gate is transparent to a logged-in user (an empty body still reaches the controllers own `422` validation). The existing `StripePaymentControllerTest` already acts as a user, so it is unaffected.

Full suite **989 passed / 0 failed**.

## Note

These endpoints also depend on Cashier (`$user->charge()`, `newSubscription()`), which isnt installed — so theyre not functional end-to-end yet. This PR is strictly the auth-posture fix (no more anonymous 500s), consistent with the PayPal subscription gating in #742; wiring real Cashier billing is separate.