### PR TITLE
fix(dropshipping): SupplierFailureNotification database channel fatals on every supplier failure

### DIFF
--- a/app/Notifications/SupplierFailureNotification.php
+++ b/app/Notifications/SupplierFailureNotification.php
@@ -19,15 +19,19 @@ class SupplierFailureNotification extends Notification
 
     public function via($notifiable)
     {
-        return ['mail', 'database'];
+        // Mail only: every caller sends this admin alert to an AnonymousNotifiable
+        // via Notification::route('mail', ...), which has no 'database' route — the
+        // database channel would call ->create() on null and throw on every supplier
+        // failure. There is no User here to persist a DB/bell notification for.
+        return ['mail'];
     }
 
     public function toMail($notifiable)
     {
         return (new MailMessage)
-                    ->subject('Dropshipping supplier error')
-                    ->line($this->message)
-                    ->line('Please review the order and contact the supplier.');
+            ->subject('Dropshipping supplier error')
+            ->line($this->message)
+            ->line('Please review the order and contact the supplier.');
     }
 
     public function toArray($notifiable)

--- a/tests/Feature/SupplierFailureNotificationTest.php
+++ b/tests/Feature/SupplierFailureNotificationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Notifications\SupplierFailureNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class SupplierFailureNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Every caller sends this notification to an AnonymousNotifiable via
+     * Notification::route('mail', ...). If via() also lists the 'database' channel,
+     * DatabaseChannel calls ->create() on the null 'database' route and throws a
+     * \Error on every supplier failure — a normal dropship outcome — which is not
+     * caught by the callers' catch(Exception) and 500s checkout after payment.
+     */
+    public function test_it_delivers_to_a_mail_only_notifiable_without_fataling(): void
+    {
+        // Production sets MAIL_FROM_ADDRESS; the test env doesn't, so set it here to
+        // exercise the real mail channel (array transport) end to end.
+        config(['mail.from.address' => 'store@example.com', 'mail.from.name' => 'Store']);
+
+        Notification::route('mail', 'ops@example.com')
+            ->notify(new SupplierFailureNotification('Supplier rejected order 1'));
+
+        // Reaching this line means no channel fataled on the anonymous notifiable.
+        $this->assertTrue(true);
+    }
+
+    public function test_via_does_not_include_database_for_an_anonymous_notifiable(): void
+    {
+        $channels = (new SupplierFailureNotification('x'))->via(
+            Notification::route('mail', 'ops@example.com')
+        );
+
+        $this->assertNotContains('database', $channels);
+    }
+}


### PR DESCRIPTION
## The bug (live path)

`SupplierFailureNotification::via()` returned `["mail", "database"]`, but **every** caller sends it to an `AnonymousNotifiable` via `Notification::route("mail", ...)`:
- `DispatchDropshippingOrder::notifyFailure` (job) — called when a supplier **rejects** an order (`handle`) or retries are **exhausted** (`failed`)
- `CheckoutController` — in the `catch` around the dropship dispatch

An `AnonymousNotifiable` has no `"database"` route, so `DatabaseChannel` calls `->create()` on `null` and throws a **`\Error` on every send**.

**Blast radius** — the trigger is a *normal* outcome (supplier rejects an order):
- The `\Error` is not an `Exception`, so the callers `catch (Exception)` blocks dont catch it.
- With `QUEUE_CONNECTION=sync` (tests, and any inline run) it propagates out of `processCheckout` **after payment was captured and the order marked paid → HTTP 500 to the buyer**.
- On a real queue worker the job dies into `failed_jobs` (the admin email is sent first, so no duplicate email).

## Fix

`via()` returns `["mail"]`. This is an admin alert routed to a plain address (`mail.from.address`) — theres no `User` to persist a DB/bell row for, so the `database` channel was never meaningful here. (Contrast `OrderRefundedNotification`, which correctly lists `database` only when the notifiable `instanceof User`.)

## Tests

**+2**: sending to a mail-routed `AnonymousNotifiable` no longer fatals; `via()` does not include `database`. Full suite **993 passed / 0 failed**. Found via a read-only notifications/events audit sweep.