### PR TITLE
feat(gdpr): account erasure / right-to-be-forgotten (Art. 17)

### DIFF
--- a/app/Http/Controllers/AccountErasureController.php
+++ b/app/Http/Controllers/AccountErasureController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\GdprErasureService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+class AccountErasureController extends Controller
+{
+    public function __invoke(Request $request, GdprErasureService $service)
+    {
+        $request->validate(['password' => 'required|string']);
+
+        $user = $request->user();
+
+        // Re-confirm the current password: erasure is irreversible, so guard against
+        // an accidental or hijacked-session trigger.
+        if (! Hash::check($request->input('password'), $user->password)) {
+            throw ValidationException::withMessages([
+                'password' => __('The provided password is incorrect.'),
+            ]);
+        }
+
+        $service->erase($user);
+
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return response()->json(['success' => true, 'message' => 'Your account data has been erased.']);
+    }
+}

--- a/app/Services/GdprErasureService.php
+++ b/app/Services/GdprErasureService.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Order;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+/**
+ * GDPR right-to-erasure (Art. 17). Anonymises a user rather than hard-deleting them so
+ * their orders remain intact for accounting/legal retention while every identifying
+ * field is scrubbed. All writes happen in one transaction.
+ *
+ * ponytail: scrubs the core identity, order PII, saved payment methods and behavioural
+ * tracking. User-generated content (reviews/ratings) and gift registries are left for a
+ * follow-up — deleting them changes public product aggregates and needs its own call.
+ */
+class GdprErasureService
+{
+    private const REDACTED_EMAIL = 'redacted@anonymized.invalid';
+
+    private const REDACTED = 'REDACTED';
+
+    public function erase(User $user): void
+    {
+        DB::transaction(function () use ($user) {
+            $customer = $user->customer;
+
+            $this->scrubOrders($user, $customer?->id);
+
+            // Personal data with no accounting value — delete outright.
+            $user->paymentMethods()->delete();
+            $user->browsingHistory()->delete();
+            $user->productInteractions()->delete();
+            $user->wishlist()->delete();
+
+            if ($customer !== null) {
+                $customer->update([
+                    'first_name' => 'Deleted',
+                    'last_name' => 'User',
+                    'email' => self::REDACTED_EMAIL,
+                    'phone_number' => null,
+                    'address' => null,
+                    'city' => null,
+                    'state' => null,
+                    'postal_code' => null,
+                ]);
+            }
+
+            // Anonymise the account in place (row kept so orders keep their owner link).
+            $user->forceFill([
+                'name' => 'Deleted User',
+                'email' => 'deleted-'.$user->id.'@anonymized.invalid',
+                'email_verified_at' => null,
+                'password' => Hash::make(Str::random(64)),
+                'remember_token' => null,
+                'two_factor_secret' => null,
+                'two_factor_recovery_codes' => null,
+            ])->save();
+        });
+    }
+
+    private function scrubOrders(User $user, ?int $customerId): void
+    {
+        $query = Order::query()->where('user_id', $user->id);
+        if ($customerId !== null) {
+            $query->orWhere('customer_id', $customerId);
+        }
+
+        $query->update([
+            'customer_email' => self::REDACTED_EMAIL,
+            'shipping_address' => self::REDACTED,
+            'recipient_name' => self::REDACTED,
+            'recipient_email' => self::REDACTED_EMAIL,
+            'gift_message' => null,
+        ]);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AccountDataExportController;
+use App\Http\Controllers\AccountErasureController;
 use App\Http\Controllers\CartController;
 use App\Http\Controllers\ChatController;
 use App\Http\Controllers\CheckoutController;
@@ -99,6 +100,9 @@ Route::middleware('auth')->group(function () {
 
     // GDPR right-of-access: download all of your own personal data as JSON.
     Route::get('/account/data-export', AccountDataExportController::class)->name('account.data-export');
+
+    // GDPR right-to-erasure: anonymise your account (orders retained, PII scrubbed).
+    Route::delete('/account', AccountErasureController::class)->name('account.erase');
 });
 
 Route::middleware('auth')->prefix('payment_methods')->group(function () {

--- a/tests/Feature/GdprErasureTest.php
+++ b/tests/Feature/GdprErasureTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Order;
+use App\Models\PaymentMethod;
+use App\Models\Product;
+use App\Models\User;
+use App\Models\Wishlist;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+/**
+ * GDPR right-to-erasure (Art. 17). Erasure ANONYMISES rather than hard-deletes: the
+ * user's orders must survive for accounting/legal retention, but every piece of
+ * identifying data (profile, saved payment methods, behavioural tracking, order PII)
+ * is scrubbed. It is a destructive, self-only action guarded by password re-entry.
+ */
+class GdprErasureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_erase_requires_authentication(): void
+    {
+        $this->delete(route('account.erase'))->assertRedirect(route('login'));
+    }
+
+    public function test_erase_requires_the_current_password(): void
+    {
+        $user = User::factory()->create(['email' => 'real@example.com', 'password' => Hash::make('correct-horse')]);
+
+        $this->actingAs($user)
+            ->deleteJson(route('account.erase'), ['password' => 'wrong-password'])
+            ->assertStatus(422);
+
+        // Nothing was scrubbed.
+        $this->assertSame('real@example.com', $user->fresh()->email);
+    }
+
+    public function test_erase_anonymises_identity_scrubs_order_pii_and_deletes_personal_data(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.com',
+            'password' => Hash::make('correct-horse'),
+            'two_factor_secret' => 'TOTPSECRET',
+        ]);
+        $customer = $user->getOrCreateCustomer();
+        $order = Order::create([
+            'user_id' => $user->id,
+            'customer_id' => $customer->id,
+            'customer_email' => 'ada@example.com',
+            'shipping_address' => '1 Analytical Engine Rd',
+            'recipient_name' => 'Ada Lovelace',
+            'gift_message' => 'Happy birthday',
+            'order_date' => now()->toDateString(),
+            'total_amount' => 99.00,
+            'payment_status' => 'paid',
+            'shipping_status' => 'pending',
+            'status' => 'paid',
+        ]);
+        $pm = PaymentMethod::create(['user_id' => $user->id, 'name' => 'Visa 4242', 'details' => 'tok_live_X', 'is_default' => true]);
+        $product = Product::factory()->create();
+        Wishlist::create(['user_id' => $user->id, 'product_id' => $product->id]);
+
+        $this->actingAs($user)
+            ->deleteJson(route('account.erase'), ['password' => 'correct-horse'])
+            ->assertOk();
+
+        // Identity anonymised, secrets cleared, row kept.
+        $user->refresh();
+        $this->assertNotSame('ada@example.com', $user->email);
+        $this->assertStringNotContainsString('ada@example.com', $user->email);
+        $this->assertNull($user->two_factor_secret);
+        $this->assertFalse(Hash::check('correct-horse', $user->password));
+
+        // Customer profile anonymised (row kept, email is NOT NULL so it is a placeholder).
+        $customer->refresh();
+        $this->assertNotSame('ada@example.com', $customer->email);
+        $this->assertNotSame('Ada', $customer->first_name);
+
+        // Order survives with financials intact but PII scrubbed.
+        $order->refresh();
+        $this->assertSame('99.00', (string) $order->total_amount);
+        $this->assertStringNotContainsString('ada@example.com', (string) $order->customer_email);
+        $this->assertStringNotContainsString('Analytical Engine', (string) $order->shipping_address);
+        $this->assertNotSame('Ada Lovelace', $order->recipient_name);
+
+        // Payment methods + behavioural data deleted.
+        $this->assertNull(PaymentMethod::find($pm->id));
+        $this->assertSame(0, Wishlist::where('user_id', $user->id)->count());
+    }
+}


### PR DESCRIPTION
feat(gdpr): account erasure / right-to-be-forgotten (Art. 17)

Adds a password-guarded self-service endpoint that ANONYMISES the current user rather
than hard-deleting them, so their orders survive for accounting/legal retention while
every identifying field is scrubbed.

- DELETE /account (auth, name account.erase). Requires the current password
  (Hash::check) — erasure is irreversible, so an accidental or hijacked-session
  trigger is blocked (wrong password -> 422). On success the user is logged out and
  the session invalidated.
- GdprErasureService::erase(User) runs in one DB transaction:
    * user: name/email anonymised (email -> deleted-{id}@anonymized.invalid),
      email_verified_at + remember_token + two_factor_secret + recovery_codes cleared,
      password replaced with a random hash. Row kept so orders keep their owner link.
    * customer: profile scrubbed (name -> Deleted/User, email -> redacted placeholder
      since customers.email is NOT NULL, address fields nulled).
    * orders (matched by user_id OR linked customer_id): PII columns scrubbed
      (customer_email, shipping_address, recipient_name/email, gift_message) while
      amounts/status/dates are untouched.
    * payment methods, browsing history, product interactions, wishlist: deleted.

No migration (writes to existing columns only; null writes target confirmed-nullable
columns, redaction strings elsewhere, so no NOT NULL risk on MySQL).

ponytail: user-generated content (reviews/ratings) + gift registries are left for a
follow-up — deleting them changes public product aggregates and needs its own pass.

TDD: 3 feature tests (auth required; wrong password rejected + nothing scrubbed;
identity anonymised + order PII scrubbed while the order survives + payment/behavioural
data deleted). Full suite 1056 passed. Pairs with the data-export endpoint (#770).
