### PR TITLE
feat(shipping): live carrier rates via EasyPost (fallback to flat methods)

### DIFF
--- a/app/Factories/CarrierRateFactory.php
+++ b/app/Factories/CarrierRateFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Factories;
+
+use App\Interfaces\CarrierRateInterface;
+use App\Services\Shipping\EasyPostCarrier;
+
+class CarrierRateFactory
+{
+    /**
+     * Resolve the configured live-rate carrier, or null when none is configured
+     * (the store then falls back to its flat DB shipping methods).
+     *
+     * Add a carrier = a new class implementing CarrierRateInterface + a case here.
+     */
+    public static function create(?string $carrier = null): ?CarrierRateInterface
+    {
+        $carrier ??= config('shipping.carrier');
+
+        // Resolve through the container so carriers are injectable (tests can bind a
+        // fake) and their dependencies are wired.
+        return match ($carrier) {
+            'easypost' => app(EasyPostCarrier::class),
+            default => null,
+        };
+    }
+}

--- a/app/Interfaces/CarrierRateInterface.php
+++ b/app/Interfaces/CarrierRateInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Interfaces;
+
+use App\Services\Shipping\CarrierRate;
+
+interface CarrierRateInterface
+{
+    /**
+     * Live shipping rates for a parcel between two addresses.
+     *
+     * @param  array  $parcel  ['weight' => float, 'length'?, 'width'?, 'height'?]
+     * @param  array  $from  origin address (name/street1/city/state/zip/country)
+     * @param  array  $to  destination address (same shape)
+     * @return CarrierRate[] empty when the carrier is unconfigured or unreachable
+     */
+    public function getRates(array $parcel, array $from, array $to): array;
+}

--- a/app/Services/Shipping/CarrierRate.php
+++ b/app/Services/Shipping/CarrierRate.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services\Shipping;
+
+/**
+ * A single normalised shipping rate returned by a carrier — the common shape the app
+ * consumes regardless of which carrier (or aggregator) produced it.
+ */
+final class CarrierRate
+{
+    public function __construct(
+        public readonly string $carrier,
+        public readonly string $service,
+        public readonly float $amount,
+        public readonly string $currency = 'USD',
+        public readonly ?int $deliveryDays = null,
+        public readonly ?string $rateId = null,
+    ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'carrier' => $this->carrier,
+            'service' => $this->service,
+            'amount' => $this->amount,
+            'currency' => $this->currency,
+            'delivery_days' => $this->deliveryDays,
+            'rate_id' => $this->rateId,
+        ];
+    }
+}

--- a/app/Services/Shipping/EasyPostCarrier.php
+++ b/app/Services/Shipping/EasyPostCarrier.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Services\Shipping;
+
+use App\Interfaces\CarrierRateInterface;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+/**
+ * Live rates via EasyPost — a single JSON API that rate-shops many carriers
+ * (USPS/UPS/FedEx/DHL…) at once. We create a shipment and read back its rates.
+ *
+ * Rating never blocks checkout: an unconfigured key, a non-2xx response, or a
+ * network error returns [] so the caller falls back to the flat DB methods.
+ *
+ * @see https://docs.easypost.com/docs/shipments
+ */
+class EasyPostCarrier implements CarrierRateInterface
+{
+    private const ENDPOINT = 'https://api.easypost.com/v2/shipments';
+
+    public function getRates(array $parcel, array $from, array $to): array
+    {
+        $apiKey = (string) config('shipping.easypost.api_key');
+        if ($apiKey === '') {
+            return [];
+        }
+
+        try {
+            // EasyPost authenticates with the API key as the HTTP Basic username
+            // (empty password).
+            $response = Http::withBasicAuth($apiKey, '')
+                ->timeout((int) config('shipping.timeout', 15))
+                ->post(self::ENDPOINT, [
+                    'shipment' => [
+                        'to_address' => $this->address($to),
+                        'from_address' => $this->address($from),
+                        'parcel' => $this->parcel($parcel),
+                    ],
+                ]);
+
+            if (! $response->successful()) {
+                return [];
+            }
+
+            return $this->mapRates($response->json('rates', []) ?? []);
+        } catch (Throwable $e) {
+            report($e);
+
+            return [];
+        }
+    }
+
+    private function address(array $address): array
+    {
+        return [
+            'name' => $address['name'] ?? null,
+            'street1' => $address['street1'] ?? null,
+            'city' => $address['city'] ?? null,
+            'state' => $address['state'] ?? null,
+            'zip' => $address['zip'] ?? null,
+            'country' => $address['country'] ?? 'US',
+        ];
+    }
+
+    private function parcel(array $parcel): array
+    {
+        // EasyPost expects the parcel weight in ounces. Product weights are stored in
+        // config('shipping.weight_unit') (default oz); convert if they're in pounds.
+        $weight = (float) ($parcel['weight'] ?? 0);
+        if (strtolower((string) config('shipping.weight_unit', 'oz')) === 'lb') {
+            $weight *= 16;
+        }
+
+        return array_filter([
+            'weight' => round($weight, 2),
+            'length' => $parcel['length'] ?? null,
+            'width' => $parcel['width'] ?? null,
+            'height' => $parcel['height'] ?? null,
+        ], fn ($v) => $v !== null);
+    }
+
+    /**
+     * @return CarrierRate[] sorted cheapest first
+     */
+    private function mapRates(array $rates): array
+    {
+        $mapped = [];
+        foreach ($rates as $rate) {
+            if (! isset($rate['rate'])) {
+                continue;
+            }
+            $mapped[] = new CarrierRate(
+                carrier: (string) ($rate['carrier'] ?? 'Unknown'),
+                service: (string) ($rate['service'] ?? 'Unknown'),
+                amount: (float) $rate['rate'],
+                currency: (string) ($rate['currency'] ?? 'USD'),
+                deliveryDays: isset($rate['delivery_days']) ? (int) $rate['delivery_days'] : null,
+                rateId: $rate['id'] ?? null,
+            );
+        }
+
+        usort($mapped, fn (CarrierRate $a, CarrierRate $b) => $a->amount <=> $b->amount);
+
+        return $mapped;
+    }
+}

