### PR TITLE
fix(security): rate-limit Fortify auth routes (forgot-password / register / reset)

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -101,7 +101,11 @@ return [
     |
     */
 
-    'middleware' => ['web'],
+    // throttle:10,1 bounds the unauthenticated Fortify actions (forgot-password,
+    // register, reset-password) that Fortify does NOT otherwise rate-limit — it only
+    // wires per-action limiters for login + two-factor. 10/min per IP is generous for
+    // real multi-step auth flows but stops email-bomb / user-enumeration / auto-signup.
+    'middleware' => ['web', 'throttle:10,1'],
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Feature/FortifyRateLimitTest.php
+++ b/tests/Feature/FortifyRateLimitTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Fortify only wires per-action rate limiters for login + two-factor, leaving
+ * forgot-password / register / reset-password unbounded (email-bomb, user
+ * enumeration, automated signup). A Fortify-wide throttle now caps them.
+ */
+class FortifyRateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_forgot_password_is_rate_limited(): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->post('/forgot-password', ['email' => 'user@example.com']);
+        }
+
+        $this->post('/forgot-password', ['email' => 'user@example.com'])->assertStatus(429);
+    }
+
+    public function test_registration_is_rate_limited(): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->post('/register', ['email' => "spam{$i}@example.com"]);
+        }
+
+        $this->post('/register', ['email' => 'spam@example.com'])->assertStatus(429);
+    }
+}


### PR DESCRIPTION
## Summary

Completes the rate-limit follow-up from #761. Fortify only wires per-action limiters for **login + two-factor**, so `POST /forgot-password`, `/register` and `/reset-password` were **unbounded**:
- **forgot-password** → email-bomb a victim with reset mails / account enumeration by timing
- **register** → automated mass account creation
- **reset-password** → unbounded bcrypt hammer

## Fix

Throttle the Fortify middleware group — `config/fortify.php`: `["web"]` → `["web", "throttle:10,1"]`. **Scoped to Fortify routes only** (not a global `web` throttle), so storefront / Livewire / Filament traffic is untouched. **10/min per IP** is generous for real multi-step auth flows (2FA setup, etc.) but stops the abuse; **login keeps its tighter Fortify 5/min limiter** on top.

## Tests

**+2** (`FortifyRateLimitTest`): forgot-password and register return `429` past the limit. Full suite **1032 passed / 0 failed** — and verified the registration/Socialstream tests still pass alongside the throttle (no 429 interference).

With this + #761, every abuse-prone unauthenticated endpoint (coupon brute-force, stock-notify flood, chat flood, forgot-password/register/reset) is now bounded; login/2FA and the `api` surface were already throttled.