### PR TITLE
feat(identity): link Customer to User 1:1 (same identity) + resolver

### DIFF
--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -14,6 +14,7 @@ class Customer extends Model
     protected $table = 'customers';
 
     protected $fillable = [
+        'user_id',
         'first_name',
         'last_name',
         'email',
@@ -23,6 +24,11 @@ class Customer extends Model
         'state',
         'postal_code',
     ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 
     public function orders()
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -179,6 +179,29 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
         return $this->hasOne(CustomerMetric::class);
     }
 
+    /**
+     * The Customer record for this user — a Customer is the same identity as a User.
+     */
+    public function customer(): HasOne
+    {
+        return $this->hasOne(Customer::class);
+    }
+
+    /**
+     * Resolve (creating if needed) this user's Customer record, seeded from the
+     * user's name + email. Idempotent — the customers.user_id link is unique.
+     */
+    public function getOrCreateCustomer(): Customer
+    {
+        $parts = explode(' ', trim((string) $this->name), 2);
+
+        return $this->customer()->firstOrCreate([], [
+            'first_name' => $parts[0] !== '' ? $parts[0] : 'Customer',
+            'last_name' => $parts[1] ?? '',
+            'email' => $this->email,
+        ]);
+    }
+
     public function giftRegistries(): HasMany
     {
         return $this->hasMany(GiftRegistry::class);

--- a/database/migrations/2026_07_20_000000_link_customers_to_users.php
+++ b/database/migrations/2026_07_20_000000_link_customers_to_users.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * A Customer is the same identity as a User: link them 1:1 via customers.user_id.
+ * A user's customer record starts minimal (just name + email), so the profile
+ * fields (phone/address/…) that guest checkout fills become nullable.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('customers', 'user_id')) {
+            Schema::table('customers', function (Blueprint $table) {
+                $table->foreignId('user_id')->nullable()->unique()->after('id')->constrained()->nullOnDelete();
+            });
+        }
+
+        Schema::table('customers', function (Blueprint $table) {
+            $table->integer('phone_number')->nullable()->change();
+            $table->string('address')->nullable()->change();
+            $table->string('city')->nullable()->change();
+            $table->string('state')->nullable()->change();
+            $table->string('postal_code')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('customers', 'user_id')) {
+            Schema::table('customers', function (Blueprint $table) {
+                $table->dropConstrainedForeignId('user_id');
+            });
+        }
+    }
+};

--- a/tests/Feature/UserCustomerIdentityTest.php
+++ b/tests/Feature/UserCustomerIdentityTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Customer;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * A Customer is the same identity as a User, linked 1:1 by customers.user_id.
+ * getOrCreateCustomer() resolves (creating if needed) that record from the user.
+ */
+class UserCustomerIdentityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_get_or_create_customer_links_a_customer_to_the_user(): void
+    {
+        $user = User::factory()->create(['name' => 'Jane Doe', 'email' => 'jane@example.com']);
+
+        $customer = $user->getOrCreateCustomer();
+
+        $this->assertEquals($user->id, $customer->user_id);
+        $this->assertEquals('Jane', $customer->first_name);
+        $this->assertEquals('Doe', $customer->last_name);
+        $this->assertEquals('jane@example.com', $customer->email);
+        $this->assertTrue($user->refresh()->customer->is($customer));
+        $this->assertTrue($customer->user->is($user));
+    }
+
+    public function test_get_or_create_customer_is_idempotent(): void
+    {
+        $user = User::factory()->create();
+
+        $first = $user->getOrCreateCustomer();
+        $second = $user->refresh()->getOrCreateCustomer();
+
+        $this->assertEquals($first->id, $second->id);
+        $this->assertDatabaseCount('customers', 1);
+    }
+
+    public function test_a_users_customer_starts_minimal_without_profile_fields(): void
+    {
+        // Regression: phone/address/city/state/postal are now nullable so a user's
+        // customer record can exist before those are filled.
+        $customer = User::factory()->create()->getOrCreateCustomer();
+
+        $this->assertNull($customer->phone_number);
+        $this->assertNull($customer->address);
+        $this->assertNull($customer->postal_code);
+    }
+
+    public function test_a_single_word_name_still_produces_a_valid_customer(): void
+    {
+        $customer = User::factory()->create(['name' => 'Cher'])->getOrCreateCustomer();
+
+        $this->assertEquals('Cher', $customer->first_name);
+        $this->assertSame('', $customer->last_name);
+    }
+
+    public function test_guest_customer_without_a_user_is_still_valid(): void
+    {
+        // The link is nullable — guest checkout customers keep working with no user_id.
+        $customer = Customer::create(['first_name' => 'Guest', 'last_name' => 'Buyer', 'email' => 'g@example.com']);
+
+        $this->assertNull($customer->user_id);
+        $this->assertNull($customer->user);
+    }
+}


### PR DESCRIPTION
## Summary

Per your **#1 same-identity** decision: a `Customer` is the same identity as a `User`. This is the **foundation** that unblocks the three tasks stuck on the users↔customers ambiguity — invoice **generation** (an `Order` has `user_id`, an `Invoice` needs `customer_id`), the **`in_customer_group`** segment (User → customer → groups), and a **customers API**.

## Change

- **Migration** — `customers.user_id` (nullable, **UNIQUE**, FK `nullOnDelete`) → 1:1; nullable so existing **guest-checkout** customers keep working with no user. The profile fields guest checkout fills (`phone_number`/`address`/`city`/`state`/`postal_code`) become **nullable** so a user-linked customer can start minimal. **MySQL 8.4 + sqlite verified.**
- `Customer::user()` belongsTo; `user_id` fillable.
- `User::customer()` hasOne + **`getOrCreateCustomer()`** — resolves (creating if needed) the users customer record from the users name (split first/last) + email; idempotent via the unique link.

## Tests

**+5** (`UserCustomerIdentityTest`): links + seeds from the user, idempotent, a customer starts minimal (nullable profile), single-word name, and a guest customer with no user still works. Full suite **1037 passed / 0 failed**.

## Next (build on this)

`getOrCreateCustomer()` is the seam for: wiring **invoice generation** (`createInvoiceForOrder` → resolve the orders users customer), fixing **`in_customer_group`** segmentation, and a **customers API**.