### PR TITLE
feat(paypal): persist subscriptions and sync status via webhook

### DIFF
--- a/app/Http/Controllers/PaypalPaymentController.php
+++ b/app/Http/Controllers/PaypalPaymentController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\PaypalSubscription;
 use App\Services\PaymentGatewayService;
 use App\Services\SubscriptionService;
 use Illuminate\Http\Request;
@@ -34,11 +35,29 @@ class PaypalPaymentController extends Controller
 
     public function createSubscription(Request $request)
     {
-        $paymentMethodId = $request->input('paymentMethodId');
-        $planId = $request->input('planId');
+        $validated = $request->validate([
+            'paymentMethodId' => 'required|string',
+            'planId' => 'required|string',
+        ]);
+
         $userDetails = $request->only(['email', 'address']);
 
-        $result = $this->subscriptionService->createSubscription($paymentMethodId, $planId, $userDetails);
+        $result = $this->subscriptionService->createSubscription(
+            $validated['paymentMethodId'],
+            $validated['planId'],
+            $userDetails,
+        );
+
+        // Persist the subscription owned by the caller so we can sync its status from
+        // webhooks later. Only on success — a failed create has no PayPal id to track.
+        if (($result['success'] ?? false) && ! empty($result['subscription_id'])) {
+            PaypalSubscription::create([
+                'user_id' => $request->user()->id,
+                'paypal_subscription_id' => $result['subscription_id'],
+                'plan_id' => $validated['planId'],
+                'status' => $result['status'] ?? 'APPROVAL_PENDING',
+            ]);
+        }
 
         return response()->json($result);
     }

--- a/app/Http/Controllers/PaypalWebhookController.php
+++ b/app/Http/Controllers/PaypalWebhookController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PaypalSubscription;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Srmklive\PayPal\Services\PayPal as PayPalClient;
+
+class PaypalWebhookController extends Controller
+{
+    /**
+     * Local (crypto) status → target: only the subscription lifecycle events that
+     * change our stored status. Everything else is acknowledged and ignored.
+     */
+    private const STATUS_MAP = [
+        'BILLING.SUBSCRIPTION.ACTIVATED' => 'ACTIVE',
+        'BILLING.SUBSCRIPTION.CANCELLED' => 'CANCELLED',
+        'BILLING.SUBSCRIPTION.SUSPENDED' => 'SUSPENDED',
+        'BILLING.SUBSCRIPTION.EXPIRED' => 'EXPIRED',
+    ];
+
+    /**
+     * Signature-verified PayPal webhook. PayPal — not our synchronous create call —
+     * is the source of truth for when a subscription activates/cancels/expires, so we
+     * reconcile the local status here. Unauthenticated + CSRF-exempt: the signature is
+     * the only gate. Verification is fully local (RSA-SHA256 against PayPal's cert), so
+     * no API credentials or round-trip are needed.
+     */
+    public function handle(Request $request, PayPalClient $paypal): JsonResponse
+    {
+        $webhookId = (string) config('paypal.webhook_id');
+
+        $verified = $webhookId !== '' && $paypal->verifyWebHookLocally(
+            $this->flatHeaders($request),
+            $webhookId,
+            $request->getContent(),
+        );
+
+        if (! $verified) {
+            return response()->json(['error' => 'Invalid signature'], 400);
+        }
+
+        $status = self::STATUS_MAP[$request->input('event_type')] ?? null;
+        $subscriptionId = $request->input('resource.id');
+
+        // Unmapped event or event for a subscription we don't track: ack and ignore.
+        // update() is a no-op on zero matches, and setting an absolute status keeps
+        // this idempotent across PayPal's at-least-once webhook retries.
+        if ($status !== null && $subscriptionId !== null) {
+            PaypalSubscription::where('paypal_subscription_id', $subscriptionId)
+                ->update(['status' => $status]);
+        }
+
+        return response()->json(['received' => true]);
+    }
+
+    /**
+     * Collapse Laravel's array-valued headers to the scalar strings
+     * verifyWebHookLocally expects (it reads each PAYPAL-* header as a string).
+     */
+    private function flatHeaders(Request $request): array
+    {
+        return array_map(
+            fn ($value) => is_array($value) ? ($value[0] ?? '') : $value,
+            $request->headers->all(),
+        );
+    }
+}

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -13,5 +13,6 @@ class VerifyCsrfToken extends Middleware
      */
     protected $except = [
         'stripe/webhook',
+        'paypal/webhook',
     ];
 }

