### PR TITLE
feat(app-panel): make the Team-tenant /app Filament panel functional

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -8,4 +8,9 @@ use Illuminate\Database\Eloquent\Model;
 class Article extends Model
 {
     use HasFactory;
+
+    public function team()
+    {
+        return $this->belongsTo(Team::class);
+    }
 }

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -47,8 +47,8 @@ class Customer extends Model
     public function groups()
     {
         return $this->belongsToMany(CustomerGroup::class, 'customer_group_memberships')
-                    ->withPivot(['joined_at', 'expires_at'])
-                    ->withTimestamps();
+            ->withPivot(['joined_at', 'expires_at'])
+            ->withTimestamps();
     }
 
     public function abandonedCarts()
@@ -69,9 +69,9 @@ class Customer extends Model
     public function getActiveGroupsAttribute()
     {
         return $this->groups()
-                    ->wherePivot('expires_at', '>', now())
-                    ->orWherePivotNull('expires_at')
-                    ->get();
+            ->wherePivot('expires_at', '>', now())
+            ->orWherePivotNull('expires_at')
+            ->get();
     }
 
     public function getTotalSpentAttribute(): float
@@ -92,5 +92,10 @@ class Customer extends Model
     public function isVip(): bool
     {
         return $this->total_spent >= 1000 || $this->order_count >= 10;
+    }
+
+    public function team()
+    {
+        return $this->belongsTo(Team::class);
     }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -15,4 +15,9 @@ class Group extends Model
         'name',
         'discount',
     ];
+
+    public function team()
+    {
+        return $this->belongsTo(Team::class);
+    }
 }

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -4,7 +4,6 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use App\Models\Order;
 
 class Invoice extends Model
 {
@@ -35,5 +34,10 @@ class Invoice extends Model
     public function products()
     {
         return $this->belongsToMany(Product::class)->withPivot('quantity', 'price');
+    }
+
+    public function team()
+    {
+        return $this->belongsTo(Team::class);
     }
 }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -176,4 +176,9 @@ class Order extends Model
             DispatchOutboundWebhook::dispatch($this->id, 'order.'.$status);
         }
     }
+
+    public function team()
+    {
+        return $this->belongsTo(Team::class);
+    }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -376,4 +376,9 @@ class Product extends Model implements Orderable
     {
         return $this->review()->count();
     }
+
+    public function team()
+    {
+        return $this->belongsTo(Team::class);
+    }
 }

--- a/app/Models/ProductCollection.php
+++ b/app/Models/ProductCollection.php
@@ -15,7 +15,7 @@ class ProductCollection extends Model implements Orderable
     use IsTenantModel;
     use SoftDeletes;
 
-    protected $table = "collections";
+    protected $table = 'collections';
 
     protected $fillable = [
         'name',
@@ -38,5 +38,10 @@ class ProductCollection extends Model implements Orderable
     {
         return $this->belongsToMany(Product::class, 'collection_items', 'collection_id')
             ->withPivot('quantity');
+    }
+
+    public function team()
+    {
+        return $this->belongsTo(Team::class);
     }
 }

--- a/app/Models/ProductRating.php
+++ b/app/Models/ProductRating.php
@@ -34,6 +34,9 @@ class ProductRating extends Model
     {
         return ($this->overall_rating + $this->quality_rating + $this->value_rating + $this->price_rating) / 4;
     }
+
+    public function team()
+    {
+        return $this->belongsTo(Team::class);
+    }
 }
-
-

--- a/app/Models/ProductReview.php
+++ b/app/Models/ProductReview.php
@@ -42,6 +42,12 @@ class ProductReview extends Model
     public function getHelpfulnessScore()
     {
         $total_votes = $this->helpful_votes + $this->unhelpful_votes;
+
         return $total_votes > 0 ? ($this->helpful_votes / $total_votes) * 100 : 0;
+    }
+
+    public function team()
+    {
+        return $this->belongsTo(Team::class);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,16 +25,16 @@ use Spatie\Permission\Traits\HasRoles;
 class User extends Authenticatable implements FilamentUser, HasDefaultTenant, HasTenants
 {
     use HasApiTokens;
-
     use HasFactory;
     use HasProfilePhoto {
         HasProfilePhoto::profilePhotoUrl as getPhotoUrl;
     }
+
     // use HasConnectedAccounts;
     use HasRoles;
     use HasTeams;
-
     use Notifiable;
+
     // use SetsProfilePhotoFromUrl;
     use TwoFactorAuthenticatable;
 
@@ -112,12 +112,16 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
      */
     public function getTenants(Panel $panel): array|Collection
     {
-        return $this->ownedTeams;
+        // Every team the user can act in — owned + membership. Using only
+        // ownedTeams (as before) hid shared/member teams from the tenant switcher.
+        return $this->allTeams();
     }
 
     public function canAccessTenant(Model $tenant): bool
     {
-        return $this->teams->contains($tenant);
+        // belongsToTeam covers ownership AND membership; the previous
+        // teams-only check locked a team's own owner out of their tenant.
+        return $this->belongsToTeam($tenant);
     }
 
     public function canAccessFilament(): bool

--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -61,7 +61,7 @@ return [
         // Features::termsAndPrivacyPolicy(),
         // Features::profilePhotos(),
         // Features::api(),
-        // Features::teams(['invitations' => true]),
+        Features::teams(['invitations' => true]),
         Features::accountDeletion(),
     ],
 

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Team>
+ */
+class TeamFactory extends Factory
+{
+    protected $model = Team::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->company(),
+            'user_id' => User::factory(),
+            'personal_team' => false,
+        ];
+    }
+}

