### PR TITLE
fix(paypal): scope subscription update/cancel to the caller's own record (IDOR)

### DIFF
--- a/app/Http/Controllers/PaypalPaymentController.php
+++ b/app/Http/Controllers/PaypalPaymentController.php
@@ -64,20 +64,42 @@ class PaypalPaymentController extends Controller
 
     public function updateSubscription(Request $request)
     {
-        $subscriptionId = $request->input('subscriptionId');
-        $planId = $request->input('planId');
+        $validated = $request->validate([
+            'subscriptionId' => 'required|string',
+            'planId' => 'required|string',
+        ]);
 
-        $result = $this->subscriptionService->updateSubscription($subscriptionId, $planId);
+        $this->ownedSubscriptionOrFail($request, $validated['subscriptionId']);
+
+        $result = $this->subscriptionService->updateSubscription($validated['subscriptionId'], $validated['planId']);
 
         return response()->json($result);
     }
 
     public function cancelSubscription(Request $request)
     {
-        $subscriptionId = $request->input('subscriptionId');
+        $validated = $request->validate([
+            'subscriptionId' => 'required|string',
+        ]);
 
-        $result = $this->subscriptionService->cancelSubscription($subscriptionId);
+        $this->ownedSubscriptionOrFail($request, $validated['subscriptionId']);
+
+        $result = $this->subscriptionService->cancelSubscription($validated['subscriptionId']);
 
         return response()->json($result);
+    }
+
+    /**
+     * The subscriptionId is caller-supplied and acts directly against PayPal, so without
+     * this an authenticated user could update/cancel anyone's subscription (IDOR). Scope
+     * it to a PaypalSubscription the caller owns; 404 (not 403) so a probe can't tell an
+     * unowned id from a nonexistent one.
+     */
+    private function ownedSubscriptionOrFail(Request $request, string $subscriptionId): PaypalSubscription
+    {
+        return PaypalSubscription::query()
+            ->where('user_id', $request->user()->id)
+            ->where('paypal_subscription_id', $subscriptionId)
+            ->firstOrFail();
     }
 }

--- a/tests/Feature/PaypalPaymentControllerTest.php
+++ b/tests/Feature/PaypalPaymentControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Interfaces\PaymentGatewayInterface;
+use App\Models\PaypalSubscription;
 use App\Models\User;
 use App\Services\PaymentGateways\PayPalGateway;
 use App\Services\SubscriptionService;
@@ -93,7 +94,7 @@ class PaypalPaymentControllerTest extends TestCase
         $response->assertJson(['success' => false, 'error' => 'declined']);
     }
 
-    /** Bind a SubscriptionService that returns a canned PayPal success without HTTP. */
+    /** Bind a SubscriptionService that returns a canned PayPal result without HTTP. */
     private function fakeSubscriptionService(array $return): void
     {
         $this->app->instance(SubscriptionService::class, new class($return) extends SubscriptionService
@@ -104,7 +105,27 @@ class PaypalPaymentControllerTest extends TestCase
             {
                 return $this->return;
             }
+
+            public function cancelSubscription($subscriptionId)
+            {
+                return $this->return;
+            }
+
+            public function updateSubscription($subscriptionId, $planId)
+            {
+                return $this->return;
+            }
         });
+    }
+
+    private function subscriptionOwnedBy(User $user, string $id = 'I-OWNED'): PaypalSubscription
+    {
+        return PaypalSubscription::create([
+            'user_id' => $user->id,
+            'paypal_subscription_id' => $id,
+            'plan_id' => 'P-PLAN',
+            'status' => 'ACTIVE',
+        ]);
     }
 
     public function test_create_subscription_persists_it_owned_by_the_user(): void
@@ -162,5 +183,70 @@ class PaypalPaymentControllerTest extends TestCase
             ->assertJson(['success' => false]);
 
         $this->assertDatabaseCount('paypal_subscriptions', 0);
