### PR TITLE
feat(tax): tax digital goods (VAT-on-digital) via a required billing country

### DIFF
--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -77,7 +77,9 @@ class CheckoutController extends Controller
             'shipping_address' => 'required_if:has_physical_products,1|string',
             'shipping_method_id' => 'required_if:has_physical_products,1|exists:shipping_methods,id',
             // Structured address drives tax (country) and is required for physical orders.
-            'country' => 'required_if:has_physical_products,1|nullable|string|size:2',
+            // Required for every order — a digital-only order still needs the buyer's
+            // country so digital goods are taxed (VAT-on-digital), not just physical ones.
+            'country' => 'required|string|size:2',
             'state' => 'nullable|string|max:100',
             'city' => 'nullable|string|max:100',
             'postal_code' => 'nullable|string|max:20',

--- a/resources/views/checkout/checkout.blade.php
+++ b/resources/views/checkout/checkout.blade.php
@@ -266,6 +266,32 @@
                             </div>
                         </div>
                     </div>
+                    @else
+                    <!-- Billing Location — a digital-only order still needs a country so it can be taxed. -->
+                    <div class="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
+                        <div class="px-6 py-4 border-b border-gray-100">
+                            <h2 class="text-lg font-semibold text-gray-900">Billing Location</h2>
+                            <p class="text-sm text-gray-500 mt-0.5">Used to calculate tax on your order.</p>
+                        </div>
+                        <div class="px-6 py-5 grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <div>
+                                <label for="country" class="block text-sm font-medium text-gray-700 mb-1.5">Country <span class="text-red-500">*</span></label>
+                                <input type="text" id="country" name="country" maxlength="2" required placeholder="ISO code, e.g. US, GB" value="{{ old('country') }}"
+                                    class="w-full px-4 py-2.5 border border-gray-300 rounded-lg text-gray-900 uppercase focus:outline-none focus:ring-2 focus:ring-indigo-500 @error('country') border-red-500 @enderror">
+                                @error('country')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+                            </div>
+                            <div>
+                                <label for="state" class="block text-sm font-medium text-gray-700 mb-1.5">State / Province</label>
+                                <input type="text" id="state" name="state" value="{{ old('state') }}"
+                                    class="w-full px-4 py-2.5 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                            </div>
+                            <div>
+                                <label for="postal_code" class="block text-sm font-medium text-gray-700 mb-1.5">Postal / ZIP code</label>
+                                <input type="text" id="postal_code" name="postal_code" value="{{ old('postal_code') }}"
+                                    class="w-full px-4 py-2.5 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                            </div>
+                        </div>
+                    </div>
                     @endif
 
                     @if($total > 0)

--- a/tests/Feature/CheckoutControllerTest.php
+++ b/tests/Feature/CheckoutControllerTest.php
@@ -79,6 +79,7 @@ class CheckoutControllerTest extends TestCase
     {
         $response = $this->post(route('checkout.process'), [
             'email' => 'test@example.com',
+            'country' => 'US',
             'payment_method' => 'cod',
         ]);
 

--- a/tests/Feature/CheckoutCouponRevalidationTest.php
+++ b/tests/Feature/CheckoutCouponRevalidationTest.php
@@ -81,6 +81,7 @@ class CheckoutCouponRevalidationTest extends TestCase
             'email' => 'buyer@example.com',
             'has_physical_products' => 0,
             'shipping_address' => '123 Test St, CA 90001',
+            'country' => 'US',
             'payment_method' => 'stripe',
             'stripeToken' => 'tok_test',
         ];

