### PR TITLE
fix(tax): classless product taxed by every tax class summed (over-charge)

### DIFF
--- a/app/Models/TaxRate.php
+++ b/app/Models/TaxRate.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -54,7 +55,14 @@ class TaxRate extends Model
         ?string $city = null,
         ?string $zipCode = null,
         ?int $taxClassId = null
-    ): \Illuminate\Database\Eloquent\Collection {
+    ): Collection {
+        // A product with no tax class must not be taxed by EVERY class's rate summed.
+        // Fall back to the default (first active) tax class so exactly one class
+        // applies. (Assign products a tax class to control which one.)
+        if ($taxClassId === null) {
+            $taxClassId = TaxClass::where('is_active', true)->orderBy('id')->value('id');
+        }
+
         $query = static::where('is_active', true)
             ->where('country', $country);
 
@@ -64,13 +72,19 @@ class TaxRate extends Model
 
         // Match specific location first, then fall back to broader areas
         $rates = collect();
-        
+
         // Try exact match
         if ($zipCode || $city || $state) {
             $exactMatch = (clone $query);
-            if ($zipCode) $exactMatch->where('zip_code', $zipCode);
-            if ($city) $exactMatch->where('city', $city);
-            if ($state) $exactMatch->where('state', $state);
+            if ($zipCode) {
+                $exactMatch->where('zip_code', $zipCode);
+            }
+            if ($city) {
+                $exactMatch->where('city', $city);
+            }
+            if ($state) {
+                $exactMatch->where('state', $state);
+            }
             $rates = $exactMatch->orderBy('priority', 'desc')->get();
         }
 

--- a/tests/Feature/TaxClasslessProductTest.php
+++ b/tests/Feature/TaxClasslessProductTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\TaxClass;
+use App\Models\TaxRate;
+use App\Services\TaxCalculator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * A product with no tax class (tax_class_id is null — the default, since the column
+ * isn't fillable) must be taxed by ONE tax class, not by every class's rate summed.
+ * The old findMatchingRates skipped the class filter for a null class and returned
+ * (and calculateCartTax summed) the rates of every class → silent over-charge.
+ */
+class TaxClasslessProductTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function usClass(string $name, float $rate): TaxClass
+    {
+        $class = TaxClass::create(['name' => $name, 'slug' => strtolower($name), 'is_active' => true]);
+        TaxRate::create([
+            'tax_class_id' => $class->id, 'country' => 'US', 'rate' => $rate,
+            'name' => "US {$name}", 'is_active' => true,
+        ]);
+
+        return $class;
+    }
+
+    public function test_classless_product_is_not_taxed_by_every_tax_class(): void
+    {
+        $this->usClass('Standard', 8);   // first active class -> the fallback
+        $this->usClass('Reduced', 5);
+
+        $product = Product::factory()->create(); // tax_class_id defaults to null
+        $this->assertNull($product->tax_class_id);
+
+        $result = app(TaxCalculator::class)->calculateCartTax(
+            [['product' => $product, 'quantity' => 1, 'price' => 100]],
+            ['country' => 'US'],
+            0
+        );
+
+        // Standard 8% only — NOT 8% + 5% = 13.
+        $this->assertEquals(8.0, $result['total']);
+    }
+
+    public function test_single_tax_class_still_taxes_a_classless_product(): void
+    {
+        $this->usClass('Standard', 8);
+
+        $product = Product::factory()->create();
+
+        $result = app(TaxCalculator::class)->calculateCartTax(
+            [['product' => $product, 'quantity' => 1, 'price' => 100]],
+            ['country' => 'US'],
+            0
+        );
+
+        $this->assertEquals(8.0, $result['total']);
+    }
+}


### PR DESCRIPTION
## The bug (silent customer over-charge, live)

`TaxRate::findMatchingRates` skipped the tax-class filter when the product had no class:

```php
if ($taxClassId) { $query->where("tax_class_id", $taxClassId); }
```

Products default to `tax_class_id = null` — the column is nullable **and not fillable**, so most products never get one. With a null class the filter is skipped, the query returns the rates of **every** tax class for the location, and `TaxCalculator::calculateCartTax` **sums them**.

**Scenario:** a store with a *Standard* (US 8%) and a *Reduced* (US 5%) class charges a \$100 classless product `8% + 5% = $13` instead of `$8`. Live on the checkout path (`CheckoutController → calculateCartTax`) and catalog display (`Product::displayPrice`). **Single-tax-class stores were unaffected** (only one class to match) — which is why it went unnoticed.

## Fix

When the product has no tax class, fall back to the **default (first active) tax class** so exactly one class applies. Within-class summing (e.g. state + city rows of the *same* class) is preserved; only the cross-class sum is removed. Assign products a tax class to control which one.

## Tests

**+2** (`TaxClasslessProductTest`): two classes → single 8% not 13%; single-class store still taxes a classless product. Full suite **1019 passed / 0 failed**. Found via a read-only tax/shipping audit sweep.

## Filed follow-ups (same sweep — conditional / need a decision, not in this PR)

- Weight-based shipping always adds \$0 (cart items carry no weight — already `ponytail:`-noted in `ShippingService`).
- `compound` tax rates are treated as simple (no tax-on-tax).
- A city/ZIP-granular rate row can fall through to a coarser rate.
- Digital-only orders are untaxed (VAT-on-digital is a policy decision).

The currency/wholesale/bundle/loyalty subsystems were also swept and are **dead scaffolding** (no live caller) — no live money bugs there.