### PR TITLE
fix(cart): stop trusting client-supplied price / flags / quantity (price tampering)

### DIFF
--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -21,7 +21,11 @@ class CartController extends Controller
 
     public function add(Request $request, Product $product)
     {
-        $quantity = $request->input('quantity', 1);
+        // Guard the quantity — a negative value passes the `inventory_count < $quantity`
+        // check and, at checkout, drags the total down and INCREMENTS stock via the
+        // atomic decrement. (add() previously skipped the min:1 guard that update() has.)
+        $request->validate(['quantity' => 'nullable|integer|min:1']);
+        $quantity = (int) $request->input('quantity', 1);
 
         if ($product->inventory_count < $quantity) {
             return redirect()->back()->with('error', 'Not enough inventory available.');

--- a/app/Livewire/ShoppingCart.php
+++ b/app/Livewire/ShoppingCart.php
@@ -2,10 +2,10 @@
 
 namespace App\Livewire;
 
+use App\Models\Product;
+use Illuminate\Support\Facades\Session;
 use Livewire\Attributes\On;
 use Livewire\Component;
-use Illuminate\Support\Facades\Session;
-use App\Models\Product;
 
 class ShoppingCart extends Component
 {
@@ -27,29 +27,37 @@ class ShoppingCart extends Component
     }
 
     #[On('addToCart')]
-    public function addToCart(int $productId, string $name, float $price, int $quantity = 1, bool $isDownloadable = false, float $weight = 0): void
+    public function addToCart(int $productId, string $name = '', float $price = 0, int $quantity = 1, bool $isDownloadable = false, float $weight = 0): void
     {
+        // Never trust the dispatched name/price/isDownloadable/weight — the checkout
+        // charges whatever the session cart holds, so a client could set price=0.01,
+        // forge the downloadable flag to skip the stock gate, or send a negative
+        // quantity. Derive everything from the Product and clamp the quantity.
         $product = Product::findOrFail($productId);
+        $quantity = max(1, $quantity);
+        $isDownloadable = (bool) $product->is_downloadable;
 
-        if (!$isDownloadable && $product->inventory_count < $quantity) {
+        if (! $isDownloadable && $product->inventory_count < $quantity) {
             session()->flash('error', 'Not enough inventory available.');
+
             return;
         }
 
         if (isset($this->items[$productId])) {
             $newQuantity = $this->items[$productId]['quantity'] + $quantity;
-            if (!$isDownloadable && $newQuantity > $product->inventory_count) {
+            if (! $isDownloadable && $newQuantity > $product->inventory_count) {
                 session()->flash('error', 'Cannot add more items than available in stock.');
+
                 return;
             }
             $this->items[$productId]['quantity'] = $newQuantity;
         } else {
             $this->items[$productId] = [
-                'name' => $name,
-                'price' => $price,
+                'name' => $product->name,
+                'price' => (float) $product->price,
                 'quantity' => $quantity,
                 'is_downloadable' => $isDownloadable,
-                'weight' => $weight,
+                'weight' => (float) ($product->weight ?? 0),
             ];
         }
 
@@ -61,10 +69,11 @@ class ShoppingCart extends Component
     public function hasPhysicalProducts(): bool
     {
         foreach ($this->items as $item) {
-            if (!$item['is_downloadable']) {
+            if (! $item['is_downloadable']) {
                 return true;
             }
         }
+
         return false;
     }
 
@@ -72,23 +81,27 @@ class ShoppingCart extends Component
     {
         if ($quantity < 1) {
             $this->addError('quantity', 'Quantity must be at least 1');
+
             return;
         }
 
-        if (!isset($this->items[$productId])) {
+        if (! isset($this->items[$productId])) {
             $this->addError('product', 'Product not found in cart');
+
             return;
         }
 
         $isDownloadable = $this->items[$productId]['is_downloadable'] ?? false;
-        if (!$isDownloadable) {
+        if (! $isDownloadable) {
             $product = Product::find($productId);
-            if (!$product) {
+            if (! $product) {
                 $this->addError('product', 'Product not found');
+
                 return;
             }
             if ($quantity > $product->inventory_count) {
                 session()->flash('error', 'Requested quantity exceeds available stock.');
+
                 return;
             }
         }
@@ -121,7 +134,7 @@ class ShoppingCart extends Component
     {
         return round(array_reduce(
             $this->items,
-            fn(float $carry, array $item) => $carry + ($item['price'] * $item['quantity']),
+            fn (float $carry, array $item) => $carry + ($item['price'] * $item['quantity']),
             0.0
         ), 2);
     }

--- a/tests/Feature/CartInputTamperingTest.php
+++ b/tests/Feature/CartInputTamperingTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\ShoppingCart;
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Session;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * The cart must derive price / name / downloadable purely from the Product — the
+ * add-to-cart paths previously trusted client-supplied values, and checkout charges
+ * whatever the session cart holds. That let a shopper set price=0.01 (buy anything
+ * for a cent), forge is_downloadable (skip the stock/shipping gate), or add a
+ * negative quantity (drag the total down and INCREMENT stock at checkout).
+ */
+class CartInputTamperingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_livewire_add_to_cart_ignores_client_supplied_price_and_name(): void
+    {
+        $product = Product::factory()->create(['price' => 100, 'inventory_count' => 10, 'is_downloadable' => false]);
+
+        Livewire::test(ShoppingCart::class)->dispatch(
+            'addToCart',
+            productId: $product->id, name: 'HACKED', price: 0.01, quantity: 1, isDownloadable: false, weight: 0
+        );
+
+        $cart = Session::get('cart');
+        $this->assertEquals(100, $cart[$product->id]['price'], 'Cart must use the product price, not the client value');
+        $this->assertEquals($product->name, $cart[$product->id]['name']);
+    }
+
+    public function test_livewire_add_to_cart_ignores_forged_downloadable_flag(): void
+    {
+        // Out-of-stock PHYSICAL product; forging isDownloadable=true would skip the stock gate.
+        $product = Product::factory()->create(['price' => 50, 'inventory_count' => 0, 'is_downloadable' => false]);
+
+        Livewire::test(ShoppingCart::class)->dispatch(
+            'addToCart',
+            productId: $product->id, name: 'x', price: 50, quantity: 1, isDownloadable: true, weight: 0
+        );
+
+        $this->assertArrayNotHasKey($product->id, Session::get('cart', []), 'A forged downloadable flag must not bypass the stock check');
+    }
+
+    public function test_livewire_add_to_cart_never_stores_a_non_positive_quantity(): void
+    {
+        $product = Product::factory()->create(['price' => 100, 'inventory_count' => 10, 'is_downloadable' => false]);
+
+        Livewire::test(ShoppingCart::class)->dispatch(
+            'addToCart',
+            productId: $product->id, name: 'x', price: 100, quantity: -5, isDownloadable: false, weight: 0
+        );
+
+        $cart = Session::get('cart', []);
+        if (isset($cart[$product->id])) {
+            $this->assertGreaterThanOrEqual(1, $cart[$product->id]['quantity']);
+        }
+    }
+
+    public function test_cart_controller_add_rejects_non_positive_quantity(): void
+    {
+        $product = Product::factory()->create(['price' => 100, 'inventory_count' => 10]);
+
+        $this->post(route('cart.add', $product), ['quantity' => -5])
+            ->assertSessionHasErrors('quantity');
+
+        $this->assertArrayNotHasKey($product->id, Session::get('cart', []));
+    }
+}


### PR DESCRIPTION
## The bug (money loss)

Two add-to-cart paths trusted client input, and checkout charges whatever the session cart holds (`CheckoutController` reads `$item["price"]`/`$item["quantity"]` verbatim into the order line and the gateway charge). So this was **direct money loss**.

### 1. Livewire `ShoppingCart::addToCart` — price/flag tampering (critical)
It stored the **dispatched** `name` / `price` / `isDownloadable` / `weight` straight into the session cart (`Session::put("cart", …)`); the `Product` was loaded only for the stock check and `$product->price` was never used.

From the browser a shopper could:
- dispatch `addToCart` with `price = 0.01` → **buy anything for a cent**;
- forge `isDownloadable = true` → skip the stock/shipping gate on a physical good;
- send a **negative quantity**.

Now `name` / `price` / `is_downloadable` are derived from the `Product` and quantity is clamped to `>= 1`. The dispatched values are ignored — the params remain in the signature only for positional event-binding compatibility.

### 2. `CartController::add` — no quantity validation
`POST /cart/add/{product}` read `quantity` with no `min:1` (its sibling `update()` guards it). A negative quantity passed the `inventory_count < $quantity` check, stored a negative line, and at checkout dragged the total down while the atomic `decrement(-n)` **incremented** stock. Added `nullable|integer|min:1`.

## Tests

**+4** (`CartInputTamperingTest`): dispatched price + name are ignored; a forged downloadable flag cant bypass the stock check; a non-positive quantity is never stored on either path. Found via a read-only controllers/Livewire audit sweep. Full suite **1001 passed / 0 failed**.

## Follow-up (noted, not in this PR)

`app/Http/Livewire/ShoppingCart.php` is an unregistered Livewire-v2-era **duplicate** carrying the same bug — not autodiscovered or referenced anywhere, so outside the live attack surface. Delete in a cleanup pass.