### PR TITLE
feat(paypal): rewrite SubscriptionService onto srmklive (Subscriptions v1)

### DIFF
--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -2,112 +2,98 @@
 
 namespace App\Services;
 
-use Exception;
-use PayPal\Api\Agreement;
-use PayPal\Api\Payer;
-use PayPal\Api\PayerInfo;
-use PayPal\Api\Plan;
-use PayPal\Api\ShippingAddress;
-use PayPal\Auth\OAuthTokenCredential;
-use Illuminate\Support\Facades\Config;
+use Srmklive\PayPal\Services\PayPal as PayPalClient;
+use Throwable;
 
+/**
+ * PayPal subscriptions on the maintained srmklive/paypal SDK (Subscriptions v1 REST
+ * API). Replaces the abandoned paypal/rest-api-sdk-php Agreement flow — whose
+ * setupSubscriptionDetails() constructed PayPal\Api\* classes that no longer exist,
+ * so createSubscription() fataled (an uncaught Error) the moment it was called.
+ */
 class SubscriptionService
 {
-    protected $paypalContext;
+    private ?PayPalClient $provider = null;
 
-    public function __construct()
+    /** Inject a preconfigured client (used in tests). */
+    public function setProvider(PayPalClient $provider): void
     {
-        // $this->paypalContext = new ApiContext(new OAuthTokenCredential(
-        //     Config::get('services.paypal.client_id'),
-        //     Config::get('services.paypal.secret')
-        // ));
-        // $this->paypalContext->setConfig(Config::get('services.paypal.settings'));
+        $this->provider = $provider;
     }
 
+    /**
+     * Create a PayPal subscription against an already-provisioned billing plan. The
+     * returned approval_url is where the buyer approves it.
+     */
     public function createSubscription($paymentMethodId, $planId, $userDetails)
     {
         try {
-            $agreement = $this->setupSubscriptionDetails($planId, $userDetails);
-        // return $this->createSubscriptionOnPaypal($agreement);
-            return ['success' => true, 'agreementID' => $agreement->getId()];
-        } catch (Exception $e) {
+            $result = $this->provider()->createSubscription([
+                'plan_id' => $planId,
+                'subscriber' => array_filter([
+                    'email_address' => $userDetails['email'] ?? null,
+                ]),
+                'application_context' => [
+                    'return_url' => url('/paypal/subscription/success'),
+                    'cancel_url' => url('/paypal/subscription/cancel'),
+                ],
+            ]);
+
+            if (! empty($result['id'])) {
+                return [
+                    'success' => true,
+                    'subscription_id' => $result['id'],
+                    'status' => $result['status'] ?? null,
+                    'approval_url' => $this->approvalLink($result),
+                ];
+            }
+
+            return ['success' => false, 'error' => $result['message'] ?? 'PayPal subscription was not created.'];
+        } catch (Throwable $e) {
+            return ['success' => false, 'error' => $e->getMessage()];
+        }
+    }
+
+    public function cancelSubscription($subscriptionId)
+    {
+        try {
+            $this->provider()->cancelSubscription($subscriptionId, 'Cancelled by customer');
+
+            return ['success' => true, 'message' => 'Subscription cancelled successfully'];
+        } catch (Throwable $e) {
             return ['success' => false, 'error' => $e->getMessage()];
         }
     }
 
     public function updateSubscription($subscriptionId, $planId)
     {
-        // Logic to update subscription's plan on PayPal
-        // This is a placeholder as the actual implementation would depend on PayPal's API and the application's design
-        return ['success' => true, 'message' => 'Subscription updated successfully'];
+        // ponytail: swapping a PayPal subscription's plan needs the
+        // /billing/subscriptions/{id}/revise endpoint, which srmklive does not expose
+        // (its updateSubscription only PATCHes fields). Return an honest failure
+        // instead of the old fake success; wire revise if plan changes are needed.
+        return ['success' => false, 'error' => 'Changing a PayPal subscription plan is not supported.'];
     }
 
-    public function cancelSubscription($subscriptionId)
+    private function provider(): PayPalClient
     {
-        // Logic to cancel subscription on PayPal
-        // This is a placeholder as the actual implementation would depend on PayPal's API and the application's design
-        return ['success' => true, 'message' => 'Subscription cancelled successfully'];
-    }
-
-    private function setupSubscriptionDetails($planId, $userDetails)
-    {
-        $payer = new Payer();
-        $payer->setPaymentMethod('paypal');
-
-        $plan = new Plan();
-        $plan->setId($planId);
-
-        $payerInfo = new PayerInfo();
-        $payerInfo->setEmail($userDetails['email']);
-
-        $shippingAddress = new ShippingAddress();
-        $shippingAddress->setLine1($userDetails['address']['line1'])
-                        ->setCity($userDetails['address']['city'])
-                        ->setState($userDetails['address']['state'])
-                        ->setPostalCode($userDetails['address']['postalCode'])
-                        ->setCountryCode($userDetails['address']['countryCode']);
-
-        $agreement = new Agreement();
-        $agreement->setName('Subscription Agreement')
-                  ->setDescription('Subscription Plan Agreement')
-                  ->setStartDate(gmdate("Y-m-d\TH:i:s\Z", strtotime("+30 days", time())))
-                  ->setPayer($payer)
-                  ->setPlan($plan)
-                  ->setPayerInfo($payerInfo)
-                  ->setShippingAddress($shippingAddress);
-
-        return $agreement;
-    }
-
-    private function createSubscriptionOnPaypal($agreement)
-    {
-        try {
-            $agreement->create($this->paypalContext);
-            return ['success' => true, 'agreementID' => $agreement->getId()];
-        } catch (Exception $e) {
-            return ['success' => false, 'error' => $e->getMessage()];
+        if ($this->provider === null) {
+            $provider = new PayPalClient;
+            $provider->setApiCredentials(config('paypal'));
+            $provider->getAccessToken();
+            $this->provider = $provider;
         }
-   
-        // Prepare update details
-        // This is a placeholder as the actual implementation would depend on PayPal's API and the application's design
-        return ['subscriptionId' => $subscriptionId, 'planId' => $planId];
+
+        return $this->provider;
     }
 
-    private function updateSubscriptionOnPaypal($updateDetails)
+    private function approvalLink(array $result): ?string
     {
-        // Perform update on PayPal
-        // This is a placeholder as the actual implementation would depend on PayPal's API and the application's design
-        return ['success' => true, 'message' => 'Subscription updated successfully'];
-    
-        // Prepare cancellation details
-        // This is a placeholder as the actual implementation would depend on PayPal's API and the application's design
-        return ['subscriptionId' => $subscriptionId];
-    }
+        foreach ($result['links'] ?? [] as $link) {
+            if (($link['rel'] ?? null) === 'approve') {
+                return $link['href'] ?? null;
+            }
+        }
 
-    private function cancelSubscriptionOnPaypal($cancellationDetails)
-    {
-        // Perform cancellation on PayPal
-        // This is a placeholder as the actual implementation would depend on PayPal's API and the application's design
-        return ['success' => true, 'message' => 'Subscription cancelled successfully'];
+        return null;
     }
 }

--- a/tests/Unit/SubscriptionServiceTest.php
+++ b/tests/Unit/SubscriptionServiceTest.php
@@ -3,31 +3,86 @@
 namespace Tests\Unit;
 
 use App\Services\SubscriptionService;
+use Mockery;
+use Srmklive\PayPal\Services\PayPal as PayPalClient;
 use Tests\TestCase;
 
+/**
+ * SubscriptionService maps srmklive/paypal (Subscriptions v1) responses onto its
+ * result arrays. The srmklive client is mocked so no HTTP is made.
+ */
 class SubscriptionServiceTest extends TestCase
 {
-    private SubscriptionService $service;
-
-    protected function setUp(): void
+    private function serviceWith(PayPalClient $provider): SubscriptionService
     {
-        parent::setUp();
-        $this->service = new SubscriptionService();
+        $service = new SubscriptionService;
+        $service->setProvider($provider);
+
+        return $service;
     }
 
-    public function test_update_subscription_returns_success(): void
+    public function test_create_subscription_returns_the_subscription_id_and_approval_url(): void
     {
-        $result = $this->service->updateSubscription('sub_123', 'plan_456');
+        $provider = Mockery::mock(PayPalClient::class);
+        $provider->shouldReceive('createSubscription')->once()->andReturn([
+            'id' => 'I-SUB123',
+            'status' => 'APPROVAL_PENDING',
+            'links' => [
+                ['rel' => 'approve', 'href' => 'https://paypal.com/approve/I-SUB123'],
+                ['rel' => 'self', 'href' => 'https://paypal.com/self'],
+            ],
+        ]);
+
+        $result = $this->serviceWith($provider)->createSubscription('pm_1', 'P-PLAN', ['email' => 'a@b.com']);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('I-SUB123', $result['subscription_id']);
+        $this->assertSame('https://paypal.com/approve/I-SUB123', $result['approval_url']);
+    }
+
+    public function test_create_subscription_reports_failure_when_paypal_returns_no_id(): void
+    {
+        $provider = Mockery::mock(PayPalClient::class);
+        $provider->shouldReceive('createSubscription')->andReturn(['message' => 'Invalid plan']);
+
+        $result = $this->serviceWith($provider)->createSubscription('pm_1', 'P-BAD', ['email' => 'a@b.com']);
+
+        $this->assertFalse($result['success']);
+    }
+
+    public function test_cancel_subscription_calls_paypal_and_reports_success(): void
+    {
+        $provider = Mockery::mock(PayPalClient::class);
+        $provider->shouldReceive('cancelSubscription')->once()->with('I-SUB123', Mockery::type('string'))->andReturn([]);
+
+        $result = $this->serviceWith($provider)->cancelSubscription('I-SUB123');
 
         $this->assertTrue($result['success']);
         $this->assertArrayHasKey('message', $result);
     }
 
-    public function test_cancel_subscription_returns_success(): void
+    public function test_update_subscription_is_reported_as_unsupported(): void
     {
-        $result = $this->service->cancelSubscription('sub_123');
+        // Plan swap needs the /revise endpoint, which srmklive doesn't expose.
+        $result = $this->serviceWith(Mockery::mock(PayPalClient::class))->updateSubscription('I-SUB123', 'P-NEW');
 
-        $this->assertTrue($result['success']);
-        $this->assertArrayHasKey('message', $result);
+        $this->assertFalse($result['success']);
+    }
+
+    public function test_create_subscription_wraps_sdk_exceptions(): void
+    {
+        $provider = Mockery::mock(PayPalClient::class);
+        $provider->shouldReceive('createSubscription')->andThrow(new \RuntimeException('PayPal down'));
+
+        $result = $this->serviceWith($provider)->createSubscription('pm_1', 'P-PLAN', ['email' => 'a@b.com']);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('PayPal down', $result['error']);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
     }
 }


### PR DESCRIPTION
## Summary

Completes the PayPal modernization from #754. `SubscriptionService` still ran the **abandoned** `paypal/rest-api-sdk-php` Agreement flow: `createSubscription()` called `setupSubscriptionDetails()`, which constructed `PayPal\Api\*` classes (`Payer`, `Plan`, `Agreement`, …) that no longer exist — and a class-not-found is an **`Error`, not an `Exception`**, so the `try/catch (Exception)` didnt catch it and the call **fataled**. `update`/`cancel` were fake canned successes.

## Rewrite (srmklive/paypal 3.x — `v1/billing/subscriptions`)

- **`createSubscription`** builds the `plan_id` + `subscriber` payload, calls `createSubscription`, and returns the subscription id + status + the buyer **`approval_url`** (from the HATEOAS `links`).
- **`cancelSubscription`** calls the real cancel endpoint.
- **`updateSubscription`** now returns an honest *"not supported"* — a PayPal plan swap needs the `/revise` endpoint, which srmklive doesnt expose (its `updateSubscription` only PATCHes fields).
- Removed the dead EOL imports + the orphaned `setup*/*OnPaypal` private methods. The client is lazily credentialed from `config/paypal.php` and **injectable** via `setProvider()` for tests.

## Tests

Rewrote `SubscriptionServiceTest` (it asserted the old fake successes) to the **real** contract with the srmklive client **mocked** (no HTTP): create returns id + approval_url, create-without-id fails, cancel succeeds, update is unsupported, SDK exceptions are wrapped. Full suite **1017 passed / 0 failed**. Live calls need `PAYPAL_*` credentials.

With #754 (gateway) + this, the PayPal integration is fully off the abandoned v1 SDK. Plan **provisioning** (createProduct/createPlan) is still manual/dashboard — a subscription assumes an existing `plan_id`.