### PR TITLE
fix(analytics): accurate low-stock count + paid-only customer segmentation

### DIFF
--- a/app/Filament/Admin/Widgets/InventoryStatsWidget.php
+++ b/app/Filament/Admin/Widgets/InventoryStatsWidget.php
@@ -16,16 +16,16 @@ class InventoryStatsWidget extends BaseWidget
         $insights = $analyticsService->getInventoryInsights();
 
         return [
-            Stat::make('Inventory Value', '$' . number_format($insights['inventory_value'], 2))
+            Stat::make('Inventory Value', '$'.number_format($insights['inventory_value'], 2))
                 ->description('Total value of current inventory')
                 ->descriptionIcon('heroicon-m-currency-dollar')
                 ->color('success'),
-            
-            Stat::make('Low Stock Items', number_format(count($insights['low_stock_products'])))
+
+            Stat::make('Low Stock Items', number_format($insights['low_stock_count']))
                 ->description('Products below threshold')
                 ->descriptionIcon('heroicon-m-exclamation-triangle')
                 ->color('warning'),
-            
+
             Stat::make('Out of Stock', number_format($insights['out_of_stock_count']))
                 ->description('Products unavailable')
                 ->descriptionIcon('heroicon-m-x-circle')

--- a/app/Services/AnalyticsService.php
+++ b/app/Services/AnalyticsService.php
@@ -143,7 +143,13 @@ class AnalyticsService
         $customerSegments = DB::query()
             ->fromSub(
                 DB::table('customers')
-                    ->leftJoin('orders', 'customers.id', '=', 'orders.customer_id')
+                    // Count only paid orders — pending/failed/cancelled orders would
+                    // otherwise inflate a customer into a higher segment. Keep it in the
+                    // JOIN (not a WHERE) so customers with no paid orders still show as 'No Orders'.
+                    ->leftJoin('orders', function ($join) {
+                        $join->on('customers.id', '=', 'orders.customer_id')
+                            ->where('orders.payment_status', '=', 'paid');
+                    })
                     ->select(
                         'customers.id',
                         DB::raw("
@@ -195,9 +201,12 @@ class AnalyticsService
      */
     public function getInventoryInsights(): array
     {
-        // Low stock products
-        $lowStockProducts = Product::whereNotNull('low_stock_threshold')
-            ->whereColumn('inventory_count', '<=', 'low_stock_threshold')
+        // Low stock products — the list is capped for display; low_stock_count is the
+        // true total so the dashboard stat doesn't silently plateau at the cap.
+        $lowStockQuery = Product::whereNotNull('low_stock_threshold')
+            ->whereColumn('inventory_count', '<=', 'low_stock_threshold');
+        $lowStockCount = (clone $lowStockQuery)->count();
+        $lowStockProducts = $lowStockQuery
             ->select('id', 'name', 'inventory_count', 'low_stock_threshold')
             ->orderBy('inventory_count')
             ->limit(20)
@@ -229,6 +238,7 @@ class AnalyticsService
 
         return [
             'low_stock_products' => $lowStockProducts,
+            'low_stock_count' => $lowStockCount,
             'out_of_stock_count' => $outOfStockCount,
             'inventory_value' => round($inventoryValue, 2),
             'stock_status' => $stockStatus,

--- a/tests/Feature/AnalyticsWidgetAccuracyTest.php
+++ b/tests/Feature/AnalyticsWidgetAccuracyTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Customer;
+use App\Models\Order;
+use App\Models\Product;
+use App\Services\AnalyticsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AnalyticsWidgetAccuracyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_low_stock_count_is_not_capped_at_the_display_list_limit(): void
+    {
+        Product::factory()->count(25)->create(['inventory_count' => 1, 'low_stock_threshold' => 5]);
+
+        $insights = app(AnalyticsService::class)->getInventoryInsights();
+
+        // The display list is capped at 20, but the headline count must be the real total.
+        $this->assertCount(20, $insights['low_stock_products']);
+        $this->assertEquals(25, $insights['low_stock_count']);
+    }
+
+    public function test_customer_segmentation_counts_only_paid_orders(): void
+    {
+        $customer = Customer::create([
+            'first_name' => 'A', 'last_name' => 'B', 'email' => 'seg@example.com',
+            'phone_number' => 1, 'address' => 'x', 'city' => 'x', 'state' => 'x', 'postal_code' => '1',
+        ]);
+        // One paid order + two non-paid; only the paid one should count → "One-time Buyer".
+        Order::create(['customer_id' => $customer->id, 'total_amount' => 10, 'status' => 'paid', 'payment_status' => 'paid']);
+        Order::create(['customer_id' => $customer->id, 'total_amount' => 10, 'status' => 'failed', 'payment_status' => 'failed']);
+        Order::create(['customer_id' => $customer->id, 'total_amount' => 10, 'status' => 'pending', 'payment_status' => 'pending']);
+
+        $segments = collect(app(AnalyticsService::class)->getCustomerDemographics()['segments'])
+            ->keyBy('segment');
+
+        $this->assertEquals(1, $segments['One-time Buyer']->customer_count ?? 0);
+        $this->assertArrayNotHasKey('Regular Customer', $segments->all());
+    }
+}


### PR DESCRIPTION
## Two admin-dashboard accuracy fixes (from the widget audit)

1. **Low Stock Items stat plateaued at 20.** `InventoryStatsWidget` used `count($insights["low_stock_products"])`, but that list is capped with `->limit(20)` for display — so the headline number never exceeded 20. Added a real `low_stock_count` (same predicate, no limit); the widget now reads it. The display list stays capped.

2. **Customer segmentation counted unpaid orders.** `getCustomerDemographics` left-joined `orders` and bucketed by `COUNT(orders.id)` with no `payment_status` filter, so pending/failed/cancelled orders inflated customers into *Regular*/*Loyal*. The `paid` filter now lives in the **JOIN condition** (not a `WHERE`) so customers with no paid orders still bucket as *No Orders*.

**+2 tests** (`AnalyticsWidgetAccuracyTest`): 25 low-stock products → count 25 (list still 20); a customer with 1 paid + 2 non-paid orders → *One-time Buyer*, not *Regular*. Full suite **1008 passed / 0 failed**.