### PR TITLE
fix(security): throttle abuse-prone unauthenticated web endpoints

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -62,7 +62,7 @@ Route::middleware('auth')->group(function () {
 Route::get('/products', [ProductController::class, 'index'])->name('products.index');
 Route::get('/products/search', [ProductController::class, 'search'])->name('products.search');
 Route::get('/products/{product}', [ProductController::class, 'show'])->name('products.show');
-Route::post('/products/{product}/notify-me', [ProductController::class, 'notifyMe'])->name('products.notify-me');
+Route::post('/products/{product}/notify-me', [ProductController::class, 'notifyMe'])->name('products.notify-me')->middleware('throttle:10,1');
 
 // Category routes
 Route::get('/categories', [ProductCategoryController::class, 'index'])->name('categories.index');
@@ -148,7 +148,9 @@ Route::post('/cart/add/{product}', [CartController::class, 'add'])->name('cart.a
 Route::put('/cart/update/{productId}', [CartController::class, 'update'])->name('cart.update');
 Route::delete('/cart/remove/{productId}', [CartController::class, 'remove'])->name('cart.remove');
 Route::delete('/cart/clear', [CartController::class, 'clear'])->name('cart.clear');
-Route::post('/cart/apply-coupon', [CartController::class, 'applyCoupon'])->name('cart.apply-coupon');
+// Throttled: distinguishable valid/invalid responses make this brute-forceable to
+// enumerate discount codes; cap attempts per IP.
+Route::post('/cart/apply-coupon', [CartController::class, 'applyCoupon'])->name('cart.apply-coupon')->middleware('throttle:10,1');
 Route::delete('/cart/remove-coupon', [CartController::class, 'removeCoupon'])->name('cart.remove-coupon');
 
 // Ratings and reviews — reads are public; writes require login (approve is admin-only, gated in the controller)
@@ -201,12 +203,14 @@ Route::view('/account', 'account')->middleware('auth')->name('account');
 
 // Chat routes
 Route::prefix('chat')->group(function () {
-    Route::post('/start', [ChatController::class, 'start'])->name('chat.start');
+    // Public chat: unauthenticated. Throttle the writes so a guest can't loop
+    // start->message to flood the conversation/message tables + the agent queue.
+    Route::post('/start', [ChatController::class, 'start'])->name('chat.start')->middleware('throttle:15,1');
     Route::get('/session/{sessionId}', [ChatController::class, 'getBySession'])->name('chat.session');
-    Route::post('/{conversationId}/message', [ChatController::class, 'sendMessage'])->name('chat.message');
+    Route::post('/{conversationId}/message', [ChatController::class, 'sendMessage'])->name('chat.message')->middleware('throttle:30,1');
     Route::get('/{conversationId}/messages', [ChatController::class, 'getMessages'])->name('chat.messages');
-    Route::post('/{conversationId}/close', [ChatController::class, 'close'])->name('chat.close');
-    Route::post('/{conversationId}/rating', [ChatController::class, 'submitRating'])->name('chat.rating');
+    Route::post('/{conversationId}/close', [ChatController::class, 'close'])->name('chat.close')->middleware('throttle:15,1');
+    Route::post('/{conversationId}/rating', [ChatController::class, 'submitRating'])->name('chat.rating')->middleware('throttle:15,1');
 
     // Agent routes
     Route::middleware(['auth'])->group(function () {

--- a/tests/Feature/RateLimitAbuseTest.php
+++ b/tests/Feature/RateLimitAbuseTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The web group carries no throttle, so unauthenticated abuse-prone endpoints were
+ * unbounded: coupon-code brute-force, stock-notify DB flooding, chat flooding.
+ * These are now throttled per IP.
+ */
+class RateLimitAbuseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_apply_coupon_is_rate_limited(): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->post(route('cart.apply-coupon'), ['coupon_code' => 'GUESS'])->assertStatus(302);
+        }
+
+        // 11th attempt within the minute is blocked — no unbounded coupon brute-force.
+        $this->post(route('cart.apply-coupon'), ['coupon_code' => 'GUESS'])->assertStatus(429);
+    }
+
+    public function test_stock_notify_is_rate_limited(): void
+    {
+        $product = Product::factory()->create();
+
+        for ($i = 0; $i < 10; $i++) {
+            $this->post(route('products.notify-me', $product), ['email' => "a{$i}@example.com"]);
+        }
+
+        $this->post(route('products.notify-me', $product), ['email' => 'flood@example.com'])->assertStatus(429);
+    }
+
+    public function test_chat_start_is_rate_limited(): void
+    {
+        for ($i = 0; $i < 15; $i++) {
+            $this->post(route('chat.start'), ['customer_name' => 'A', 'customer_email' => 'a@example.com']);
+        }
+
+        $this->post(route('chat.start'), ['customer_name' => 'A', 'customer_email' => 'a@example.com'])->assertStatus(429);
+    }
+}


### PR DESCRIPTION
## The gap

The `web` middleware group carries **no throttle** (Fortify throttles login/2FA; the whole `api` group has `throttle:api`), so several public endpoints were unbounded:

| Endpoint | Abuse |
|---|---|
| `POST /cart/apply-coupon` | Distinguishable valid/invalid response → **coupon-code brute-force** → drains promo margin |
| `POST /products/{product}/notify-me` | `firstOrCreate(email, product)` on attacker input → unbounded `stock_notifications` rows + silently subscribes arbitrary emails to restock mail |
| `POST /chat/start` (+message/close/rating) | Guest loops `start → message` → floods conversation/message tables + the agent queue |

## Fix

Per-route `throttle` middleware (keyed by IP): apply-coupon **10/min**, notify-me **10/min**, chat.start/close/rating **15/min**, chat.message **30/min**. Legit users are well under these; scripted abuse hits `429`.

## Tests

**+3** (`RateLimitAbuseTest`): each route returns `429` past its limit. Full suite **1030 passed / 0 failed**. Found via a read-only rate-limiting audit — which also **confirmed login/2FA and the entire `api` surface are already correctly throttled**, and a parallel mass-assignment audit found **no exploitable `$fillable` privilege-escalation** (`User` fillable is `name/email/password` only; all write sites use explicit arrays / validated / server-derived values).

## Follow-up (needs your decision)

Fortify-owned `POST /forgot-password`, `/register`, `/reset-password` are also unthrottled (email-bomb / user enumeration / automated signup). Fortify only exposes limiters for login + two-factor, so closing these means either a Fortify route override or a **generous global `web` limiter** — the latter risks `429`s for NAT / Livewire-heavy legit traffic, so I left it for you to call.