### PR TITLE
fix(tax): location matching treats null rate columns as wildcards (most specific wins)

### DIFF
--- a/app/Models/TaxRate.php
+++ b/app/Models/TaxRate.php
@@ -70,44 +70,29 @@ class TaxRate extends Model
             $query->where('tax_class_id', $taxClassId);
         }
 
-        // Match specific location first, then fall back to broader areas
-        $rates = collect();
+        // A rate applies when each of its non-null location columns matches the
+        // address — a null column is a wildcard ("applies everywhere at this level").
+        // (Laravel turns where('state', null) into whereNull, so a null address field
+        // only matches wildcard rates, never a location-specific one.)
+        $candidates = $query
+            ->where(fn ($q) => $q->whereNull('state')->orWhere('state', $state))
+            ->where(fn ($q) => $q->whereNull('city')->orWhere('city', $city))
+            ->where(fn ($q) => $q->whereNull('zip_code')->orWhere('zip_code', $zipCode))
+            ->orderBy('priority', 'desc')
+            ->get();
 
-        // Try exact match
-        if ($zipCode || $city || $state) {
-            $exactMatch = (clone $query);
-            if ($zipCode) {
-                $exactMatch->where('zip_code', $zipCode);
-            }
-            if ($city) {
-                $exactMatch->where('city', $city);
-            }
-            if ($state) {
-                $exactMatch->where('state', $state);
-            }
-            $rates = $exactMatch->orderBy('priority', 'desc')->get();
+        if ($candidates->isEmpty()) {
+            return $candidates;
         }
 
-        // Fall back to state level if no exact match
-        if ($rates->isEmpty() && $state) {
-            $rates = (clone $query)
-                ->where('state', $state)
-                ->whereNull('city')
-                ->whereNull('zip_code')
-                ->orderBy('priority', 'desc')
-                ->get();
-        }
+        // Most specific wins: a ZIP/city rate beats a state rate beats a country rate.
+        // The old exact->state->country tiers made a partially-specified rate (e.g.
+        // state + city but no ZIP) unreachable, silently falling through to a coarser one.
+        $specificity = fn (TaxRate $rate): int => (int) ($rate->zip_code !== null)
+            + (int) ($rate->city !== null)
+            + (int) ($rate->state !== null);
+        $mostSpecific = $candidates->max($specificity);
 
-        // Fall back to country level
-        if ($rates->isEmpty()) {
-            $rates = (clone $query)
-                ->whereNull('state')
-                ->whereNull('city')
-                ->whereNull('zip_code')
-                ->orderBy('priority', 'desc')
-                ->get();
-        }
-
-        return $rates;
+        return $candidates->filter(fn (TaxRate $rate): bool => $specificity($rate) === $mostSpecific)->values();
     }
 }

--- a/tests/Feature/TaxRateLocationMatchingTest.php
+++ b/tests/Feature/TaxRateLocationMatchingTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\TaxClass;
+use App\Models\TaxRate;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Location matching must treat a rate's NULL location columns as wildcards and let
+ * the most specific match win. The old rigid exact->state->country tiers made a
+ * partially-specified rate (e.g. state + city, no ZIP) unreachable, so it fell
+ * through to a coarser (wrong) rate.
+ */
+class TaxRateLocationMatchingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private int $classId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->classId = TaxClass::create(['name' => 'Standard', 'slug' => 'standard', 'is_active' => true])->id;
+    }
+
+    private function rate(array $o): TaxRate
+    {
+        return TaxRate::create(array_merge([
+            'tax_class_id' => $this->classId, 'country' => 'US', 'rate' => 5, 'name' => 'r', 'is_active' => true,
+        ], $o));
+    }
+
+    public function test_city_level_rate_with_null_zip_is_matched_and_wins(): void
+    {
+        $city = $this->rate(['state' => 'CA', 'city' => 'Los Angeles', 'rate' => 9.5, 'name' => 'LA City']);
+        $this->rate(['name' => 'US National', 'rate' => 5]); // broader, must not win
+
+        $rates = TaxRate::findMatchingRates('US', 'CA', 'Los Angeles', '90001', $this->classId);
+
+        $this->assertTrue($rates->contains('id', $city->id), 'City rate must match despite a null zip_code');
+        $this->assertFalse($rates->contains('name', 'US National'), 'Coarser rate must not apply when a more specific one matches');
+        $this->assertEquals(1, $rates->count());
+    }
+
+    public function test_country_rate_applies_when_no_finer_rate_matches(): void
+    {
+        $us = $this->rate(['name' => 'US National', 'rate' => 5]);
+
+        $rates = TaxRate::findMatchingRates('US', 'TX', 'Austin', '73301', $this->classId);
+
+        $this->assertTrue($rates->contains('id', $us->id));
+    }
+
+    public function test_state_rate_beats_country_rate(): void
+    {
+        $state = $this->rate(['state' => 'CA', 'rate' => 7.25, 'name' => 'CA']);
+        $this->rate(['name' => 'US National', 'rate' => 5]);
+
+        $rates = TaxRate::findMatchingRates('US', 'CA', 'Los Angeles', '90001', $this->classId);
+
+        $this->assertTrue($rates->contains('id', $state->id));
+        $this->assertFalse($rates->contains('name', 'US National'));
+    }
+
+    public function test_rate_for_a_different_state_does_not_match(): void
+    {
+        $this->rate(['state' => 'NY', 'rate' => 8, 'name' => 'NY']);
+
+        $rates = TaxRate::findMatchingRates('US', 'CA', null, null, $this->classId);
+
+        $this->assertFalse($rates->contains('name', 'NY'));
+    }
+}


### PR DESCRIPTION
## The bug

`TaxRate::findMatchingRates` used rigid `exact → state → country` tiers: the exact tier ANDed `zip AND city AND state`, and each fallback required the **finer** columns to be `NULL`. So a partially-specified rate — e.g. a city rate `(state=CA, city=LA, zip_code=null)` — was **unreachable** for a full `CA / LA / 90001` address (exact needs a ZIP match; the state fallback needs `city` null), and the lookup fell through to the state or country rate → silently applied the **wrong (usually lower) rate**.

## Fix

A rate applies when each of its **non-null** location columns equals the address (a null column is a **wildcard**), and among the matches the **most specific wins** (ZIP > city > state > country). Laravel maps `where("state", null)` → `whereNull`, so a null address field only matches wildcard rates, never a location-specific one.

Preserves the existing contract — country match, state-beats-country, unknown-country-empty, inactive-excluded (all prior `TaxRate`/engine tests still green).

## Tests

**+4** (`TaxRateLocationMatchingTest`): a city rate with a null ZIP now matches and beats the country rate; the country rate applies when nothing finer matches; state beats country; a different-state rate doesnt match. Full suite **1025 passed / 0 failed**. This is **F4** from the tax/shipping audit sweep.

Remaining sweep items: **F2** weight-shipping-\$0 (needs a `products.weight` column + cart-weight capture) and **F5** digital-only VAT (policy).