### PR TITLE
fix(modules): single source of truth for module enabled state (+ latent per-request fatal)

### DIFF
--- a/app/Modules/BaseModule.php
+++ b/app/Modules/BaseModule.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules;
 
+use App\Models\Module;
 use App\Modules\Contracts\ModuleInterface;
 use App\Modules\Events\ModuleDisabled;
 use App\Modules\Events\ModuleEnabled;
@@ -10,8 +11,8 @@ use App\Modules\Events\ModuleUninstalled;
 use App\Modules\Traits\Configurable;
 use App\Modules\Traits\HasModuleHooks;
 use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 use ReflectionClass;
 
 abstract class BaseModule implements ModuleInterface
@@ -19,9 +20,13 @@ abstract class BaseModule implements ModuleInterface
     use Configurable, HasModuleHooks;
 
     protected string $name;
+
     protected string $version = '1.0.0';
+
     protected string $description = '';
+
     protected array $dependencies = [];
+
     protected array $config = [];
 
     public function __construct()
@@ -51,13 +56,20 @@ abstract class BaseModule implements ModuleInterface
 
     public function isEnabled(): bool
     {
-        return Cache::get("module.{$this->name}.enabled", false);
+        // The modules DB table is the single source of truth — ModuleServiceProvider
+        // reads it to gate route/view/Filament registration. A cache flag (the old
+        // approach) drifted from it and was wiped by cache:clear.
+        try {
+            return (bool) Module::where('name', $this->name)->value('enabled');
+        } catch (\Throwable) {
+            return false;
+        }
     }
 
     public function enable(): void
     {
         $this->beforeEnable();
-        Cache::put("module.{$this->name}.enabled", true);
+        $this->persistEnabled(true);
         $this->onEnable();
         $this->afterEnable();
         event(new ModuleEnabled($this));
@@ -66,10 +78,19 @@ abstract class BaseModule implements ModuleInterface
     public function disable(): void
     {
         $this->beforeDisable();
-        Cache::put("module.{$this->name}.enabled", false);
+        $this->persistEnabled(false);
         $this->onDisable();
         $this->afterDisable();
         event(new ModuleDisabled($this));
+    }
+
+    protected function persistEnabled(bool $enabled): void
+    {
+        try {
+            Module::updateOrCreate(['name' => $this->name], ['enabled' => $enabled]);
+        } catch (\Throwable $e) {
+            Log::warning("Failed to persist enabled state for module '{$this->name}': ".$e->getMessage());
+        }
     }
 
     public function install(): void
@@ -101,6 +122,13 @@ abstract class BaseModule implements ModuleInterface
 
     protected function loadModuleInfo(): void
     {
+        // Always have a name. A typed $name left uninitialized (no module.json and no
+        // subclass default) fatals getName() — which ModuleManager calls on every
+        // request — with an "accessed before initialization" \Error.
+        if (! isset($this->name)) {
+            $this->name = class_basename(static::class);
+        }
+
         $modulePath = $this->getModulePath();
         $moduleInfoPath = $modulePath.'/module.json';
 
@@ -127,8 +155,13 @@ abstract class BaseModule implements ModuleInterface
         $migrationsPath = $this->getModulePath().'/database/migrations';
 
         if (File::exists($migrationsPath)) {
+            // Derive --path from the actual module directory, not the declared name:
+            // when module.json's name differs from the folder the old path pointed at
+            // a nonexistent dir, so migrate ran 0 migrations and install() lied.
+            $relativePath = ltrim(str_replace(base_path(), '', $migrationsPath), DIRECTORY_SEPARATOR);
+
             Artisan::call('migrate', [
-                '--path' => 'app/Modules/'.$this->name.'/database/migrations',
+                '--path' => $relativePath,
                 '--force' => true,
             ]);
         }

--- a/tests/Feature/ModuleStateTest.php
+++ b/tests/Feature/ModuleStateTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Modules\BaseModule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+/**
+ * The module "enabled" flag must have a single source of truth — the modules DB
+ * table that ModuleServiceProvider reads to gate route/view/Filament registration.
+ * Previously BaseModule tracked it in a cache key, so install() never persisted it,
+ * uninstall() never cleared it, and cache:clear wiped all module state.
+ */
+class ModuleStateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_install_persists_enabled_to_the_database(): void
+    {
+        $module = new FakeModule;
+        $module->install();
+
+        $this->assertDatabaseHas('modules', ['name' => 'fake', 'enabled' => true]);
+        $this->assertTrue($module->isEnabled());
+    }
+
+    public function test_uninstall_persists_disabled_to_the_database(): void
+    {
+        $module = new FakeModule;
+        $module->install();
+        $module->uninstall();
+
+        $this->assertDatabaseHas('modules', ['name' => 'fake', 'enabled' => false]);
+        $this->assertFalse($module->isEnabled());
+    }
+
+    public function test_enabled_state_survives_a_cache_clear(): void
+    {
+        $module = new FakeModule;
+        $module->enable();
+
+        Cache::flush();
+
+        $this->assertTrue($module->isEnabled(), 'Module state must live in the DB, not the cache');
+    }
+
+    public function test_a_module_without_module_json_has_a_usable_name_and_does_not_fatal(): void
+    {
+        // getName() previously read an uninitialized typed $name → \Error on every
+        // request for a module shipped without module.json.
+        $module = new NamelessModule;
+
+        $this->assertSame('NamelessModule', $module->getName());
+        $this->assertFalse($module->isEnabled());
+    }
+}
+
+/** A concrete module with an explicit name; install side effects stubbed out. */
+class FakeModule extends BaseModule
+{
+    protected string $name = 'fake';
+
+    protected function runMigrations(): void {}
+
+    protected function rollbackMigrations(): void {}
+
+    protected function publishAssets(): void {}
+
+    protected function removeAssets(): void {}
+}
+
+/** A module that declares no name and ships no module.json. */
+class NamelessModule extends BaseModule
+{
+    protected function runMigrations(): void {}
+
+    protected function publishAssets(): void {}
+}

--- a/tests/Unit/ModuleSystemTest.php
+++ b/tests/Unit/ModuleSystemTest.php
@@ -6,10 +6,7 @@ use App\Modules\BaseModule;
 use App\Modules\Contracts\ModuleInterface;
 use App\Modules\Events\ModuleDisabled;
 use App\Modules\Events\ModuleEnabled;
-use App\Modules\Events\ModuleInstalled;
-use App\Modules\Events\ModuleUninstalled;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
@@ -20,7 +17,8 @@ class ModuleSystemTest extends TestCase
 
     private function makeModule(string $name = 'TestModule'): BaseModule
     {
-        return new class($name) extends BaseModule {
+        return new class($name) extends BaseModule
+        {
             private string $moduleName;
 
             public function __construct(string $name)
@@ -39,7 +37,9 @@ class ModuleSystemTest extends TestCase
             }
 
             protected function runMigrations(): void {}
+
             protected function publishAssets(): void {}
+
             protected function removeAssets(): void {}
         };
     }
@@ -133,15 +133,17 @@ class ModuleSystemTest extends TestCase
         $this->assertIsArray($module->getConfig());
     }
 