+    }
+
+    public function test_cancel_subscription_requires_authentication(): void
+    {
+        $this->deleteJson(route('paypal.subscription.cancel'), ['subscriptionId' => 'I-OWNED'])
+            ->assertUnauthorized();
+    }
+
+    public function test_cancel_subscription_requires_a_subscription_id(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->deleteJson(route('paypal.subscription.cancel'), [])
+            ->assertStatus(422);
+    }
+
+    public function test_cannot_cancel_another_users_subscription(): void
+    {
+        // Guard would otherwise let any authed user cancel anyone's subscription id
+        // straight against PayPal — a fake success here proves the request never
+        // reaches the gateway (it is stopped at the ownership check).
+        $this->fakeSubscriptionService(['success' => true, 'message' => 'cancelled']);
+        $this->subscriptionOwnedBy(User::factory()->create(), 'I-OTHERS');
+
+        $this->actingAs(User::factory()->create())
+            ->deleteJson(route('paypal.subscription.cancel'), ['subscriptionId' => 'I-OTHERS'])
+            ->assertNotFound();
+    }
+
+    public function test_can_cancel_own_subscription(): void
+    {
+        $this->fakeSubscriptionService(['success' => true, 'message' => 'cancelled']);
+        $user = User::factory()->create();
+        $this->subscriptionOwnedBy($user, 'I-MINE');
+
+        $this->actingAs($user)
+            ->deleteJson(route('paypal.subscription.cancel'), ['subscriptionId' => 'I-MINE'])
+            ->assertOk()
+            ->assertJson(['success' => true]);
+    }
+
+    public function test_cannot_update_another_users_subscription(): void
+    {
+        $this->fakeSubscriptionService(['success' => true]);
+        $this->subscriptionOwnedBy(User::factory()->create(), 'I-OTHERS');
+
+        $this->actingAs(User::factory()->create())
+            ->patchJson(route('paypal.subscription.update'), [
+                'subscriptionId' => 'I-OTHERS',
+                'planId' => 'P-NEW',
+            ])
+            ->assertNotFound();
+    }
+
+    public function test_can_update_own_subscription(): void
+    {
+        $this->fakeSubscriptionService(['success' => true]);
+        $user = User::factory()->create();
+        $this->subscriptionOwnedBy($user, 'I-MINE');
+
+        $this->actingAs($user)
+            ->patchJson(route('paypal.subscription.update'), [
+                'subscriptionId' => 'I-MINE',
+                'planId' => 'P-NEW',
+            ])
+            ->assertOk();
     }
 }


### PR DESCRIPTION
## Vulnerability

`PATCH /paypal/subscription/update` and `DELETE /paypal/subscription/cancel` took a **caller-supplied `subscriptionId`** and acted directly against PayPal with no check that the caller owns it. Any authenticated user could **cancel or re-plan anyone else's PayPal subscription** by supplying its id — a classic IDOR. Flagged as the follow-up when subscription persistence landed in #772.

## Fix

Subscriptions are now persisted (`paypal_subscriptions`, owned by `user_id` — #772), so both routes resolve the subscription through a `PaypalSubscription` **scoped to the authenticated caller** and `firstOrFail()`:

```php
private function ownedSubscriptionOrFail(Request $request, string $subscriptionId): PaypalSubscription
{
    return PaypalSubscription::query()
        ->where('user_id', $request->user()->id)
        ->where('paypal_subscription_id', $subscriptionId)
        ->firstOrFail();
}
```

- An id the caller doesn't own → **404** *before any PayPal call*. 404 (not 403) so a probe can't distinguish an unowned id from a nonexistent one.
- Added the previously-missing **validation** (`subscriptionId` + `planId` required strings).

Ownership scoping only — no behavioural/status change to the underlying PayPal calls. `updateSubscription` still returns its honest-fail (srmklive exposes no `/revise`); `cancelSubscription` still delegates to the real SDK.

## Tests (TDD, RED→GREEN)

+6:
- **cancel**: requires auth (401); requires `subscriptionId` (422); another user's id → 404 (fake gateway success proves the request never reaches PayPal — it's stopped at the ownership check); own id → 200.
- **update**: another user's id → 404; own id → 200.

Full suite **1071 passed**, including `--order-by=random`.