--- a/database/migrations/2026_07_15_000000_add_team_to_remaining_resources.php
+++ b/database/migrations/2026_07_15_000000_add_team_to_remaining_resources.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Completes 2024_10_10_100000_add_team_to_resources: three tables backing App-panel
+ * Filament resources (invoices, articles, product_rating) were left without a
+ * team_id, so the Team-tenant-scoped panel could not scope them. Adds the same
+ * nullable team_id (default 1, cascade) those siblings already carry.
+ */
+return new class extends Migration
+{
+    protected $tables = ['invoices', 'articles', 'product_rating'];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            if (Schema::hasTable($table) && ! Schema::hasColumn($table, 'team_id')) {
+                Schema::table($table, function (Blueprint $table) {
+                    $table->foreignId('team_id')->nullable()->constrained()->onDelete('cascade')->default(1);
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            if (Schema::hasTable($table) && Schema::hasColumn($table, 'team_id')) {
+                Schema::table($table, function (Blueprint $table) {
+                    $table->dropForeign(['team_id']);
+                    $table->dropColumn('team_id');
+                });
+            }
+        }
+    }
+};

--- a/tests/Feature/Filament/AppPanelTenancyTest.php
+++ b/tests/Feature/Filament/AppPanelTenancyTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\Articles\Pages\ListArticles;
+use App\Filament\App\Resources\Collections\Pages\ListCollections;
+use App\Filament\App\Resources\Customers\Pages\ListCustomers;
+use App\Filament\App\Resources\Groups\Pages\ListGroups;
+use App\Filament\App\Resources\Invoices\Pages\ListInvoices;
+use App\Filament\App\Resources\Orders\Pages\ListOrders;
+use App\Filament\App\Resources\ProductRatings\Pages\ListProductRatings;
+use App\Filament\App\Resources\ProductReviews\Pages\ListProductReviews;
+use App\Filament\App\Resources\Products\Pages\ListProducts;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * The /app Filament panel is Team-tenant-scoped (ownershipRelationship: 'team').
+ * Every resource model therefore needs a team() relationship and a team_id column,
+ * and the tenant owner must be able to access the tenant. These tests mount each
+ * resource's list page under a tenant to prove the panel is wired end to end.
+ */
+class AppPanelTenancyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingInTeamPanel(): Team
+    {
+        // Allow all authorization so these tests isolate the TENANCY wiring, not the
+        // Shield permission layer (which gates resources on the admin panel separately).
+        Gate::before(fn () => true);
+        Role::findOrCreate('super_admin', 'web');
+        $user = User::factory()->withPersonalTeam()->create()->assignRole('super_admin');
+        $team = $user->ownedTeams()->first();
+        $this->actingAs($user);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($team);
+
+        return $team;
+    }
+
+    public function test_team_owner_can_access_their_tenant(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $team = $user->ownedTeams()->first();
+
+        $this->assertTrue($user->canAccessTenant($team));
+        $this->assertTrue($user->getTenants(Filament::getPanel('app'))->contains($team));
+    }
+
+    public function test_every_app_panel_list_page_mounts(): void
+    {
+        $this->actingInTeamPanel();
+
+        $pages = [
+            ListOrders::class, ListProducts::class, ListCustomers::class,
+            ListCollections::class, ListGroups::class, ListProductReviews::class,
+            ListProductRatings::class, ListInvoices::class, ListArticles::class,
+        ];
+
+        foreach ($pages as $page) {
+            Livewire::test($page)->assertSuccessful();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The `/app` Filament panel is configured for Team tenancy (`->tenant(Team::class, ownershipRelationship: "team")`), but the tenancy was only **half-wired** — so the panel was effectively **dead** (not exploitable): users could not resolve a tenant, and its resource pages could not scope their models. This PR wires it end to end.

## Root causes fixed

1. **Jetstream teams were disabled.** `Features::teams(...)` was commented out in `config/jetstream.php` while the panel demanded a Team tenant. Enabled it. With teams on, `withPersonalTeam()` actually creates a team, which surfaced a **missing `TeamFactory`** (added).
2. **`getTenants` vs `canAccessTenant` were inconsistent.** `getTenants` returned `ownedTeams` while `canAccessTenant` checked the membership pivot — so a teams **own owner was locked out** of their tenant. Both now use the canonical Jetstream helpers (`allTeams()` / `belongsToTeam()`), covering ownership **and** membership.
3. **The 9 resource models lacked a `team()` relationship** (Order, Product, Customer, Group, ProductCollection, ProductReview, ProductRating, Invoice, Article), so Filament couldnt scope by the ownership relationship. Added `team()` belongsTo on each.
4. **`team_id` was missing on 3 tables.** Present on most (from `add_team_to_resources`) but not `invoices`, `articles`, `product_rating`. New migration adds the same nullable `team_id` — **MySQL 8.4 verified** (columns + FKs to `teams` created).

## Tests

**+2** in `AppPanelTenancyTest`: the team owner can access their tenant, and **every one of the 9 App-panel list pages mounts** under a tenant. Authorization is allowed via `Gate::before` so the tests isolate the **tenancy** wiring (the Shield permission layer is separate). Full suite **991 passed / 0 failed**, including random order — the config flip added no regressions once `TeamFactory` existed.

## Follow-ups (out of scope)

- The Shield plugin is only on the **admin** panel, so app-panel resources are gated by policies **without** the super_admin gate bypass. Seed/assign the `view_any_*` permissions (or add the Shield plugin to the app panel) so real staff users can actually open these pages.
- Existing rows carry `NULL team_id` (same as the sibling `add_team_to_resources` columns); backfill if a populated production DB is migrated.
- Registration attaches users to a shared `Team::first()` (not per-user personal teams); revisit if per-team isolation is the goal.