--- a/app/Models/PaypalSubscription.php
+++ b/app/Models/PaypalSubscription.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A PayPal subscription owned by a local user. Created (APPROVAL_PENDING) when the
+ * user starts a subscription; its status is thereafter driven by PayPal webhooks
+ * (ACTIVE / SUSPENDED / CANCELLED / EXPIRED).
+ */
+class PaypalSubscription extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'paypal_subscription_id',
+        'plan_id',
+        'status',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/config/paypal.php
+++ b/config/paypal.php
@@ -23,6 +23,7 @@ return [
     'payment_action' => env('PAYPAL_PAYMENT_ACTION', 'Sale'), // Can only be 'Sale', 'Authorization' or 'Order'
     'currency' => env('PAYPAL_CURRENCY', 'USD'),
     'notify_url' => env('PAYPAL_NOTIFY_URL', ''), // Change this accordingly for your application.
+    'webhook_id' => env('PAYPAL_WEBHOOK_ID', ''), // From developer.paypal.com → your app → Webhooks. Required to verify webhook signatures.
     'locale' => env('PAYPAL_LOCALE', 'en_US'), // force gateway language  i.e. it_IT, es_ES, en_US ... (for express checkout only)
     'validate_ssl' => env('PAYPAL_VALIDATE_SSL', true), // Validate SSL when creating api client.
     'timeout' => env('PAYPAL_TIMEOUT', 30), // Total request timeout in seconds.

--- a/database/migrations/2026_07_14_000201_create_paypal_subscriptions_table.php
+++ b/database/migrations/2026_07_14_000201_create_paypal_subscriptions_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Local record of a PayPal subscription so the app can own it (link to a user) and
+ * keep its lifecycle status in sync via webhooks — PayPal, not the app, decides when
+ * a subscription activates/cancels/expires, and those transitions arrive out of band.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('paypal_subscriptions')) {
+            return;
+        }
+
+        Schema::create('paypal_subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('paypal_subscription_id')->unique();
+            $table->string('plan_id');
+            $table->string('status')->default('APPROVAL_PENDING');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('paypal_subscriptions');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\InvoiceController;
 use App\Http\Controllers\OrderHistoryController;
 use App\Http\Controllers\PaymentMethodController;
 use App\Http\Controllers\PaypalPaymentController;
+use App\Http\Controllers\PaypalWebhookController;
 use App\Http\Controllers\RatingController;
 use App\Http\Controllers\ReviewController;
 use App\Http\Controllers\ShippingController;
@@ -113,6 +114,11 @@ Route::middleware('auth')->prefix('payment_methods')->group(function () {
 // Stripe webhook — unauthenticated + CSRF-exempt (verified by signature in the controller)
 Route::post('/stripe/webhook', [StripeWebhookController::class, 'handle'])->name('stripe.webhook');
 
+// PayPal subscription webhook — unauthenticated + CSRF-exempt (signature verified in
+// the controller). PayPal drives subscription lifecycle status (activated/cancelled/…)
+// out of band; this reconciles it onto the local PaypalSubscription record.
+Route::post('/paypal/webhook', [PaypalWebhookController::class, 'handle'])->name('paypal.webhook');
+
 // Stripe subscription mutations act only on the current user ($request->user()),
 // so an anonymous request would deref null and 500. Require auth.
 Route::middleware('auth')->group(function () {
@@ -135,9 +141,10 @@ Route::middleware('auth')->group(function () {
 // (a PayPal order id to capture / a subscriptionId) against the merchant's live
 // PayPal credentials — require auth so an anonymous request can't trigger a capture
 // or update/cancel someone else's subscription.
-// ponytail: real per-user ownership scoping must come when the PayPal integration is
-// actually built; SubscriptionService is a stub today with no persisted
-// subscription↔user link to check against.
+// createSubscription now persists a PaypalSubscription owned by the caller, and the
+// webhook keeps its status in sync. ponytail: update/cancel still act on a
+// caller-supplied subscriptionId without checking that persisted ownership — a
+// follow-up should scope them to the caller's own PaypalSubscription rows.
 Route::middleware('auth')->group(function () {
     Route::post('/paypal/payment', [PaypalPaymentController::class, 'createOneTimePayment'])->name('paypal.payment.create');
     Route::post('/paypal/subscription', [PaypalPaymentController::class, 'createSubscription'])->name('paypal.subscription.create');

--- a/tests/Feature/PaypalPaymentControllerTest.php
+++ b/tests/Feature/PaypalPaymentControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Interfaces\PaymentGatewayInterface;
 use App\Models\User;
 use App\Services\PaymentGateways\PayPalGateway;
+use App\Services\SubscriptionService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -90,5 +91,76 @@ class PaypalPaymentControllerTest extends TestCase
 
         $response->assertOk();
         $response->assertJson(['success' => false, 'error' => 'declined']);
+    }
+
+    /** Bind a SubscriptionService that returns a canned PayPal success without HTTP. */
+    private function fakeSubscriptionService(array $return): void
+    {
+        $this->app->instance(SubscriptionService::class, new class($return) extends SubscriptionService
+        {
+            public function __construct(private array $return) {}
+
+            public function createSubscription($paymentMethodId, $planId, $userDetails)
+            {
+                return $this->return;
+            }
+        });
+    }
+
+    public function test_create_subscription_persists_it_owned_by_the_user(): void
+    {
+        $this->fakeSubscriptionService([
+            'success' => true,
+            'subscription_id' => 'I-SUB999',
+            'status' => 'APPROVAL_PENDING',
+            'approval_url' => 'https://paypal.com/approve/I-SUB999',
+        ]);
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->postJson(route('paypal.subscription.create'), [
+                'paymentMethodId' => 'pm_1',
+                'planId' => 'P-PLAN',
+            ])
+            ->assertOk()
+            ->assertJson(['success' => true, 'subscription_id' => 'I-SUB999']);
+
+        $this->assertDatabaseHas('paypal_subscriptions', [
+            'user_id' => $user->id,
+            'paypal_subscription_id' => 'I-SUB999',
+            'plan_id' => 'P-PLAN',
+            'status' => 'APPROVAL_PENDING',
+        ]);
+    }
+
+    public function test_create_subscription_requires_authentication(): void
+    {
+        $this->postJson(route('paypal.subscription.create'), [
+            'paymentMethodId' => 'pm_1',
+            'planId' => 'P-PLAN',
+        ])->assertUnauthorized();
+    }
+
+    public function test_create_subscription_requires_a_plan_id(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->postJson(route('paypal.subscription.create'), ['paymentMethodId' => 'pm_1'])
+            ->assertStatus(422);
+    }
+
+    public function test_failed_subscription_is_not_persisted(): void
+    {
+        $this->fakeSubscriptionService(['success' => false, 'error' => 'Invalid plan']);
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->postJson(route('paypal.subscription.create'), [
+                'paymentMethodId' => 'pm_1',
+                'planId' => 'P-BAD',
+            ])
+            ->assertOk()
+            ->assertJson(['success' => false]);
+
+        $this->assertDatabaseCount('paypal_subscriptions', 0);
     }
 }

--- a/tests/Feature/PaypalWebhookTest.php
+++ b/tests/Feature/PaypalWebhookTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\PaypalSubscription;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Srmklive\PayPal\Services\PayPal as PayPalClient;
+use Tests\TestCase;
+
+/**
+ * PayPal subscription webhook: signature-verified, then maps subscription lifecycle
+ * events onto the local PaypalSubscription status. Unauthenticated + CSRF-exempt
+ * (PayPal is the caller), so the signature check is the only gate.
+ */
+class PaypalWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** Bind a PayPal client whose local signature verification returns $verified. */
+    private function fakeVerification(bool $verified): void
+    {
+        config(['paypal.webhook_id' => 'WH-TEST']);
+
+        $client = Mockery::mock(PayPalClient::class);
+        $client->shouldReceive('verifyWebHookLocally')->andReturn($verified);
+        $this->app->instance(PayPalClient::class, $client);
+    }
+
+    private function subscription(string $status = 'APPROVAL_PENDING'): PaypalSubscription
+    {
+        return PaypalSubscription::create([
+            'user_id' => User::factory()->create()->id,
+            'paypal_subscription_id' => 'I-SUB123',
+            'plan_id' => 'P-PLAN',
+            'status' => $status,
+        ]);
+    }
+
+    private function event(string $type, string $subId = 'I-SUB123'): array
+    {
+        return ['event_type' => $type, 'resource' => ['id' => $subId]];
+    }
+
+    public function test_invalid_signature_is_rejected_and_changes_nothing(): void
+    {
+        $this->fakeVerification(false);
+        $sub = $this->subscription();
+
+        $this->postJson(route('paypal.webhook'), $this->event('BILLING.SUBSCRIPTION.ACTIVATED'))
+            ->assertStatus(400);
+
+        $this->assertSame('APPROVAL_PENDING', $sub->fresh()->status);
+    }
+
+    public function test_activated_event_marks_the_subscription_active(): void
+    {
+        $this->fakeVerification(true);
+        $sub = $this->subscription();
+
+        $this->postJson(route('paypal.webhook'), $this->event('BILLING.SUBSCRIPTION.ACTIVATED'))
+            ->assertOk();
+
+        $this->assertSame('ACTIVE', $sub->fresh()->status);
+    }
+
+    public function test_cancelled_event_marks_the_subscription_cancelled(): void
+    {
+        $this->fakeVerification(true);
+        $sub = $this->subscription('ACTIVE');
+
+        $this->postJson(route('paypal.webhook'), $this->event('BILLING.SUBSCRIPTION.CANCELLED'))
+            ->assertOk();
+
+        $this->assertSame('CANCELLED', $sub->fresh()->status);
+    }
+
+    public function test_unmapped_event_is_acknowledged_without_changing_status(): void
+    {
+        $this->fakeVerification(true);
+        $sub = $this->subscription('ACTIVE');
+
+        $this->postJson(route('paypal.webhook'), $this->event('PAYMENT.SALE.COMPLETED'))
+            ->assertOk();
+
+        $this->assertSame('ACTIVE', $sub->fresh()->status);
+    }
+
+    public function test_event_for_an_unknown_subscription_is_acknowledged(): void
+    {
+        $this->fakeVerification(true);
+
+        $this->postJson(route('paypal.webhook'), $this->event('BILLING.SUBSCRIPTION.ACTIVATED', 'I-DOES-NOT-EXIST'))
+            ->assertOk();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
## What

Makes PayPal subscriptions **durable and self-syncing**. Previously `createSubscription` returned a PayPal subscription id that was never persisted — nothing linked a subscription to a user, and nothing tracked its lifecycle. Since PayPal (not our synchronous create call) decides when a subscription activates / cancels / suspends / expires, and those events arrive out of band, the local state had no way to stay correct.

## Changes

- **New `paypal_subscriptions` table + `PaypalSubscription` model** — `user_id`, `paypal_subscription_id` (unique), `plan_id`, `status`. Verified on a disposable **MySQL 8.4**, full migration chain green.
- **Persist on create** — `PaypalPaymentController::createSubscription` now validates `paymentMethodId` + `planId` and, on a successful PayPal create, stores the subscription **owned by the authenticated caller** (`status = APPROVAL_PENDING` until PayPal activates it). A failed create persists nothing.
- **`POST /paypal/webhook`** — unauthenticated + CSRF-exempt, **signature-verified** via srmklive `verifyWebHookLocally` (local RSA-SHA256 against PayPal's cert, no API round-trip, SSRF-guarded cert URL). Maps subscription lifecycle events onto local status:
  | PayPal event | local status |
  |---|---|
  | `BILLING.SUBSCRIPTION.ACTIVATED` | `ACTIVE` |
  | `BILLING.SUBSCRIPTION.CANCELLED` | `CANCELLED` |
  | `BILLING.SUBSCRIPTION.SUSPENDED` | `SUSPENDED` |
  | `BILLING.SUBSCRIPTION.EXPIRED` | `EXPIRED` |

  Unmapped events and events for untracked subscription ids are acknowledged and ignored. Setting an absolute status keeps it **idempotent** across PayPal's at-least-once retries. Mirrors the existing `StripeWebhookController` pattern.
- Config: `paypal.webhook_id` (`PAYPAL_WEBHOOK_ID`) — required to verify signatures.

## Deferred (follow-up)

`update` / `cancel` still act on a caller-supplied `subscriptionId` without checking the now-persisted ownership. A follow-up should scope them to the caller's own `PaypalSubscription` rows (closing the IDOR the route comment has flagged). Called out in a `ponytail:` comment on the route group.

## Tests (TDD, RED→GREEN)

9 new:
- **Webhook** (5): invalid signature → 400 + no state change; ACTIVATED → active; CANCELLED → cancelled; unmapped event → ack, no change; unknown subscription → ack.
- **Create** (4): persists owned by user; requires auth; requires `planId`; failed create persists nothing.

Full suite **1062 passed** (default order). The single `--order-by=random` failure is the pre-existing `SocialstreamRegistrationTest` Socialite facade-mock flake — unrelated to this change.
