### PR TITLE
feat(invoices): generate an invoice when an order is paid

### DIFF
--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -11,22 +11,7 @@ class InvoiceController extends Controller
 {
     public function createInvoiceForOrder(int $orderId): Invoice
     {
-        $order = Order::findOrFail($orderId);
-        $invoice = Invoice::create([
-            'order_id' => $order->id,
-            'invoice_date' => now(),
-            'total_amount' => $order->total,
-            'coupon_id' => $order->coupon_id,
-            'discount_amount' => $order->discount_amount,
-        ]);
-        foreach ($order->products as $product) {
-            $invoice->products()->attach($product->id, [
-                'quantity' => $product->pivot->quantity,
-                'price' => $product->price,
-            ]);
-        }
-
-        return $invoice;
+        return Invoice::generateForOrder(Order::findOrFail($orderId));
     }
 
     public function index(Request $request): View

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -13,13 +13,64 @@ class Invoice extends Model
 
     protected $fillable = [
         'order_id',
+        'customer_id',
         'invoice_date',
         'total_amount',
+        'payment_status',
     ];
 
     protected $casts = [
         'invoice_date' => 'datetime',
     ];
+
+    /**
+     * Generate (once) the invoice for a paid order: resolve the customer via the
+     * User<->Customer identity link — or create one from the guest email — and copy
+     * the order's line items onto the invoice. Idempotent per order_id.
+     */
+    public static function generateForOrder(Order $order): self
+    {
+        $order->loadMissing('items');
+
+        $invoice = static::firstOrCreate(
+            ['order_id' => $order->id],
+            [
+                'customer_id' => static::resolveCustomerId($order),
+                'invoice_date' => now(),
+                'total_amount' => $order->total_amount,
+                'payment_status' => $order->payment_status ?: 'paid',
+            ]
+        );
+
+        if ($invoice->wasRecentlyCreated) {
+            foreach ($order->items as $item) {
+                $invoice->products()->attach($item->product_id, [
+                    'quantity' => $item->quantity,
+                    'price' => $item->price,
+                ]);
+            }
+        }
+
+        return $invoice;
+    }
+
+    protected static function resolveCustomerId(Order $order): int
+    {
+        if ($order->user_id) {
+            return $order->user->getOrCreateCustomer()->id;
+        }
+
+        if ($order->customer_id) {
+            return $order->customer_id;
+        }
+
+        // Guest order: a minimal customer from the order email (profile fields nullable).
+        return Customer::create([
+            'first_name' => 'Guest',
+            'last_name' => '',
+            'email' => $order->customer_email,
+        ])->id;
+    }
 
     public function order()
     {

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -163,6 +163,16 @@ class Order extends Model
         ]);
 
         $this->fireOutboundWebhooks($status);
+
+        // Generate the invoice once the order is paid (idempotent per order).
+        if ($status === self::STATUS_PAID) {
+            Invoice::generateForOrder($this);
+        }
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
     }
 
     /**

--- a/tests/Feature/InvoiceGenerationTest.php
+++ b/tests/Feature/InvoiceGenerationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Invoice;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Paying an order generates its invoice: the customer is resolved via the
+ * User<->Customer identity link (or created from the guest email), and the order's
+ * line items are copied onto the invoice. Idempotent per order.
+ */
+class InvoiceGenerationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function order(?int $userId, float $total = 100): Order
+    {
+        return Order::create([
+            'user_id' => $userId,
+            'customer_email' => 'buyer@example.com',
+            'total_amount' => $total,
+            'status' => 'pending',
+            'payment_status' => 'pending',
+        ]);
+    }
+
+    public function test_paying_an_order_generates_an_invoice_for_the_users_customer(): void
+    {
+        $user = User::factory()->create(['name' => 'Jane Doe']);
+        $order = $this->order($user->id, 100);
+        $order->items()->create(['product_id' => Product::factory()->create()->id, 'quantity' => 2, 'price' => 50]);
+
+        $order->transitionTo(Order::STATUS_PAID);
+
+        $invoice = Invoice::where('order_id', $order->id)->first();
+        $this->assertNotNull($invoice, 'Invoice should be generated on the paid transition');
+        $this->assertEquals(100, (float) $invoice->total_amount);
+        $this->assertEquals('paid', $invoice->payment_status);
+        $this->assertEquals($user->getOrCreateCustomer()->id, $invoice->customer_id);
+        $this->assertCount(1, $invoice->products);
+        $this->assertEquals(2, $invoice->products->first()->pivot->quantity);
+    }
+
+    public function test_guest_order_invoice_creates_a_customer_from_the_email(): void
+    {
+        $order = $this->order(null, 50);
+
+        $order->transitionTo(Order::STATUS_PAID);
+
+        $invoice = Invoice::where('order_id', $order->id)->first();
+        $this->assertNotNull($invoice->customer_id);
+        $this->assertEquals('buyer@example.com', $invoice->customer->email);
+    }
+
+    public function test_invoice_generation_is_idempotent(): void
+    {
+        $order = $this->order(User::factory()->create()->id, 10);
+
+        Invoice::generateForOrder($order);
+        Invoice::generateForOrder($order->fresh());
+
+        $this->assertDatabaseCount('invoices', 1);
+    }
+}


### PR DESCRIPTION
feat(invoices): generate an invoice when an order is paid (fix broken createInvoiceForOrder)

Invoice generation never worked: createInvoiceForOrder read the nonexistent
order->total (column is total_amount), order->coupon_id/discount_amount (Order has
neither, nor are they Invoice-fillable), iterated order->products (Order has items()),
and omitted the NOT-NULL customer_id + payment_status. So it fataled on the first
call and no invoice was ever created. The invoice read side (#742) had no data, and
nothing triggered generation.

Now that a Customer is the same identity as a User (#763), this wires it up:

- Invoice::generateForOrder(Order) is idempotent per order_id (firstOrCreate). It
  resolves the customer via the identity link (order.user->getOrCreateCustomer()),
  falls back to the order's existing customer_id, or creates a minimal Customer from
  the guest email; copies the order's line items onto the invoice_product pivot; sets
  total_amount + payment_status from the order.
- Order::transitionTo() generates the invoice on the STATUS_PAID transition, so it
  fires for every paid order (checkout AND the Stripe webhook capture) exactly once.
- Added the missing Order::user() relation; customer_id + payment_status made
  Invoice-fillable; InvoiceController::createInvoiceForOrder now delegates to the model.

+3 tests (paid order -> invoice for the user's customer with line items; guest order
-> customer created from email; idempotent). No migration. Full suite 1040 passed /
0 failed (random order clean; only the known Socialstream flake).
