### PR TITLE
fix(analytics): report revenue net of refunds on the admin dashboard

### DIFF
--- a/app/Services/AnalyticsService.php
+++ b/app/Services/AnalyticsService.php
@@ -2,12 +2,11 @@
 
 namespace App\Services;
 
-use App\Models\AnalyticsEvent;
 use App\Models\Customer;
 use App\Models\Order;
 use App\Models\Product;
-use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class AnalyticsService
 {
@@ -19,12 +18,12 @@ class AnalyticsService
         $startDate = $startDate ?? now()->subDays(30);
         $endDate = $endDate ?? now();
 
-        $groupBy = match($period) {
+        $groupBy = match ($period) {
             'hourly' => "DATE_FORMAT(order_date, '%Y-%m-%d %H:00:00')",
-            'daily' => "DATE(order_date)",
-            'weekly' => "YEARWEEK(order_date, 1)",
+            'daily' => 'DATE(order_date)',
+            'weekly' => 'YEARWEEK(order_date, 1)',
             'monthly' => "DATE_FORMAT(order_date, '%Y-%m')",
-            default => "DATE(order_date)"
+            default => 'DATE(order_date)'
         };
 
         $sales = Order::whereBetween('order_date', [$startDate, $endDate])
@@ -32,8 +31,10 @@ class AnalyticsService
             ->select(
                 DB::raw("{$groupBy} as period"),
                 DB::raw('COUNT(*) as order_count'),
-                DB::raw('SUM(total_amount) as total_revenue'),
-                DB::raw('AVG(total_amount) as avg_order_value')
+                // Net of refunds: refunded orders keep payment_status='paid' and track
+                // the returned money in refund_total, so gross would overstate revenue.
+                DB::raw('SUM(total_amount - COALESCE(refund_total, 0)) as total_revenue'),
+                DB::raw('AVG(total_amount - COALESCE(refund_total, 0)) as avg_order_value')
             )
             ->groupBy('period')
             ->orderBy('period')
@@ -53,7 +54,8 @@ class AnalyticsService
         $orders = Order::whereBetween('order_date', [$startDate, $endDate])
             ->where('payment_status', 'paid');
 
-        $totalRevenue = $orders->sum('total_amount');
+        // Net of refunds — see the note in getSalesTrends.
+        $totalRevenue = (float) $orders->sum(DB::raw('total_amount - COALESCE(refund_total, 0)'));
         $orderCount = $orders->count();
         $avgOrderValue = $orderCount > 0 ? $totalRevenue / $orderCount : 0;
 
@@ -64,16 +66,16 @@ class AnalyticsService
 
         $previousOrders = Order::whereBetween('order_date', [$previousStartDate, $previousEndDate])
             ->where('payment_status', 'paid');
-        
-        $previousRevenue = $previousOrders->sum('total_amount');
+
+        $previousRevenue = (float) $previousOrders->sum(DB::raw('total_amount - COALESCE(refund_total, 0)'));
         $previousOrderCount = $previousOrders->count();
 
-        $revenueGrowth = $previousRevenue > 0 
-            ? (($totalRevenue - $previousRevenue) / $previousRevenue) * 100 
+        $revenueGrowth = $previousRevenue > 0
+            ? (($totalRevenue - $previousRevenue) / $previousRevenue) * 100
             : 0;
-        
-        $orderGrowth = $previousOrderCount > 0 
-            ? (($orderCount - $previousOrderCount) / $previousOrderCount) * 100 
+
+        $orderGrowth = $previousOrderCount > 0
+            ? (($orderCount - $previousOrderCount) / $previousOrderCount) * 100
             : 0;
 
         return [
@@ -118,7 +120,7 @@ class AnalyticsService
     public function getCustomerDemographics(): array
     {
         $totalCustomers = Customer::count();
-        
+
         // Customers by location (city)
         $byCity = Customer::select('city', DB::raw('COUNT(*) as count'))
             ->whereNotNull('city')
@@ -163,13 +165,14 @@ class AnalyticsService
 
         // Top customers by revenue
         $topCustomers = Customer::select(
-                'customers.id',
-                'customers.first_name',
-                'customers.last_name',
-                'customers.email',
-                DB::raw('COUNT(orders.id) as order_count'),
-                DB::raw('SUM(orders.total_amount) as lifetime_value')
-            )
+            'customers.id',
+            'customers.first_name',
+            'customers.last_name',
+            'customers.email',
+            DB::raw('COUNT(orders.id) as order_count'),
+            // Net of refunds — refunded orders stay payment_status='paid'.
+            DB::raw('SUM(orders.total_amount - COALESCE(orders.refund_total, 0)) as lifetime_value')
+        )
             ->join('orders', 'customers.id', '=', 'orders.customer_id')
             ->where('orders.payment_status', 'paid')
             ->groupBy('customers.id', 'customers.first_name', 'customers.last_name', 'customers.email')
@@ -217,7 +220,7 @@ class AnalyticsService
                 ->where('inventory_count', '>', 0)
                 ->count(),
             'in_stock' => Product::where('inventory_count', '>', 0)
-                ->where(function($q) {
+                ->where(function ($q) {
                     $q->whereNull('low_stock_threshold')
                         ->orWhereColumn('inventory_count', '>', 'low_stock_threshold');
                 })
@@ -245,8 +248,8 @@ class AnalyticsService
                 return [
                     'id' => $order->id,
                     'order_date' => $order->order_date,
-                    'customer_name' => $order->customer 
-                        ? $order->customer->first_name . ' ' . $order->customer->last_name 
+                    'customer_name' => $order->customer
+                        ? $order->customer->first_name.' '.$order->customer->last_name
                         : 'Guest',
                     'total_amount' => $order->total_amount,
                     'payment_status' => $order->payment_status,

--- a/tests/Feature/AnalyticsNetRevenueTest.php
+++ b/tests/Feature/AnalyticsNetRevenueTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Order;
+use App\Services\AnalyticsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Refunded orders deliberately keep payment_status='paid' (the payment happened;
+ * refund_total tracks the money returned — see Order::transitionTo). So revenue
+ * reporting must subtract refund_total, otherwise a fully refunded order still
+ * shows as full gross revenue on the admin dashboard.
+ */
+class AnalyticsNetRevenueTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function paidOrder(float $total, float $refund, string $status = 'paid'): Order
+    {
+        return Order::create([
+            'customer_email' => 'buyer@example.com',
+            'order_date' => now(),
+            'payment_status' => 'paid',
+            'status' => $status,
+            'total_amount' => $total,
+            'refund_total' => $refund,
+        ]);
+    }
+
+    public function test_sales_metrics_report_revenue_net_of_refunds(): void
+    {
+        $this->paidOrder(500, 0);                               // full 500
+        $this->paidOrder(300, 300, 'refunded');                // fully refunded → 0
+        $this->paidOrder(200, 50, 'partially_refunded');       // nets 150
+
+        $metrics = app(AnalyticsService::class)->getSalesMetrics();
+
+        // 500 + 0 + 150 = 650, not the gross 1000.
+        $this->assertEquals(650.0, $metrics['total_revenue']);
+        $this->assertEquals(3, $metrics['order_count']);
+    }
+
+    public function test_sales_trends_report_revenue_net_of_refunds(): void
+    {
+        $this->paidOrder(500, 0);
+        $this->paidOrder(300, 300, 'refunded');
+
+        $trends = app(AnalyticsService::class)->getSalesTrends('daily');
+
+        // Both orders fall on the same day → one bucket, net = 500 + 0.
+        $this->assertCount(1, $trends);
+        $this->assertEquals(500.0, (float) $trends[0]['total_revenue']);
+    }
+}


### PR DESCRIPTION
## The bug

Refunded orders **deliberately keep `payment_status = "paid"`** — `Order::transitionTo` only sets `payment_status` on the paid/failed transitions and leaves refund states as `"paid"`, tracking the returned money in the separate `refund_total` column. (The comment at `Order.php:142` literally names *analytics, LTV, invoices and the admin sales widgets* as the readers that must account for `refund_total`.)

But `AnalyticsService` summed **gross `total_amount`** where `payment_status = "paid"` with no deduction. So a fully refunded **\$500** order still counted as **\$500 of revenue** on the admin dashboard — Total Revenue, Average Order Value, the Sales Trends line, and customer lifetime value all systematically **overstated** revenue for any store with refunds.

## Fix

Subtract `COALESCE(refund_total, 0)` from the revenue aggregates:
- `getSalesMetrics` — current **and** previous-period revenue (so growth % is also net)
- `getSalesTrends` — revenue line **and** AOV
- `getCustomerDemographics` — top-customers lifetime value

`net = total_amount − refund_total`, portable SQL — no schema change, and the MySQL-only date-grouping (`DATE_FORMAT`/`YEARWEEK`) is untouched.

## Tests

**+2** (`AnalyticsNetRevenueTest`): a fully refunded order contributes 0; a partial refund nets the remainder (metrics `650` not gross `1000`; trends net per bucket). Full suite **1003 passed / 0 failed**. Found via a read-only admin-Filament audit sweep.

## Follow-ups (noted, not in this PR)

- `getTopProducts` sums per-item `price*quantity`; the order-level `refund_total` cant be attributed per product without per-item refund data (`RefundItem`), so its revenue stays gross.
- The demographics order-count segmentation counts orders regardless of `payment_status`.