### PR TITLE
feat(shipping): wire weight-based shipping (F2)

### DIFF
--- a/app/Filament/Admin/Resources/Products/ProductResource.php
+++ b/app/Filament/Admin/Resources/Products/ProductResource.php
@@ -116,6 +116,12 @@ class ProductResource extends Resource
                             ->numeric()
                             ->minValue(0)
                             ->label('Low Stock Threshold'),
+                        TextInput::make('weight')
+                            ->numeric()
+                            ->minValue(0)
+                            ->default(0)
+                            ->suffix('kg')
+                            ->helperText('Used by weight-based shipping methods.'),
                     ]),
 
                 Section::make('Downloadable Product')

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -35,6 +35,7 @@ class Product extends Model implements Orderable
         'featured_image',
         'inventory_count',
         'low_stock_threshold',
+        'weight',
         'meta_title',
         'meta_description',
         'meta_keywords',
@@ -51,6 +52,7 @@ class Product extends Model implements Orderable
     protected $casts = [
         'is_downloadable' => 'boolean',
         'price' => 'decimal:2',
+        'weight' => 'decimal:2',
         'suggested_price' => 'decimal:2',
         'minimum_price' => 'decimal:2',
     ];

--- a/app/Services/ShippingService.php
+++ b/app/Services/ShippingService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\Product;
 use App\Models\ShippingMethod;
 use Illuminate\Support\Facades\Http;
 
@@ -12,7 +13,7 @@ class ShippingService
         // Only offer active methods; a deactivated method must never be selectable.
         $availableMethods = ShippingMethod::where('is_active', true)->get();
 
-        if (!$cart || !$address) {
+        if (! $cart || ! $address) {
             return $availableMethods;
         }
 
@@ -64,6 +65,7 @@ class ShippingService
     private function calculateWeightRate($method, $cart)
     {
         $totalWeight = $this->calculateTotalWeight($cart);
+
         return $totalWeight * $method->weight_rate;
     }
 
@@ -76,11 +78,26 @@ class ShippingService
 
     private function calculateTotalWeight($cart)
     {
-        return array_sum(array_map(function ($item) {
-            // ponytail: session cart items carry no 'weight' yet (wiring gap in
-            // Cart/CheckoutController) — treat missing weight as 0, don't fatal.
-            return ($item['weight'] ?? 0) * $item['quantity'];
-        }, $cart));
+        // The session cart is keyed by product_id and carries no weight, so look the
+        // product weights up (one batched query). An item-carried 'weight', if a
+        // future path adds one, still wins.
+        $lookupIds = [];
+        foreach ($cart as $productId => $item) {
+            if (! isset($item['weight'])) {
+                $lookupIds[] = $productId;
+            }
+        }
+        $weights = empty($lookupIds)
+            ? collect()
+            : Product::whereIn('id', $lookupIds)->pluck('weight', 'id');
+
+        $total = 0.0;
+        foreach ($cart as $productId => $item) {
+            $weight = (float) ($item['weight'] ?? $weights[$productId] ?? 0);
+            $total += $weight * $item['quantity'];
+        }
+
+        return $total;
     }
 
     public function calculateDropShippingCost(ShippingMethod $method, $cart, $address)

--- a/database/migrations/2026_07_19_000000_add_weight_to_products.php
+++ b/database/migrations/2026_07_19_000000_add_weight_to_products.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Weight-based shipping (ShippingMethod.weight_rate) had no product weight to work
+ * with, so it always added $0. Give products a weight the shipping calculator reads.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('products', 'weight')) {
+            Schema::table('products', function (Blueprint $table) {
+                $table->decimal('weight', 8, 2)->default(0);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('products', 'weight')) {
+            Schema::table('products', function (Blueprint $table) {
+                $table->dropColumn('weight');
+            });
+        }
+    }
+};

--- a/tests/Feature/WeightBasedShippingTest.php
+++ b/tests/Feature/WeightBasedShippingTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\ShippingMethod;
+use App\Services\ShippingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * A shipping method with a weight_rate must actually charge for weight. The cart is
+ * keyed by product_id and carries no weight, so ShippingService looks the product
+ * weight up. Before this it always added $0 (charging base_rate only).
+ */
+class WeightBasedShippingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_weight_rate_charges_for_the_product_weight(): void
+    {
+        $product = Product::factory()->create(['weight' => 2]); // 2kg each
+        $method = ShippingMethod::create(['name' => 'Std', 'base_rate' => 5, 'weight_rate' => 3]);
+
+        // 4 units x 2kg = 8kg; base 5 + 8 x 3 = 29.
+        $cost = app(ShippingService::class)->calculateShippingCost(
+            $method,
+            [$product->id => ['quantity' => 4, 'price' => 10]],
+            '123 Test St'
+        );
+
+        $this->assertEquals(29.0, $cost);
+    }
+
+    public function test_zero_weight_rate_charges_only_the_base(): void
+    {
+        $product = Product::factory()->create(['weight' => 2]);
+        $method = ShippingMethod::create(['name' => 'Flat', 'base_rate' => 5, 'weight_rate' => 0]);
+
+        $cost = app(ShippingService::class)->calculateShippingCost(
+            $method,
+            [$product->id => ['quantity' => 4, 'price' => 10]],
+            '123 Test St'
+        );
+
+        $this->assertEquals(5.0, $cost);
+    }
+}


### PR DESCRIPTION
## The gap

A `ShippingMethod` with `weight_rate > 0` always added **\$0** for weight. Cart items carry no weight, so `ShippingService::calculateTotalWeight` (reading `$item["weight"] ?? 0`) was always `0` and every weight-priced method charged only `base_rate` — a silent under-charge. The `max_weight` availability filter was likewise inert. (This was the **F2** gap already `ponytail:`-flagged in `ShippingService`.)

## Fix

- New **`products.weight`** column (`decimal(8,2)` default 0 — MySQL 8.4 **and** sqlite verified); `fillable` + `decimal:2` cast; an admin Product-form field (kg).
- `calculateTotalWeight` now **looks the product weights up by the cart key** (the session cart is keyed by `product_id`) in one batched query, so `weight_rate` and the `max_weight` filter actually work. An item-carried `weight` still wins if a future cart path adds one.

## Tests

**+2** (`WeightBasedShippingTest`): a `weight_rate` method charges `base + weight × rate × qty` (4 units × 2kg, base \$5 + 8kg × \$3 = **\$29**); a zero `weight_rate` still charges only base. Full suite **1027 passed / 0 failed**.

Remaining tax/shipping sweep item: **F5** digital-only VAT (a policy decision).