### PR TITLE
feat(api): customer profile API (authenticated user's own record)

### DIFF
--- a/app/Http/Controllers/Api/CustomerController.php
+++ b/app/Http/Controllers/Api/CustomerController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * The authenticated user's own customer profile. A Customer is the same identity as
+ * a User, so this always operates on the caller's own record (resolved/created via
+ * getOrCreateCustomer) — there is no id in the route, so no cross-user access.
+ */
+class CustomerController extends Controller
+{
+    public function show(Request $request): JsonResponse
+    {
+        return response()->json(['data' => $request->user()->getOrCreateCustomer()]);
+    }
+
+    public function update(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'first_name' => ['sometimes', 'required', 'string', 'max:255'],
+            'last_name' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'email' => ['sometimes', 'required', 'email', 'max:255'],
+            'phone_number' => ['sometimes', 'nullable', 'integer'],
+            'address' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'city' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'state' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'postal_code' => ['sometimes', 'nullable', 'string', 'max:255'],
+        ]);
+
+        $customer = $request->user()->getOrCreateCustomer();
+        $customer->update($data);
+
+        return response()->json(['data' => $customer->fresh()]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\CartController;
 use App\Http\Controllers\Api\CollectionController;
+use App\Http\Controllers\Api\CustomerController;
 use App\Http\Controllers\Api\DropshippingController;
 use App\Http\Controllers\Api\OrderController;
 use App\Http\Controllers\Api\OrderRefundController;
@@ -72,6 +73,12 @@ Route::middleware('auth:sanctum')->prefix('returns')->group(function () {
     Route::post('/{returnRequest}/approve', [ReturnRequestController::class, 'approve']);
     Route::post('/{returnRequest}/received', [ReturnRequestController::class, 'markReceived']);
 });
+// Customer profile API (the authenticated user's own customer record).
+Route::middleware('auth:sanctum')->prefix('customer')->group(function () {
+    Route::get('/', [CustomerController::class, 'show']);
+    Route::put('/', [CustomerController::class, 'update']);
+});
+
 // Cart API routes (headless: read/manage the authenticated user's persistent cart).
 Route::middleware('auth:sanctum')->prefix('cart')->group(function () {
     Route::get('/', [CartController::class, 'index']);

--- a/tests/Feature/Api/CustomerApiTest.php
+++ b/tests/Feature/Api/CustomerApiTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CustomerApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_customer_endpoints_require_authentication(): void
+    {
+        $this->getJson('/api/customer')->assertUnauthorized();
+        $this->putJson('/api/customer', [])->assertUnauthorized();
+    }
+
+    public function test_show_returns_the_users_own_customer_creating_it(): void
+    {
+        $user = User::factory()->create(['name' => 'Jane Doe', 'email' => 'jane@example.com']);
+
+        $this->actingAs($user)->getJson('/api/customer')
+            ->assertOk()
+            ->assertJsonPath('data.user_id', $user->id)
+            ->assertJsonPath('data.first_name', 'Jane')
+            ->assertJsonPath('data.email', 'jane@example.com');
+
+        $this->assertDatabaseHas('customers', ['user_id' => $user->id]);
+    }
+
+    public function test_show_is_idempotent(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->getJson('/api/customer')->assertOk();
+        $this->actingAs($user)->getJson('/api/customer')->assertOk();
+
+        $this->assertDatabaseCount('customers', 1);
+    }
+
+    public function test_update_persists_the_users_profile(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->putJson('/api/customer', [
+            'first_name' => 'Updated', 'city' => 'Berlin', 'postal_code' => '10115',
+        ])->assertOk()->assertJsonPath('data.city', 'Berlin');
+
+        $this->assertDatabaseHas('customers', [
+            'user_id' => $user->id, 'first_name' => 'Updated', 'city' => 'Berlin', 'postal_code' => '10115',
+        ]);
+    }
+
+    public function test_update_validates_input(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->putJson('/api/customer', ['email' => 'not-an-email'])
+            ->assertStatus(422);
+    }
+
+    public function test_each_user_gets_their_own_customer(): void
+    {
+        $a = User::factory()->create();
+        $b = User::factory()->create();
+
+        $this->actingAs($a)->putJson('/api/customer', ['first_name' => 'Alice']);
+        $bCustomer = $this->actingAs($b)->getJson('/api/customer')->json('data');
+
+        $this->assertEquals($b->id, $bCustomer['user_id']);
+        $this->assertNotEquals('Alice', $bCustomer['first_name']);
+    }
+}


### PR DESCRIPTION
feat(api): customer profile API (the authenticated user's own customer record)

Completes the 1.7 REST-API set (cart/orders/collections already shipped) and the
last of the three tasks the User<->Customer identity decision (#763) unblocked.

Api\CustomerController:
  GET /api/customer   the caller's customer record (resolved/created via
                      getOrCreateCustomer, seeded from the user's name + email)
  PUT /api/customer   update the caller's profile (first_name/last_name/email/
                      phone_number/address/city/state/postal_code)

Both under auth:sanctum. There is no id in the route — it always operates on the
caller's own customer via the identity link, so there is no cross-user access to
guard. Validated input; other keys (user_id, team_id) can't be set.

+6 tests (auth required; show returns + creates the user's customer; idempotent;
update persists; validation 422; each user gets their own). No migration. Full
suite 1047 passed / 0 failed.

This closes out the whole users<->customers identity chain from the #1 decision:
identity link (#763) -> invoice generation (#764) -> in_customer_group (#765) ->
customers API (this).