-    public function test_module_uses_cache_for_enabled_state(): void
+    public function test_module_persists_enabled_state_to_the_database(): void
     {
+        // The modules table is the single source of truth (read by ModuleServiceProvider
+        // to gate registration) — not a cache flag, which drifted and was cache:clear'd.
         $module = $this->makeModule('CacheModule');
         $module->enable();
 
-        $this->assertTrue(Cache::get('module.CacheModule.enabled'));
+        $this->assertDatabaseHas('modules', ['name' => 'CacheModule', 'enabled' => true]);
 
         $module->disable();
 
-        $this->assertFalse(Cache::get('module.CacheModule.enabled'));
+        $this->assertDatabaseHas('modules', ['name' => 'CacheModule', 'enabled' => false]);
     }
 }


### PR DESCRIPTION
## Summary

The bespoke module system tracked a module’s **enabled** flag in two places that drifted apart:
- a **cache key** `module.{name}.enabled` (written/read by `BaseModule`), and
- the **`modules.enabled` DB column** — written by `ModuleManager`, and the *only* thing `ModuleServiceProvider` reads to gate route/view/Filament registration.

### Consequences of the split
- **`install()` never persisted to the DB.** `BaseModule::install → enable` wrote only the cache, so a freshly installed module stayed `enabled=false` in the DB → its routes/views were never registered (installed-but-dead until a separate `enable`).
- **`uninstall()` never cleared the DB.** A previously-enabled module kept `enabled=true` → re-registered on the next boot.
- **`cache:clear` (routine on deploy) wiped all module state** → every module read `isEnabled()===false` while the DB still said enabled; dependency guards computed against empty state.

## Fix

`BaseModule::isEnabled/enable/disable` now read/write the `modules` table (`persistEnabled` via `updateOrCreate`); the cache flag is gone. `install()`/`uninstall()` are correct because they route through `enable()`/`disable()`.

Two more defects fixed in the same file:
- **Latent per-request fatal:** a module shipped without `module.json` (and no subclass default) left the typed `$name` uninitialized, so `getName()` — which `ModuleManager` (a **per-request singleton**) calls on every request — threw an *“accessed before initialization”* `\Error`, **500ing every web request**. `loadModuleInfo` now defaults `$name` to the class basename first.
- **`runMigrations`** built `--path` from the declared name, not the module dir → when `module.json`’s name differed from the folder, `migrate` ran 0 migrations while `install()` reported success. Now derived from `getModulePath()`.

## Scope

The subsystem is currently **dormant** (no concrete modules in `app/Modules`), so this is a correctness / latent-fatal fix, not a live regression.

## Tests

**+4** (`ModuleStateTest`): install/uninstall persist to DB; state survives a cache clear; a `module.json`-less module has a usable name and doesn’t fatal. Updated the existing cache-contract test to assert DB persistence. Full suite **997 passed / 0 failed** (random order shows only the known `SocialstreamRegistration` seed flake).

Found via a read-only audit of the module subsystem.