--- a/tests/Feature/CheckoutInventoryTest.php
+++ b/tests/Feature/CheckoutInventoryTest.php
@@ -22,7 +22,8 @@ class CheckoutInventoryTest extends TestCase
      */
     private function bindGateway(Closure $result): object
     {
-        $spy = new class($result) implements PaymentGatewayInterface {
+        $spy = new class($result) implements PaymentGatewayInterface
+        {
             public ?int $inventoryAtCharge = null;
 
             public function __construct(private Closure $result) {}
@@ -69,6 +70,7 @@ class CheckoutInventoryTest extends TestCase
             'email' => 'buyer@example.com',
             'has_physical_products' => 0,
             'shipping_address' => '123 Test St, CA 90001',
+            'country' => 'US',
             'payment_method' => 'stripe',
             'stripeToken' => 'tok_test',
         ];

--- a/tests/Feature/TaxDigitalGoodsTest.php
+++ b/tests/Feature/TaxDigitalGoodsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Interfaces\PaymentGatewayInterface;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\TaxClass;
+use App\Models\TaxRate;
+use App\Services\PaymentGateways\StripeGateway;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+/**
+ * VAT-on-digital: a digital-only order still needs the buyer's country, and its
+ * downloadable goods are taxed by it (they were previously untaxed because checkout
+ * only collected a country for physical orders).
+ */
+class TaxDigitalGoodsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Notification::fake();
+        $spy = new class implements PaymentGatewayInterface
+        {
+            public function processPayment(float $amount, array $paymentDetails): array
+            {
+                return ['success' => true, 'transaction_id' => 'ch_1'];
+            }
+
+            public function processSubscription(string $planId, array $subscriptionDetails): array
+            {
+                return ['success' => true];
+            }
+
+            public function refundPayment(string $transactionId, float $amount): array
+            {
+                return ['success' => true];
+            }
+        };
+        $this->app->instance(StripeGateway::class, $spy);
+    }
+
+    private function digitalCart(Product $product): array
+    {
+        return [$product->id => ['quantity' => 1, 'price' => (float) $product->price, 'is_downloadable' => true, 'name' => $product->name]];
+    }
+
+    public function test_digital_only_order_is_taxed_by_the_buyers_country(): void
+    {
+        $class = TaxClass::create(['name' => 'Standard', 'slug' => 'standard', 'is_active' => true]);
+        TaxRate::create(['tax_class_id' => $class->id, 'country' => 'US', 'rate' => 10, 'name' => 'US', 'is_active' => true]);
+        $product = Product::factory()->create(['price' => 200, 'inventory_count' => 5, 'is_downloadable' => true, 'tax_class_id' => $class->id]);
+
+        $this->withSession(['cart' => $this->digitalCart($product)])->post(route('checkout.process'), [
+            'email' => 'buyer@example.com',
+            'has_physical_products' => 0,
+            'country' => 'US',
+            'payment_method' => 'stripe',
+            'stripeToken' => 'tok_test',
+        ]);
+
+        // 10% of $200 = $20 tax on a digital-only order.
+        $this->assertEquals(20.0, (float) Order::first()->tax_amount);
+    }
+
+    public function test_checkout_requires_a_country_even_for_a_digital_order(): void
+    {
+        $product = Product::factory()->create(['inventory_count' => 5, 'is_downloadable' => true]);
+
+        $this->withSession(['cart' => $this->digitalCart($product)])->post(route('checkout.process'), [
+            'email' => 'buyer@example.com',
+            'has_physical_products' => 0,
+            'payment_method' => 'stripe',
+            'stripeToken' => 'tok_test',
+        ])->assertSessionHasErrors('country');
+
+        $this->assertNull(Order::first());
+    }
+}


### PR DESCRIPTION
feat(tax): tax digital goods too (VAT-on-digital) by requiring a billing country

Decision: yes, tax digital goods. Digital-only orders escaped tax entirely:
checkout only required (and the form only collected) a country when the cart had
physical products, so a downloadable-only cart submitted no country and
TaxCalculator::calculateCartTax short-circuited to zero at its "no country" guard.
(The tax engine already taxes downloadable items once a country is present.)

- Checkout validation: country is now required for EVERY order (was
  required_if:has_physical_products,1), so a digital order carries the buyer's tax
  country.
- Checkout form: added a "Billing Location" section (country + optional state/postal)
  shown for digital-only orders — the physical path already collects these in the
  shipping section.

Existing digital-checkout tests that omitted country updated to the new contract
(country added to the shared payload helpers + the empty-cart case).

+2 tests (a digital-only order is taxed by its country -> 10% of $200 = $20;
checkout without a country is rejected). No migration. Full suite 1049 passed /
0 failed.