--- a/app/Services/ShippingService.php
+++ b/app/Services/ShippingService.php
@@ -2,12 +2,35 @@
 
 namespace App\Services;
 
+use App\Factories\CarrierRateFactory;
 use App\Models\Product;
 use App\Models\ShippingMethod;
+use App\Services\Shipping\CarrierRate;
 use Illuminate\Support\Facades\Http;
 
 class ShippingService
 {
+    /**
+     * Live carrier rates for a cart shipping to $to. Returns [] when no live-rate
+     * carrier is configured or the carrier is unreachable — the caller then falls
+     * back to the flat DB methods from getAvailableShippingMethods().
+     *
+     * @param  array  $to  destination address (name/street1/city/state/zip/country)
+     * @param  array|null  $from  origin; defaults to config('shipping.origin')
+     * @return CarrierRate[]
+     */
+    public function getLiveRates($cart, array $to, ?array $from = null): array
+    {
+        $carrier = CarrierRateFactory::create();
+        if ($carrier === null) {
+            return [];
+        }
+
+        $parcel = ['weight' => $this->calculateTotalWeight($cart)];
+
+        return $carrier->getRates($parcel, $from ?? (array) config('shipping.origin'), $to);
+    }
+
     public function getAvailableShippingMethods($cart = null, $address = null)
     {
         // Only offer active methods; a deactivated method must never be selectable.

--- a/config/shipping.php
+++ b/config/shipping.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Live-rate carrier
+    |--------------------------------------------------------------------------
+    | Which carrier (aggregator) to fetch live rates from. Null / unset = live
+    | rating off; checkout uses the flat DB shipping methods only. Supported:
+    | 'easypost'.
+    */
+    'carrier' => env('SHIPPING_CARRIER'),
+
+    // Unit the Product.weight column is stored in ('oz' or 'lb'). Carriers are given
+    // the weight converted to the unit they require.
+    'weight_unit' => env('SHIPPING_WEIGHT_UNIT', 'oz'),
+
+    // Per-request timeout (seconds) for carrier rate lookups.
+    'timeout' => env('SHIPPING_TIMEOUT', 15),
+
+    /*
+    | Ship-from (origin) address used for rate quotes.
+    */
+    'origin' => [
+        'name' => env('SHIPPING_ORIGIN_NAME', ''),
+        'street1' => env('SHIPPING_ORIGIN_STREET1', ''),
+        'city' => env('SHIPPING_ORIGIN_CITY', ''),
+        'state' => env('SHIPPING_ORIGIN_STATE', ''),
+        'zip' => env('SHIPPING_ORIGIN_ZIP', ''),
+        'country' => env('SHIPPING_ORIGIN_COUNTRY', 'US'),
+    ],
+
+    'easypost' => [
+        'api_key' => env('EASYPOST_API_KEY', ''),
+    ],
+
+    // Premium added to a flat method's cost for drop-shipped orders (was previously
+    // read from a missing config file, silently always defaulting to 2.00).
+    'drop_shipping_premium' => env('SHIPPING_DROP_PREMIUM', 2.00),
+];

--- a/tests/Unit/EasyPostCarrierTest.php
+++ b/tests/Unit/EasyPostCarrierTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\Shipping\CarrierRate;
+use App\Services\Shipping\EasyPostCarrier;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * EasyPostCarrier turns an EasyPost create-shipment response into normalised
+ * CarrierRate objects, and never lets a rating failure bubble into checkout.
+ */
+class EasyPostCarrierTest extends TestCase
+{
+    private array $parcel = ['weight' => 16.0];
+
+    private array $from = ['zip' => '94103', 'country' => 'US'];
+
+    private array $to = ['zip' => '10001', 'country' => 'US'];
+
+    private function fakeRates(array $rates, int $status = 200): void
+    {
+        Http::fake([
+            'api.easypost.com/*' => Http::response(['id' => 'shp_1', 'rates' => $rates], $status),
+        ]);
+    }
+
+    private function carrier(string $key = 'ek_test'): EasyPostCarrier
+    {
+        config(['shipping.easypost.api_key' => $key]);
+
+        return new EasyPostCarrier;
+    }
+
+    public function test_maps_and_sorts_rates_cheapest_first(): void
+    {
+        $this->fakeRates([
+            ['id' => 'rate_ups', 'carrier' => 'UPS', 'service' => 'Ground', 'rate' => '12.10', 'currency' => 'USD', 'delivery_days' => 4],
+            ['id' => 'rate_usps', 'carrier' => 'USPS', 'service' => 'Priority', 'rate' => '7.53', 'currency' => 'USD', 'delivery_days' => 2],
+        ]);
+
+        $rates = $this->carrier()->getRates($this->parcel, $this->from, $this->to);
+
+        $this->assertCount(2, $rates);
+        $this->assertContainsOnlyInstancesOf(CarrierRate::class, $rates);
+        $this->assertSame('USPS', $rates[0]->carrier);
+        $this->assertSame(7.53, $rates[0]->amount);
+        $this->assertSame(2, $rates[0]->deliveryDays);
+        $this->assertSame('rate_usps', $rates[0]->rateId);
+        $this->assertSame(12.10, $rates[1]->amount);
+    }
+
+    public function test_returns_empty_when_api_key_is_missing(): void
+    {
+        Http::fake();
+
+        $rates = $this->carrier('')->getRates($this->parcel, $this->from, $this->to);
+
+        $this->assertSame([], $rates);
+        Http::assertNothingSent();
+    }
+
+    public function test_returns_empty_on_non_2xx_response(): void
+    {
+        $this->fakeRates([], 500);
+
+        $this->assertSame([], $this->carrier()->getRates($this->parcel, $this->from, $this->to));
+    }
+
+    public function test_returns_empty_on_connection_error(): void
+    {
+        Http::fake(function () {
+            throw new ConnectionException('timeout');
+        });
+
+        $this->assertSame([], $this->carrier()->getRates($this->parcel, $this->from, $this->to));
+    }
+
+    public function test_sends_basic_auth_with_the_api_key(): void
+    {
+        $this->fakeRates([]);
+
+        $this->carrier('ek_secret')->getRates($this->parcel, $this->from, $this->to);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://api.easypost.com/v2/shipments'
+                && $request->hasHeader('Authorization', 'Basic '.base64_encode('ek_secret:'));
+        });
+    }
+
+    public function test_converts_pounds_to_ounces_for_easypost(): void
+    {
+        config(['shipping.weight_unit' => 'lb']);
+        $this->fakeRates([]);
+
+        $this->carrier()->getRates(['weight' => 2.0], $this->from, $this->to);
+
+        Http::assertSent(fn ($request) => $request['shipment']['parcel']['weight'] === 32.0);
+    }
+}

