### PR TITLE
fix(segments): implement in_customer_group via the User<->Customer link

### DIFF
--- a/app/Models/CustomerSegment.php
+++ b/app/Models/CustomerSegment.php
@@ -99,7 +99,12 @@ class CustomerSegment extends Model
             'has_purchased_product' => $query->whereHas('orders.items', function ($q) use ($value) {
                 $q->where('product_id', $value);
             }),
-            'in_customer_group' => $query->where('customer_group_id', $value),
+            // A user is "in" a customer group when their identity-linked Customer
+            // belongs to it (User -> customer -> customer_group_memberships). The old
+            // where('customer_group_id') hit a nonexistent users column.
+            'in_customer_group' => $query->whereHas('customer.groups', function ($q) use ($value) {
+                $q->where('customer_groups.id', $value);
+            }),
             // Fail closed: an unrecognised field must not silently drop the filter
             // (which would match EVERY user under match_type=all) — match no one.
             default => $query->whereRaw('1 = 0'),

--- a/tests/Feature/InCustomerGroupSegmentTest.php
+++ b/tests/Feature/InCustomerGroupSegmentTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\CustomerGroup;
+use App\Models\CustomerSegment;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The in_customer_group segment condition matches users by the customer group their
+ * (User<->Customer identity-linked) customer belongs to. It used to query a
+ * nonexistent users.customer_group_id column and error out.
+ */
+class InCustomerGroupSegmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_in_customer_group_matches_users_whose_customer_is_in_the_group(): void
+    {
+        $group = CustomerGroup::create(['name' => 'VIP', 'is_active' => true]);
+
+        $inUser = User::factory()->create();
+        $inUser->getOrCreateCustomer()->groups()->attach($group->id, ['joined_at' => now()]);
+
+        $outUser = User::factory()->create();
+        $outUser->getOrCreateCustomer(); // has a customer, but not in the group
+
+        $segment = CustomerSegment::create([
+            'name' => 'VIPs',
+            'match_type' => 'all',
+            'is_active' => true,
+            'conditions' => [['field' => 'in_customer_group', 'operator' => '=', 'value' => $group->id]],
+        ]);
+
+        $segment->calculateMembers();
+
+        $memberIds = $segment->members()->pluck('users.id');
+        $this->assertTrue($memberIds->contains($inUser->id), 'A user whose customer is in the group must match');
+        $this->assertFalse($memberIds->contains($outUser->id), 'A user not in the group must not match');
+        $this->assertEquals(1, $segment->fresh()->customer_count);
+    }
+}


### PR DESCRIPTION
fix(segments): implement the in_customer_group condition via the User<->Customer link

CustomerSegment::applyCondition matched the in_customer_group condition with
where('customer_group_id', $value) on the users query, but users has no such
column — so the condition matched no one (swallowed by the per-segment guard),
making any segment that used it silently empty.

Now that a Customer is the same identity as a User (#763), a user is "in" a
customer group when their linked Customer belongs to it:
User -> customer -> customer_group_memberships. Implemented as
whereHas('customer.groups', fn => where customer_groups.id = value).

+1 test (a user whose customer is in the group matches; one not in it does not;
customer_count is correct). No migration. Full suite 1041 passed / 0 failed.

Third of the three tasks the #763 identity decision unblocked. Remaining: customers API.
