### PR TITLE
fix(payment): require auth + validate the PayPal one-time-payment route

### DIFF
--- a/app/Http/Controllers/PaypalPaymentController.php
+++ b/app/Http/Controllers/PaypalPaymentController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 class PaypalPaymentController extends Controller
 {
     private $paymentGatewayService;
+
     private $subscriptionService;
 
     public function __construct(PaymentGatewayService $paymentGatewayService, SubscriptionService $subscriptionService)
@@ -19,11 +20,13 @@ class PaypalPaymentController extends Controller
 
     public function createOneTimePayment(Request $request)
     {
-        $paymentMethodId = $request->input('paymentMethodId');
-        $amount = $request->input('amount');
+        $validated = $request->validate([
+            'paymentMethodId' => 'required|string',
+            'amount' => 'required|numeric|min:0',
+        ]);
 
-        $result = $this->paymentGatewayService->processPayment('paypal', (float) $amount, [
-            'payment_id' => $paymentMethodId,
+        $result = $this->paymentGatewayService->processPayment('paypal', (float) $validated['amount'], [
+            'payment_id' => $validated['paymentMethodId'],
         ]);
 
         return response()->json($result);

--- a/routes/web.php
+++ b/routes/web.php
@@ -129,14 +129,15 @@ Route::middleware('auth')->group(function () {
     Route::delete('/subscription/cancel', [SubscriptionController::class, 'cancelSubscription'])->name('subscription.cancel');
 });
 
-Route::post('/paypal/payment', [PaypalPaymentController::class, 'createOneTimePayment'])->name('paypal.payment.create');
-
-// PayPal subscription mutations act on a caller-supplied subscriptionId — require
-// auth so an anonymous request can't update/cancel someone else's subscription.
+// PayPal one-time payment + subscription mutations act on caller-supplied ids
+// (a PayPal order id to capture / a subscriptionId) against the merchant's live
+// PayPal credentials — require auth so an anonymous request can't trigger a capture
+// or update/cancel someone else's subscription.
 // ponytail: real per-user ownership scoping must come when the PayPal integration is
 // actually built; SubscriptionService is a stub today with no persisted
 // subscription↔user link to check against.
 Route::middleware('auth')->group(function () {
+    Route::post('/paypal/payment', [PaypalPaymentController::class, 'createOneTimePayment'])->name('paypal.payment.create');
     Route::post('/paypal/subscription', [PaypalPaymentController::class, 'createSubscription'])->name('paypal.subscription.create');
     Route::patch('/paypal/subscription/update', [PaypalPaymentController::class, 'updateSubscription'])->name('paypal.subscription.update');
     Route::delete('/paypal/subscription/cancel', [PaypalPaymentController::class, 'cancelSubscription'])->name('paypal.subscription.cancel');

--- a/tests/Feature/PaypalPaymentControllerTest.php
+++ b/tests/Feature/PaypalPaymentControllerTest.php
@@ -3,14 +3,19 @@
 namespace Tests\Feature;
 
 use App\Interfaces\PaymentGatewayInterface;
+use App\Models\User;
 use App\Services\PaymentGateways\PayPalGateway;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class PaypalPaymentControllerTest extends TestCase
 {
+    use RefreshDatabase;
+
     private function bindPaypalGateway(array $return): void
     {
-        $this->app->instance(PayPalGateway::class, new class($return) implements PaymentGatewayInterface {
+        $this->app->instance(PayPalGateway::class, new class($return) implements PaymentGatewayInterface
+        {
             public function __construct(private array $return) {}
 
             public function processPayment(float $amount, array $paymentDetails): array
@@ -30,14 +35,40 @@ class PaypalPaymentControllerTest extends TestCase
         });
     }
 
+    public function test_one_time_payment_requires_authentication(): void
+    {
+        // The route captures a caller-supplied PayPal order id against the merchant's
+        // live PayPal credentials — an anonymous request must not reach it (matches the
+        // sibling /paypal/subscription routes, already behind auth).
+        $this->postJson(route('paypal.payment.create'), [
+            'paymentMethodId' => 'pm_123',
+            'amount' => 25,
+        ])->assertUnauthorized();
+    }
+
+    public function test_one_time_payment_requires_a_payment_method_id(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->postJson(route('paypal.payment.create'), ['amount' => 25])
+            ->assertStatus(422);
+    }
+
+    public function test_one_time_payment_requires_an_amount(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->postJson(route('paypal.payment.create'), ['paymentMethodId' => 'pm_123'])
+            ->assertStatus(422);
+    }
+
     public function test_one_time_payment_delegates_to_the_paypal_gateway(): void
     {
         $this->bindPaypalGateway(['success' => true, 'transaction_id' => 'txn_test']);
 
-        $response = $this->postJson(route('paypal.payment.create'), [
-            'paymentMethodId' => 'pm_123',
-            'amount' => 25,
-        ]);
+        $response = $this->actingAs(User::factory()->create())
+            ->postJson(route('paypal.payment.create'), [
+                'paymentMethodId' => 'pm_123',
+                'amount' => 25,
+            ]);
 
         $response->assertOk();
         $response->assertJson([
@@ -51,10 +82,11 @@ class PaypalPaymentControllerTest extends TestCase
     {
         $this->bindPaypalGateway(['success' => false, 'error' => 'declined']);
 
-        $response = $this->postJson(route('paypal.payment.create'), [
-            'paymentMethodId' => 'pm_bad',
-            'amount' => 10,
-        ]);
+        $response = $this->actingAs(User::factory()->create())
+            ->postJson(route('paypal.payment.create'), [
+                'paymentMethodId' => 'pm_bad',
+                'amount' => 10,
+            ]);
 
         $response->assertOk();
         $response->assertJson(['success' => false, 'error' => 'declined']);


### PR DESCRIPTION
fix(payment): require auth + validate the PayPal one-time-payment route

POST /paypal/payment was the one PayPal route left OUTSIDE the auth group. It
delegates to PayPalGateway::processPayment, which captures a caller-supplied
PayPal order id (paymentMethodId) against the merchant's live PayPal credentials
via capturePaymentOrder(). Unauthenticated + unvalidated, that is an open,
credential-backed outbound-capture endpoint (abuse/amplification vector) and is
inconsistent with the sibling /paypal/subscription routes, which were already put
behind auth for exactly this reason.

- Moved the route into the existing `auth` group.
- Added request validation (paymentMethodId required string, amount required
  numeric >= 0) — the controller previously validated nothing and passed a
  possibly-null id straight to the gateway.

Note on "client-supplied amount": PayPalGateway ignores the amount and captures
the amount baked into the pre-approved PayPal order, so there is no amount-integrity
hole here to bind to an order — the real defect was the missing auth. The Stripe
/payment + /stripe/payment endpoints charge $user->charge() (the caller's OWN
Cashier card, already auth'd + validated), so they carry no cross-user/merchant
integrity risk either; their only caller is an orphaned demo blade. No pending-order
model exists to bind these floating endpoints to, so order-binding is left out (YAGNI).

Tests: PaypalPaymentControllerTest gains auth-required + two validation cases and
now acts as an authenticated user for the delegation cases. Full suite 1052 passed
(also green under random order).