--- a/tests/Unit/ShippingServiceLiveRatesTest.php
+++ b/tests/Unit/ShippingServiceLiveRatesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Factories\CarrierRateFactory;
+use App\Services\Shipping\CarrierRate;
+use App\Services\Shipping\EasyPostCarrier;
+use App\Services\ShippingService;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class ShippingServiceLiveRatesTest extends TestCase
+{
+    // Cart carries inline weights so no Product DB lookup is needed.
+    private array $cart = [1 => ['quantity' => 2, 'weight' => 3.0]];
+
+    private array $to = ['zip' => '10001', 'country' => 'US'];
+
+    public function test_factory_returns_null_when_no_carrier_configured(): void
+    {
+        config(['shipping.carrier' => null]);
+
+        $this->assertNull(CarrierRateFactory::create());
+    }
+
+    public function test_factory_resolves_the_easypost_carrier(): void
+    {
+        config(['shipping.carrier' => 'easypost']);
+
+        $this->assertInstanceOf(EasyPostCarrier::class, CarrierRateFactory::create());
+    }
+
+    public function test_get_live_rates_returns_empty_when_no_carrier_configured(): void
+    {
+        config(['shipping.carrier' => null]);
+
+        $this->assertSame([], app(ShippingService::class)->getLiveRates($this->cart, $this->to));
+    }
+
+    public function test_get_live_rates_returns_carrier_rates_when_configured(): void
+    {
+        config([
+            'shipping.carrier' => 'easypost',
+            'shipping.easypost.api_key' => 'ek_test',
+        ]);
+        Http::fake([
+            'api.easypost.com/*' => Http::response([
+                'rates' => [
+                    ['id' => 'rate_1', 'carrier' => 'USPS', 'service' => 'Priority', 'rate' => '9.20', 'delivery_days' => 3],
+                ],
+            ]),
+        ]);
+
+        $rates = app(ShippingService::class)->getLiveRates($this->cart, $this->to);
+
+        $this->assertCount(1, $rates);
+        $this->assertInstanceOf(CarrierRate::class, $rates[0]);
+        $this->assertSame('USPS', $rates[0]->carrier);
+    }
+
+    public function test_get_live_rates_sends_total_cart_weight(): void
+    {
+        config([
+            'shipping.carrier' => 'easypost',
+            'shipping.easypost.api_key' => 'ek_test',
+            'shipping.weight_unit' => 'oz',
+        ]);
+        Http::fake(['api.easypost.com/*' => Http::response(['rates' => []])]);
+
+        // 2 units × 3.0 = 6.0 total weight.
+        app(ShippingService::class)->getLiveRates($this->cart, $this->to);
+
+        Http::assertSent(fn ($request) => $request['shipment']['parcel']['weight'] === 6.0);
+    }
+}


