### PR TITLE
feat(paypal): rewrite PayPalGateway onto the maintained srmklive/paypal SDK

### DIFF
--- a/app/Services/PaymentGateways/PayPalGateway.php
+++ b/app/Services/PaymentGateways/PayPalGateway.php
@@ -2,105 +2,91 @@
 
 namespace App\Services\PaymentGateways;
 
-use Exception;
 use App\Interfaces\PaymentGatewayInterface;
-use PayPal\Rest\ApiContext;
-use PayPal\Auth\OAuthTokenCredential;
-use PayPal\Api\Amount;
-use PayPal\Api\Payer;
-use PayPal\Api\Payment;
-use PayPal\Api\RedirectUrls;
-use PayPal\Api\Transaction;
-use PayPal\Api\RefundRequest;
-use Illuminate\Support\Facades\Config;
+use Srmklive\PayPal\Services\PayPal as PayPalClient;
+use Throwable;
 
+/**
+ * PayPal gateway on the maintained srmklive/paypal SDK (PayPal Orders v2 REST API).
+ * Replaces the abandoned paypal/rest-api-sdk-php (PayPal\Api\*, v1) the class used to
+ * construct in its ctor — which fataled on instantiation once that package was gone.
+ */
 class PayPalGateway implements PaymentGatewayInterface
 {
-    private $apiContext;
+    private ?PayPalClient $provider = null;
 
-    public function __construct()
+    /** Inject a preconfigured client (used in tests). */
+    public function setProvider(PayPalClient $provider): void
     {
-        $this->apiContext = new ApiContext(
-            new OAuthTokenCredential(
-                Config::get('services.paypal.client_id'),
-                Config::get('services.paypal.secret')
-            )
-        );
-        $this->apiContext->setConfig(Config::get('services.paypal.settings'));
+        $this->provider = $provider;
     }
 
+    /**
+     * Capture a PayPal order the buyer already created + approved client-side. The
+     * order id arrives as $paymentDetails['payment_id'] (see CheckoutController).
+     */
     public function processPayment(float $amount, array $paymentDetails): array
     {
-        $payer = new Payer();
-        $payer->setPaymentMethod('paypal');
-
-        $amountDetails = new Amount();
-        $amountDetails->setTotal($amount)
-                      ->setCurrency('USD');
-
-        $transaction = new Transaction();
-        $transaction->setAmount($amountDetails)
-                    ->setDescription('Payment transaction');
-
-        $redirectUrls = new RedirectUrls();
-        $redirectUrls->setReturnUrl(url('/payment/success'))
-                     ->setCancelUrl(url('/payment/cancel'));
-
-        $payment = new Payment();
-        $payment->setIntent('sale')
-                ->setPayer($payer)
-                ->setTransactions([$transaction])
-                ->setRedirectUrls($redirectUrls);
+        $orderId = $paymentDetails['payment_id'] ?? null;
+        if (empty($orderId)) {
+            return ['success' => false, 'error' => 'Missing PayPal order id.'];
+        }
 
         try {
-            $payment->create($this->apiContext);
-            return ['success' => true, 'payment_id' => $payment->getId(), 'approval_url' => $payment->getApprovalLink()];
-        } catch (Exception $e) {
+            $result = $this->provider()->capturePaymentOrder($orderId);
+
+            if (($result['status'] ?? null) === 'COMPLETED') {
+                return [
+                    'success' => true,
+                    'transaction_id' => $this->captureId($result) ?? $orderId,
+                    'status' => 'COMPLETED',
+                ];
+            }
+
+            return ['success' => false, 'error' => 'PayPal capture not completed', 'status' => $result['status'] ?? 'unknown'];
+        } catch (Throwable $e) {
+            return ['success' => false, 'error' => $e->getMessage()];
+        }
+    }
+
+    public function refundPayment(string $transactionId, float $amount): array
+    {
+        try {
+            $result = $this->provider()->refundCapturedPayment($transactionId, $transactionId, $amount, 'Order refund');
+
+            if (($result['status'] ?? null) === 'COMPLETED') {
+                return ['success' => true, 'refund_id' => $result['id'] ?? null, 'status' => 'COMPLETED'];
+            }
+
+            return ['success' => false, 'error' => 'Refund not completed', 'status' => $result['status'] ?? 'unknown'];
+        } catch (Throwable $e) {
             return ['success' => false, 'error' => $e->getMessage()];
         }
     }
 
     public function processSubscription(string $planId, array $subscriptionDetails): array
     {
-        // Implement PayPal subscription logic here
-        // This is a placeholder implementation
-        return ['success' => true, 'subscription_id' => 'paypal_sub_' . uniqid()];
+        // ponytail: real PayPal subscriptions need a billing plan provisioned via the
+        // Subscriptions API first; not wired. Return an honest failure rather than the
+        // fake uniqid() "success" the old stub returned.
+        return ['success' => false, 'error' => 'PayPal subscriptions are not implemented.'];
     }
 
-    public function refundPayment(string $transactionId, float $amount): array
+    private function provider(): PayPalClient
     {
-        try {
-            // Retrieve the sale transaction
-            $sale = \PayPal\Api\Sale::get($transactionId, $this->apiContext);
-            
-            // Create refund object
-            $refund = new \PayPal\Api\RefundRequest();
-            $refundAmount = new Amount();
-            $refundAmount->setCurrency('USD')
-                        ->setTotal($amount);
-            $refund->setAmount($refundAmount);
-            
-            // Execute the refund
-            $refundedSale = $sale->refundSale($refund, $this->apiContext);
-            
-            if ($refundedSale->getState() === 'completed') {
-                return [
-                    'success' => true,
-                    'refund_id' => $refundedSale->getId(),
-                    'status' => $refundedSale->getState()
-                ];
-            }
-            
-            return [
-                'success' => false,
-                'error' => 'Refund not completed',
-                'status' => $refundedSale->getState()
-            ];
-        } catch (Exception $e) {
-            return [
-                'success' => false,
-                'error' => $e->getMessage()
-            ];
+        if ($this->provider === null) {
+            $provider = new PayPalClient;
+            $provider->setApiCredentials(config('paypal'));
+            $provider->getAccessToken();
+            $this->provider = $provider;
         }
+
+        return $this->provider;
+    }
+
+    /** Pull the capture id out of the Orders-v2 capture response. */
+    private function captureId(array $result): ?string
+    {
+        return $result['purchase_units'][0]['payments']['captures'][0]['id'] ?? null;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "orangehill/iseed": "^3.0",
         "spatie/laravel-menu": "^4.2",
         "spatie/laravel-permission": "^6.0",
-        "spatie/laravel-query-builder": "^7.0"
+        "spatie/laravel-query-builder": "^7.0",
+        "srmklive/paypal": "^3.1"
     },
     "require-dev": {
         "driftingly/rector-laravel": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb74e9510dc4f5a1912dd1d7d0d6cb40",
+    "content-hash": "e0907251f3dc706e87906806598ee01b",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -8747,6 +8747,70 @@
                 }
             ],
             "time": "2024-03-08T11:35:19+00:00"
+        },
+        {
+            "name": "srmklive/paypal",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/blendbyte/laravel-paypal.git",
+                "reference": "522834a22fbd10e8fa1be21cb7c84d3d45c3a763"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/blendbyte/laravel-paypal/zipball/522834a22fbd10e8fa1be21cb7c84d3d45c3a763",
+                "reference": "522834a22fbd10e8fa1be21cb7c84d3d45c3a763",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.9",
+                "guzzlehttp/psr7": "^2.0",
+                "illuminate/support": "^12.0|^13.0",
+                "nesbot/carbon": "^3.0",
+                "php": "^8.2",
+                "psr/http-client": "^1.0"
+            },
+            "require-dev": {
+                "larastan/larastan": "^3.0",
+                "laravel/framework": "^12.0|^13.0",
+                "laravel/pint": "^1.29",
+                "orchestra/testbench": "^10.0|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "phpunit/phpunit": "^11.0|^12.0",
+                "symfony/var-dumper": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "PayPal": "Srmklive\\PayPal\\Facades\\PayPal"
+                    },
+                    "providers": [
+                        "Srmklive\\PayPal\\Providers\\PayPalServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Srmklive\\PayPal\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PayPal REST API client for Laravel and standalone PHP.",
+            "keywords": [
+                "REST API",
+                "laravel",
+                "payments",
+                "paypal"
+            ],
+            "support": {
+                "issues": "https://github.com/blendbyte/laravel-paypal/issues",
+                "source": "https://github.com/blendbyte/laravel-paypal/tree/3.1.1"
+            },
+            "time": "2026-04-18T05:16:56+00:00"
         },
         {
             "name": "stripe/stripe-php",

--- a/config/paypal.php
+++ b/config/paypal.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * PayPal Setting & API Credentials
+ * Created by Raza Mehdi <srmk@outlook.com>.
+ */
+
+return [
+    'mode' => env('PAYPAL_MODE', 'sandbox'), // Can only be 'sandbox' Or 'live'. If empty or invalid, 'live' will be used.
+    'sandbox' => [
+        'client_id' => env('PAYPAL_SANDBOX_CLIENT_ID', ''),
+        'client_secret' => env('PAYPAL_SANDBOX_CLIENT_SECRET', ''),
+        'app_id' => 'APP-80W284485P519543T', // Sandbox app_id is always this fixed value.
+    ],
+    'live' => [
+        'client_id' => env('PAYPAL_LIVE_CLIENT_ID', ''),
+        'client_secret' => env('PAYPAL_LIVE_CLIENT_SECRET', ''),
+        // Live app_id: log in to developer.paypal.com → My Apps & Credentials →
+        // select your app → the App ID shown at the top (starts with "APP-").
+        'app_id' => env('PAYPAL_LIVE_APP_ID', ''),
+    ],
+
+    'payment_action' => env('PAYPAL_PAYMENT_ACTION', 'Sale'), // Can only be 'Sale', 'Authorization' or 'Order'
+    'currency' => env('PAYPAL_CURRENCY', 'USD'),
+    'notify_url' => env('PAYPAL_NOTIFY_URL', ''), // Change this accordingly for your application.
+    'locale' => env('PAYPAL_LOCALE', 'en_US'), // force gateway language  i.e. it_IT, es_ES, en_US ... (for express checkout only)
+    'validate_ssl' => env('PAYPAL_VALIDATE_SSL', true), // Validate SSL when creating api client.
+    'timeout' => env('PAYPAL_TIMEOUT', 30), // Total request timeout in seconds.
+    'connect_timeout' => env('PAYPAL_CONNECT_TIMEOUT', 10), // Connection timeout in seconds.
+    'max_retries' => env('PAYPAL_MAX_RETRIES', 2), // Retries on 5xx / connection errors (0 to disable). Uses exponential backoff.
+];

--- a/tests/Feature/PayPalGatewayTest.php
+++ b/tests/Feature/PayPalGatewayTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\PaymentGateways\PayPalGateway;
+use Mockery;
+use Srmklive\PayPal\Services\PayPal as PayPalClient;
+use Tests\TestCase;
+
+/**
+ * PayPalGateway maps the srmklive/paypal (Orders v2) responses onto the
+ * PaymentGatewayInterface array shape. The srmklive client is mocked so no HTTP
+ * is made; this pins the mapping, not PayPal itself.
+ */
+class PayPalGatewayTest extends TestCase
+{
+    private function gatewayWith(PayPalClient $provider): PayPalGateway
+    {
+        $gateway = new PayPalGateway;
+        $gateway->setProvider($provider);
+
+        return $gateway;
+    }
+
+    public function test_process_payment_captures_an_approved_order(): void
+    {
+        $provider = Mockery::mock(PayPalClient::class);
+        $provider->shouldReceive('capturePaymentOrder')->once()->with('ORDER123')->andReturn([
+            'status' => 'COMPLETED',
+            'purchase_units' => [['payments' => ['captures' => [['id' => 'CAPTURE999']]]]],
+        ]);
+
+        $result = $this->gatewayWith($provider)->processPayment(50.0, ['payment_id' => 'ORDER123']);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('CAPTURE999', $result['transaction_id']);
+    }
+
+    public function test_process_payment_without_an_order_id_fails_without_calling_paypal(): void
+    {
+        $provider = Mockery::mock(PayPalClient::class);
+        $provider->shouldNotReceive('capturePaymentOrder');
+
+        $result = $this->gatewayWith($provider)->processPayment(50.0, []);
+
+        $this->assertFalse($result['success']);
+    }
+
+    public function test_process_payment_reports_failure_on_an_incomplete_capture(): void
+    {
+        $provider = Mockery::mock(PayPalClient::class);
+        $provider->shouldReceive('capturePaymentOrder')->andReturn(['status' => 'DECLINED']);
+
+        $result = $this->gatewayWith($provider)->processPayment(50.0, ['payment_id' => 'ORDER123']);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('DECLINED', $result['status']);
+    }
+
+    public function test_refund_payment_refunds_a_capture(): void
+    {
+        $provider = Mockery::mock(PayPalClient::class);
+        $provider->shouldReceive('refundCapturedPayment')->once()
+            ->with('CAPTURE999', 'CAPTURE999', 12.5, Mockery::type('string'))
+            ->andReturn(['status' => 'COMPLETED', 'id' => 'REFUND777']);
+
+        $result = $this->gatewayWith($provider)->refundPayment('CAPTURE999', 12.5);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('REFUND777', $result['refund_id']);
+    }
+
+    public function test_process_payment_wraps_sdk_exceptions_as_a_failure(): void
+    {
+        $provider = Mockery::mock(PayPalClient::class);
+        $provider->shouldReceive('capturePaymentOrder')->andThrow(new \RuntimeException('PayPal down'));
+
+        $result = $this->gatewayWith($provider)->processPayment(50.0, ['payment_id' => 'ORDER123']);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('PayPal down', $result['error']);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
## The problem

`PayPalGateway` constructed the **abandoned** `paypal/rest-api-sdk-php` (`PayPal\Api\*`, PayPal **v1** API, archived 2021) **in its constructor**. Once that package was gone, the gateway threw a class-not-found the instant `PaymentGatewayFactory::create("paypal")` built it — i.e. **any PayPal checkout fataled**. (The suite stayed green only because every existing PayPal test injects a *fake* gateway.)

## The rewrite (srmklive/paypal 3.x — PayPal Orders v2)

- **`processPayment`** captures the order the buyer created + approved client-side (id arrives as `payment_details["payment_id"]`, per `CheckoutController::processPayPalPayment`); a `COMPLETED` capture → `success` + the capture id as `transaction_id`.
- **`refundPayment`** refunds the capture via `refundCapturedPayment`.
- The srmklive client is **lazily built + credentialed** from `config/paypal.php` (published; reads `PAYPAL_*` env) and is **injectable** via `setProvider()` for testing.
- **`processSubscription`** now returns an honest *"not implemented"* instead of the old fake `uniqid()` success — real PayPal subscriptions need a provisioned billing plan (follow-up; `SubscriptionService` still holds the old v1 subscription stub).

## Tests

**+5** (`PayPalGatewayTest`) with the srmklive client **mocked** (no HTTP): capture success + capture-id extraction, missing-order-id short-circuit, incomplete-capture failure, refund, SDK-exception wrapping. Full suite **1014 passed / 0 failed**. Live capture needs `PAYPAL_*` credentials.

## Scope note

This modernizes the payment **gateway** (the checkout-reachable path). `SubscriptionService` (PayPal *subscriptions*, still on the v1 Agreement stub) is a separate rewrite — filed as a follow-up.