### PR TITLE
fix(tax): apply compound (tax-on-tax) rates on base + simple tax

### DIFF
--- a/app/Services/TaxCalculator.php
+++ b/app/Services/TaxCalculator.php
@@ -45,22 +45,7 @@ class TaxCalculator
             // Find matching tax rates
             $rates = TaxRate::findMatchingRates($country, $state, $city, $zipCode, $taxClassId);
 
-            foreach ($rates as $rate) {
-                $taxAmount = $rate->calculateTax($itemSubtotal);
-                $totalTax += $taxAmount;
-
-                // Group by rate for tax lines
-                $rateKey = $rate->id;
-                if (! isset($taxLines[$rateKey])) {
-                    $taxLines[$rateKey] = [
-                        'label' => $rate->name,
-                        'rate' => $rate->rate,
-                        'amount' => 0,
-                        'compound' => $rate->compound,
-                    ];
-                }
-                $taxLines[$rateKey]['amount'] += $taxAmount;
-            }
+            $this->applyRates($rates, $itemSubtotal, $totalTax, $taxLines);
         }
 
         // Calculate shipping tax if applicable
@@ -68,27 +53,53 @@ class TaxCalculator
             $shippingRates = TaxRate::findMatchingRates($country, $state, $city, $zipCode)
                 ->where('shipping', true);
 
-            foreach ($shippingRates as $rate) {
-                $taxAmount = $rate->calculateTax($shippingCost);
-                $totalTax += $taxAmount;
-
-                $rateKey = $rate->id;
-                if (! isset($taxLines[$rateKey])) {
-                    $taxLines[$rateKey] = [
-                        'label' => $rate->name.' (Shipping)',
-                        'rate' => $rate->rate,
-                        'amount' => 0,
-                        'compound' => $rate->compound,
-                    ];
-                }
-                $taxLines[$rateKey]['amount'] += $taxAmount;
-            }
+            $this->applyRates($shippingRates, $shippingCost, $totalTax, $taxLines, ' (Shipping)');
         }
 
         return [
             'total' => round($totalTax, 2),
             'lines' => array_values($taxLines),
         ];
+    }
+
+    /**
+     * Apply a set of tax rates to a base amount, honouring compound (tax-on-tax)
+     * rates: simple rates are computed on the base, then compound rates on the base
+     * plus the simple tax. Accumulates into $totalTax and the grouped $taxLines.
+     *
+     * @param  iterable<TaxRate>  $rates
+     */
+    private function applyRates(iterable $rates, float $base, float &$totalTax, array &$taxLines, string $labelSuffix = ''): void
+    {
+        $record = function (TaxRate $rate, float $on) use (&$totalTax, &$taxLines, $labelSuffix): float {
+            $amount = $rate->calculateTax($on);
+            $totalTax += $amount;
+
+            $key = $rate->id;
+            if (! isset($taxLines[$key])) {
+                $taxLines[$key] = [
+                    'label' => $rate->name.$labelSuffix,
+                    'rate' => $rate->rate,
+                    'amount' => 0,
+                    'compound' => $rate->compound,
+                ];
+            }
+            $taxLines[$key]['amount'] += $amount;
+
+            return $amount;
+        };
+
+        $simpleTax = 0.0;
+        foreach ($rates as $rate) {
+            if (! $rate->compound) {
+                $simpleTax += $record($rate, $base);
+            }
+        }
+        foreach ($rates as $rate) {
+            if ($rate->compound) {
+                $record($rate, $base + $simpleTax);
+            }
+        }
     }
 
     /**

--- a/tests/Feature/TaxCompoundRateTest.php
+++ b/tests/Feature/TaxCompoundRateTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\TaxClass;
+use App\Models\TaxRate;
+use App\Services\TaxCalculator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * A compound tax rate is tax-on-tax: it applies to the item subtotal PLUS the
+ * simple taxes, not the bare subtotal. calculateCartTax used to compute every rate
+ * on the bare base, silently treating compound rates as simple (under-charge).
+ */
+class TaxCompoundRateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function rate(int $classId, float $rate, bool $compound, string $name): void
+    {
+        TaxRate::create([
+            'tax_class_id' => $classId, 'country' => 'CA', 'rate' => $rate,
+            'name' => $name, 'compound' => $compound, 'is_active' => true,
+        ]);
+    }
+
+    public function test_compound_rate_is_taxed_on_base_plus_simple_tax(): void
+    {
+        $class = TaxClass::create(['name' => 'Standard', 'slug' => 'standard', 'is_active' => true]);
+        $this->rate($class->id, 10, false, 'GST');  // simple 10%
+        $this->rate($class->id, 5, true, 'PST');     // compound 5%
+
+        $product = Product::factory()->create(['tax_class_id' => $class->id]);
+
+        $result = app(TaxCalculator::class)->calculateCartTax(
+            [['product' => $product, 'quantity' => 1, 'price' => 100]],
+            ['country' => 'CA'],
+            0
+        );
+
+        // simple: 10% of 100 = 10; compound: 5% of (100 + 10) = 5.50; total = 15.50 (not 15).
+        $this->assertEquals(15.50, $result['total']);
+    }
+
+    public function test_simple_only_rates_are_unchanged(): void
+    {
+        $class = TaxClass::create(['name' => 'Standard', 'slug' => 'standard', 'is_active' => true]);
+        $this->rate($class->id, 10, false, 'A');
+        $this->rate($class->id, 5, false, 'B');
+
+        $product = Product::factory()->create(['tax_class_id' => $class->id]);
+
+        $result = app(TaxCalculator::class)->calculateCartTax(
+            [['product' => $product, 'quantity' => 1, 'price' => 100]],
+            ['country' => 'CA'],
+            0
+        );
+
+        // Both simple on the base: 10 + 5 = 15.
+        $this->assertEquals(15.0, $result['total']);
+    }
+}


### PR DESCRIPTION
## The bug

`calculateCartTax` computed **every** rate as `rate% of the item subtotal`, so a rate flagged `compound = true` was silently treated as **simple**. A compound tax (e.g. a PST levied on the GST-inclusive price) must apply to the base **plus** the already-computed simple taxes.

**Scenario:** \$100 item, GST 10% (simple) + PST 5% (compound).
- Correct: `10% × 100 = $10`, then `5% × (100 + 10) = $5.50` → **\$15.50**
- Old: `10% + 5%` both on 100 → **\$15.00** (silent under-charge whenever any active rate is `compound`)

## Fix

Extracted a shared `applyRates()` helper (used for **both** item and shipping tax): compute simple rates on the base, sum them, then compute compound rates on `base + simple total`. Identical behaviour for the common all-simple case.

## Tests

**+2** (`TaxCompoundRateTest`): compound taxed on the grossed-up base = 15.50; simple-only unchanged = 15. Full suite **1021 passed / 0 failed**. This is **F3** from the tax/shipping audit sweep (F1 was #756).

Remaining sweep follow-ups (conditional / decision): F2 weight-shipping-\$0 (needs a `products.weight` column + cart-weight capture), F4 city/ZIP rate fall-through, F5 digital-only VAT.