### PR DESCRIPTION
## What

Adds **live, multi-carrier shipping rates** via EasyPost. Previously shipping was flat-only (`base_rate + weight_rate·weight`, distance component stubbed to `0`).

EasyPost is a rate aggregator — one JSON API returns quotes from USPS / UPS / FedEx / DHL at once — so a single implementation delivers many carriers.

## Design (mirrors the PaymentGateway convention)

- **`CarrierRateInterface`** — `getRates(parcel, from, to): CarrierRate[]`
- **`CarrierRate`** — normalised DTO (carrier, service, amount, currency, deliveryDays, rateId)
- **`CarrierRateFactory::create()`** — resolves `config('shipping.carrier')` → carrier, or `null` when unset. *Add a carrier = new class + a `case`.*
- **`EasyPostCarrier`** — creates a shipment, maps + sorts the returned rates cheapest-first.
- **`ShippingService::getLiveRates($cart, $to)`** — returns the configured carrier's rates, or `[]` when none configured / unreachable.
- **`config/shipping.php`** — carrier selector, EasyPost key, ship-from origin, weight unit (oz/lb, converted per carrier), timeout. *(This file was missing entirely — `drop_shipping_premium` was silently always defaulting to 2.00; now defined.)*

## Fallback is the safety property

Rating **never blocks checkout**. Unconfigured key, non-2xx, or a network error → `getRates` / `getLiveRates` return `[]` (error is `report()`ed, not thrown), and the caller falls back to the flat DB methods. Non-destructive augmentation — existing flat rates keep working untouched.

## Deferred (separate PR)

Surfacing live rates as **selectable options in the checkout UI + POST flow**. That needs **quote persistence**: the chosen rate's amount must be trusted from the stored quote, never recomputed or accepted from the client. The current checkout recomputes cost server-side from a `ShippingMethod` id — that model can't price an API-quoted rate, and trusting a client-posted price would be a vulnerability. Called out so it isn't mistaken for done.

## Tests (Http::fake, no live API)

**+11:**
- **EasyPost**: maps + sorts rates cheapest-first; sends HTTP Basic auth with the key; converts lb→oz; returns `[]` on missing key (asserts nothing sent), non-2xx, and connection error.
- **Factory**: `null` when unconfigured; resolves `EasyPostCarrier` for `easypost`.
- **ShippingService**: `getLiveRates` returns carrier rates when configured, `[]` when not, and sends the correct total cart weight.

Full suite **1082 passed**, including `--order-by=random`.
