### PR TITLE
fix(admin): make the Adjust Inventory stock action atomic (lost-update race)

### DIFF
--- a/app/Filament/Admin/Resources/Products/ProductResource.php
+++ b/app/Filament/Admin/Resources/Products/ProductResource.php
@@ -2,46 +2,39 @@
 
 namespace App\Filament\Admin\Resources\Products;
 
-use Filament\Schemas\Schema;
-use Filament\Forms\Components\Textarea;
-use Filament\Schemas\Components\Section;
-use Filament\Forms\Components\FileUpload;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Actions\EditAction;
-use Filament\Actions\Action;
-use Filament\Actions\DeleteBulkAction;
-use Filament\Actions\BulkAction;
-use App\Filament\Admin\Resources\Products\Pages\ListProducts;
 use App\Filament\Admin\Resources\Products\Pages\CreateProduct;
 use App\Filament\Admin\Resources\Products\Pages\EditProduct;
-use App\Filament\Admin\Resources\ProductResource\Pages;
-use App\Models\InventoryLog;
+use App\Filament\Admin\Resources\Products\Pages\ListProducts;
 use App\Models\Product;
 use App\Models\ProductCategory;
-use App\Models\ProductTag;
-use Filament\Notifications\Notification;
-use Filament\Forms;
-use Filament\Resources\Resource;
-use Filament\Tables;
-use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Collection;
-use League\Csv\Writer;
-use Filament\Forms\Components\Toggle;
+use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use League\Csv\Writer;
 
 class ProductResource extends Resource
 {
     protected static ?string $model = Product::class;
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-circle-stack';
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-circle-stack';
 
     protected static ?int $navigationSort = 2;
 
@@ -187,23 +180,15 @@ class ProductResource extends Resource
                             ->default('purchase'),
                     ])
                     ->action(function (Product $record, array $data): void {
-                        DB::transaction(function () use ($record, $data): void {
-                            $record->increment('inventory_count', $data['quantity']);
-
-                            InventoryLog::create([
-                                'product_id' => $record->id,
-                                'quantity_change' => $data['quantity'],
-                                'reason' => $data['reason'],
-                            ]);
-                        });
+                        $record->adjustInventory((int) $data['quantity'], $data['reason']);
                     }),
                 Action::make('adjustInventory')
                     ->label('Adjust Inventory')
                     ->icon('heroicon-o-adjustments-horizontal')
                     ->action(function (Product $record, array $data): void {
-                        $newInventory = $record->inventory_count + $data['adjustment'];
-
-                        if ($newInventory < 0) {
+                        // Atomic guarded adjust — see Product::adjustInventory. Returns
+                        // false when a decrease would take the count below zero.
+                        if (! $record->adjustInventory((int) $data['adjustment'], $data['reason'])) {
                             Notification::make()
                                 ->title('Inventory cannot go below zero.')
                                 ->danger()
@@ -212,15 +197,10 @@ class ProductResource extends Resource
                             return;
                         }
 
-                        DB::transaction(function () use ($record, $data, $newInventory): void {
-                            $record->update(['inventory_count' => $newInventory]);
-
-                            InventoryLog::create([
-                                'product_id' => $record->id,
-                                'quantity_change' => $data['adjustment'],
-                                'reason' => $data['reason'],
-                            ]);
-                        });
+                        Notification::make()
+                            ->title('Inventory adjusted.')
+                            ->success()
+                            ->send();
                     })
                     ->schema([
                         TextInput::make('adjustment')
@@ -261,9 +241,9 @@ class ProductResource extends Resource
     protected static function export(Collection $records)
     {
         $csv = Writer::createFromString('');
-        
+
         $csv->insertOne(['Name', 'SKU', 'Category', 'Price', 'Inventory Count', 'Low Stock Threshold', 'Status']);
-        
+
         foreach ($records as $record) {
             $csv->insertOne([
                 $record->name,
@@ -275,11 +255,11 @@ class ProductResource extends Resource
                 $record->inventory_count > $record->low_stock_threshold ? 'In Stock' : ($record->inventory_count > 0 ? 'Low Stock' : 'Out of Stock'),
             ]);
         }
-        
-        $filename = 'inventory_report_' . date('Y-m-d') . '.csv';
-        $path = storage_path('app/public/' . $filename);
+
+        $filename = 'inventory_report_'.date('Y-m-d').'.csv';
+        $path = storage_path('app/public/'.$filename);
         file_put_contents($path, $csv->getContent());
-        
+
         return response()->download($path)->deleteFileAfterSend();
     }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -380,5 +381,41 @@ class Product extends Model implements Orderable
     public function team()
     {
         return $this->belongsTo(Team::class);
+    }
+
+    /**
+     * Atomically adjust stock by $delta (positive to add, negative to remove) and
+     * record a reconcilable old/new InventoryLog row. A decrease is a guarded atomic
+     * decrement — it only succeeds while enough stock remains, so concurrent
+     * adjustments (or an adjustment racing a checkout decrement) can neither lose an
+     * update nor drive the count negative. Returns false if the decrease was refused.
+     */
+    public function adjustInventory(int $delta, string $reason): bool
+    {
+        return (bool) DB::transaction(function () use ($delta, $reason) {
+            if ($delta < 0) {
+                $affected = static::whereKey($this->getKey())
+                    ->where('inventory_count', '>=', abs($delta))
+                    ->decrement('inventory_count', abs($delta));
+
+                if ($affected === 0) {
+                    return false;
+                }
+            } else {
+                $this->increment('inventory_count', $delta);
+            }
+
+            $this->refresh();
+
+            InventoryLog::create([
+                'product_id' => $this->id,
+                'quantity_change' => $delta,
+                'old_quantity' => $this->inventory_count - $delta,
+                'new_quantity' => $this->inventory_count,
+                'reason' => $reason,
+            ]);
+
+            return true;
+        });
     }
 }

--- a/tests/Feature/ProductAdjustInventoryTest.php
+++ b/tests/Feature/ProductAdjustInventoryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The admin "Adjust Inventory" / "Add Stock" actions must change stock atomically
+ * (guarded increment/decrement), not read-modify-write — otherwise two staff, or an
+ * adjustment racing a checkout decrement, lose one update. The floor-at-zero check
+ * must also be atomic, and each change must leave a reconcilable old/new audit row.
+ */
+class ProductAdjustInventoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_positive_adjustment_increments_and_logs_old_and_new(): void
+    {
+        $product = Product::factory()->create(['inventory_count' => 20]);
+
+        $this->assertTrue($product->adjustInventory(5, 'restock'));
+        $this->assertEquals(25, $product->fresh()->inventory_count);
+        $this->assertDatabaseHas('inventory_logs', [
+            'product_id' => $product->id, 'quantity_change' => 5, 'old_quantity' => 20, 'new_quantity' => 25,
+        ]);
+    }
+
+    public function test_negative_adjustment_decrements_and_logs_old_and_new(): void
+    {
+        $product = Product::factory()->create(['inventory_count' => 20]);
+
+        $this->assertTrue($product->adjustInventory(-8, 'shrinkage'));
+        $this->assertEquals(12, $product->fresh()->inventory_count);
+        $this->assertDatabaseHas('inventory_logs', [
+            'product_id' => $product->id, 'quantity_change' => -8, 'old_quantity' => 20, 'new_quantity' => 12,
+        ]);
+    }
+
+    public function test_adjustment_below_zero_is_refused_and_leaves_stock_and_ledger_untouched(): void
+    {
+        $product = Product::factory()->create(['inventory_count' => 5]);
+
+        $this->assertFalse($product->adjustInventory(-10, 'oversized decrease'));
+        $this->assertEquals(5, $product->fresh()->inventory_count);
+        $this->assertDatabaseMissing('inventory_logs', ['product_id' => $product->id, 'quantity_change' => -10]);
+    }
+}


### PR DESCRIPTION
## The bug

The admin **Adjust Inventory** action did a read-modify-write:

```php
$newInventory = $record->inventory_count + $data["adjustment"];   // stale PHP read
if ($newInventory < 0) { … reject … }
$record->update(["inventory_count" => $newInventory]);            // absolute write
```

Two staff adjusting the same product at once — or an adjustment racing a **checkout decrement** — both read the same starting count, and the last write wins, silently dropping the other change (oversell or phantom stock). The `< 0` floor was computed on the stale read too. The sibling **Add Stock** action was already atomic (`increment()`).

## Fix

Extracted `Product::adjustInventory(int $delta, string $reason): bool`:
- positive delta → atomic `increment`;
- negative delta → **guarded atomic decrement** (`where inventory_count >= |delta|`), so it can never lose an update or go below zero, returning `false` when a decrease is refused.

Both admin actions now route through it — one atomic entry point (the same pattern checkout already uses to prevent oversell).

Also completes the **InventoryLog ledger**: each adjustment now records `old_quantity` / `new_quantity` (the columns the tracking-columns migration claimed `ProductResource` populated but didnt) — `old = new − delta`, exact under concurrency because the atomic op applied exactly `delta`.

## Tests

**+3** on `Product::adjustInventory` (increment + log; decrement + log; a below-zero decrease is refused, leaving stock **and** ledger untouched). Full suite **1006 passed / 0 failed**. Found via a read-only admin-Filament audit sweep.