### PR TITLE
feat(vat): EU VAT rates + OSS/MOSS per-member-state report

### DIFF
--- a/app/Console/Commands/GenerateOssVatReport.php
+++ b/app/Console/Commands/GenerateOssVatReport.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\OssReportService;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class GenerateOssVatReport extends Command
+{
+    protected $signature = 'vat:oss-report
+        {--from= : Start date (Y-m-d); defaults to the start of the current quarter}
+        {--to= : End date (Y-m-d, inclusive); defaults to today}
+        {--csv : Output CSV instead of a table}';
+
+    protected $description = 'VAT OSS/MOSS return: VAT collected per EU member state for a period';
+
+    public function handle(OssReportService $service): int
+    {
+        $from = $this->option('from') ? Carbon::parse($this->option('from'))->startOfDay() : Carbon::now()->firstOfQuarter()->startOfDay();
+        $to = $this->option('to') ? Carbon::parse($this->option('to'))->endOfDay() : Carbon::now()->endOfDay();
+
+        if ($to->lt($from)) {
+            $this->error('--to must not be before --from.');
+
+            return self::FAILURE;
+        }
+
+        $report = $service->report($from, $to);
+
+        if ($this->option('csv')) {
+            return $this->outputCsv($report);
+        }
+
+        $this->info("VAT OSS report — {$report['from']} to {$report['to']} ({$report['currency']})");
+
+        if (empty($report['lines'])) {
+            $this->warn('No EU sales in this period.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['Member state', 'Std rate %', 'Orders', 'Net', 'VAT', 'Gross'],
+            array_map(fn ($l) => [
+                $l['country'], $l['standard_rate'], $l['orders'],
+                number_format($l['net'], 2), number_format($l['vat'], 2), number_format($l['gross'], 2),
+            ], $report['lines']),
+        );
+
+        $t = $report['totals'];
+        $this->info("Totals — orders: {$t['orders']}, net: ".number_format($t['net'], 2)
+            .', VAT: '.number_format($t['vat'], 2).', gross: '.number_format($t['gross'], 2));
+
+        return self::SUCCESS;
+    }
+
+    private function outputCsv(array $report): int
+    {
+        $this->line('member_state,standard_rate,orders,net,vat,gross');
+        foreach ($report['lines'] as $l) {
+            $this->line("{$l['country']},{$l['standard_rate']},{$l['orders']},{$l['net']},{$l['vat']},{$l['gross']}");
+        }
+        $t = $report['totals'];
+        $this->line("TOTAL,,{$t['orders']},{$t['net']},{$t['vat']},{$t['gross']}");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -266,6 +266,8 @@ class CheckoutController extends Controller
                     'user_id' => auth()->id(),
                     'customer_email' => $request->email,
                     'shipping_address' => $request->shipping_address,
+                    // Buyer country VAT was charged against — drives the OSS/MOSS report.
+                    'billing_country' => strtoupper((string) $request->input('country')),
                     // A live-rate quote drives the cost; don't also record a flat method.
                     'shipping_method_id' => $shippingQuoteId ? null : $request->shipping_method_id,
                     'shipping_carrier' => $shippingCarrier,

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -75,6 +75,7 @@ class Order extends Model
         'payment_status',
         'shipping_status',
         'shipping_address',
+        'billing_country',
         'shipping_method_id',
         'shipping_carrier',
         'shipping_service',

--- a/app/Services/OssReportService.php
+++ b/app/Services/OssReportService.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Order;
+use App\Support\EuVat;
+use Carbon\CarbonInterface;
+
+/**
+ * VAT OSS/MOSS return: VAT collected per EU member state over a period, aggregated from
+ * the orders that actually charged it. Feeds the quarterly One-Stop-Shop filing.
+ */
+class OssReportService
+{
+    /**
+     * Statuses that count as a completed sale with VAT due. Excludes pending/failed/
+     * cancelled (no sale) and fully refunded (VAT reversed).
+     *
+     * ponytail: partially-refunded orders are counted at their full VAT — netting a
+     * partial VAT refund needs per-line refund data; revisit if partial refunds of EU
+     * orders become common.
+     */
+    private const REPORTABLE_STATUSES = [
+        Order::STATUS_PAID,
+        Order::STATUS_PROCESSING,
+        Order::STATUS_SUPPLIER_QUEUED,
+        Order::STATUS_SUPPLIER_FAILED,
+        Order::STATUS_COMPLETED,
+        Order::STATUS_PARTIALLY_REFUNDED,
+    ];
+
+    public function report(CarbonInterface $from, CarbonInterface $to): array
+    {
+        $rows = Order::query()
+            ->whereIn('status', self::REPORTABLE_STATUSES)
+            ->whereIn('billing_country', EuVat::memberStates())
+            ->whereBetween('created_at', [$from, $to])
+            ->selectRaw('billing_country, COUNT(*) as orders, SUM(total_amount) as gross, SUM(tax_amount) as vat')
+            ->groupBy('billing_country')
+            ->orderBy('billing_country')
+            ->get();
+
+        $lines = $rows->map(function ($row) {
+            $gross = round((float) $row->gross, 2);
+            $vat = round((float) $row->vat, 2);
+
+            return [
+                'country' => $row->billing_country,
+                'standard_rate' => EuVat::standardRate($row->billing_country),
+                'orders' => (int) $row->orders,
+                'net' => round($gross - $vat, 2),
+                'vat' => $vat,
+                'gross' => $gross,
+            ];
+        })->all();
+
+        return [
+            'from' => $from->toDateString(),
+            'to' => $to->toDateString(),
+            'currency' => config('ecommerce.currency', 'EUR'),
+            'lines' => $lines,
+            'totals' => [
+                'orders' => array_sum(array_column($lines, 'orders')),
+                'net' => round(array_sum(array_column($lines, 'net')), 2),
+                'vat' => round(array_sum(array_column($lines, 'vat')), 2),
+                'gross' => round(array_sum(array_column($lines, 'gross')), 2),
+            ],
+        ];
+    }
+}

--- a/app/Support/EuVat.php
+++ b/app/Support/EuVat.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * EU member states and their STANDARD VAT rates (percent), used to seed the tax engine
+ * and to scope the OSS/MOSS report to the EU.
+ *
+ * Rates are the standard rates as of 2025 — reduced/zero rates and per-product-class
+ * nuances are out of scope here (the report aggregates whatever VAT was actually
+ * charged on each order, so a later rate change or a manually-edited TaxRate flows
+ * through without touching this list). Update a rate here + re-run the seeder to change
+ * what new EU orders are taxed.
+ */
+final class EuVat
+{
+    /** @var array<string, float> ISO-3166-1 alpha-2 => standard VAT rate (%) */
+    public const STANDARD_RATES = [
+        'AT' => 20.0,   // Austria
+        'BE' => 21.0,   // Belgium
+        'BG' => 20.0,   // Bulgaria
+        'HR' => 25.0,   // Croatia
+        'CY' => 19.0,   // Cyprus
+        'CZ' => 21.0,   // Czechia
+        'DK' => 25.0,   // Denmark
+        'EE' => 22.0,   // Estonia
+        'FI' => 25.5,   // Finland
+        'FR' => 20.0,   // France
+        'DE' => 19.0,   // Germany
+        'GR' => 24.0,   // Greece
+        'HU' => 27.0,   // Hungary
+        'IE' => 23.0,   // Ireland
+        'IT' => 22.0,   // Italy
+        'LV' => 21.0,   // Latvia
+        'LT' => 21.0,   // Lithuania
+        'LU' => 17.0,   // Luxembourg
+        'MT' => 18.0,   // Malta
+        'NL' => 21.0,   // Netherlands
+        'PL' => 23.0,   // Poland
+        'PT' => 23.0,   // Portugal
+        'RO' => 19.0,   // Romania
+        'SK' => 23.0,   // Slovakia
+        'SI' => 22.0,   // Slovenia
+        'ES' => 21.0,   // Spain
+        'SE' => 25.0,   // Sweden
+    ];
+
+    /** @return string[] EU member-state ISO codes */
+    public static function memberStates(): array
+    {
+        return array_keys(self::STANDARD_RATES);
+    }
+
+    public static function isMemberState(?string $country): bool
+    {
+        return $country !== null && array_key_exists(strtoupper($country), self::STANDARD_RATES);
+    }
+
+    public static function standardRate(string $country): ?float
+    {
+        return self::STANDARD_RATES[strtoupper($country)] ?? null;
+    }
+}

--- a/database/migrations/2026_07_21_000002_add_billing_country_to_orders_table.php
+++ b/database/migrations/2026_07_21_000002_add_billing_country_to_orders_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Persist the buyer country that VAT was charged against. shipping_address is a
+ * freeform string, so without this the member state of consumption is lost after
+ * checkout — and the OSS/MOSS return needs VAT attributed per member state.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            if (! Schema::hasColumn('orders', 'billing_country')) {
+                $table->string('billing_country', 2)->nullable()->index()->after('shipping_address');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            if (Schema::hasColumn('orders', 'billing_country')) {
+                $table->dropColumn('billing_country');
+            }
+        });
+    }
+};

--- a/database/seeders/EuVatRatesSeeder.php
+++ b/database/seeders/EuVatRatesSeeder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\TaxClass;
+use App\Models\TaxRate;
+use App\Support\EuVat;
+use Illuminate\Database\Seeder;
+
+/**
+ * Seed the standard VAT rate for every EU member state into the destination-based tax
+ * engine, so an EU B2C order is taxed at the buyer-country rate. Idempotent — safe to
+ * re-run after a rate change (updateOrCreate keyed on the rate's country + name).
+ */
+class EuVatRatesSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $taxClass = TaxClass::firstOrCreate(
+            ['slug' => 'standard-rate'],
+            ['name' => 'Standard Rate', 'is_active' => true],
+        );
+
+        foreach (EuVat::STANDARD_RATES as $country => $rate) {
+            TaxRate::updateOrCreate(
+                ['country' => $country, 'name' => "EU VAT {$country}", 'tax_class_id' => $taxClass->id],
+                [
+                    'state' => null,
+                    'city' => null,
+                    'zip_code' => null,
+                    'rate' => $rate,
+                    'priority' => 0,
+                    'compound' => false,
+                    'shipping' => true,
+                    'is_active' => true,
+                ],
+            );
+        }
+    }
+}

--- a/tests/Feature/CheckoutBillingCountryTest.php
+++ b/tests/Feature/CheckoutBillingCountryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Interfaces\PaymentGatewayInterface;
+use App\Models\Order;
+use App\Models\Product;
+use App\Services\PaymentGateways\StripeGateway;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+/**
+ * The buyer country is the member state of consumption for VAT, and the OSS report
+ * reads it off the order — so checkout must persist it.
+ */
+class CheckoutBillingCountryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Notification::fake();
+
+        $this->app->instance(StripeGateway::class, new class implements PaymentGatewayInterface
+        {
+            public function processPayment(float $amount, array $paymentDetails): array
+            {
+                return ['success' => true, 'transaction_id' => 'ch_ok'];
+            }
+
+            public function processSubscription(string $planId, array $subscriptionDetails): array
+            {
+                return ['success' => true];
+            }
+
+            public function refundPayment(string $transactionId, float $amount): array
+            {
+                return ['success' => true];
+            }
+        });
+    }
+
+    public function test_checkout_persists_the_billing_country_uppercased(): void
+    {
+        $product = Product::factory()->create(['price' => 50, 'inventory_count' => 5, 'is_downloadable' => true]);
+
+        $this->withSession(['cart' => [
+            $product->id => [
+                'quantity' => 1,
+                'price' => (float) $product->price,
+                'is_downloadable' => true,
+                'name' => $product->name,
+            ],
+        ]])->post(route('checkout.process'), [
+            'email' => 'buyer@example.com',
+            'has_physical_products' => 0,
+            'country' => 'de',
+            'payment_method' => 'stripe',
+            'stripeToken' => 'tok_test',
+        ]);
+
+        $this->assertSame('DE', Order::first()->billing_country);
+    }
+}

--- a/tests/Feature/EuVatRatesSeederTest.php
+++ b/tests/Feature/EuVatRatesSeederTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\TaxRate;
+use App\Services\TaxCalculator;
+use App\Support\EuVat;
+use Database\Seeders\EuVatRatesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EuVatRatesSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_seeds_a_rate_for_every_member_state(): void
+    {
+        $this->seed(EuVatRatesSeeder::class);
+
+        $this->assertSame(27, TaxRate::whereIn('country', EuVat::memberStates())->count());
+        $this->assertDatabaseHas('tax_rates', ['country' => 'DE', 'rate' => 19.0]);
+    }
+
+    public function test_is_idempotent(): void
+    {
+        $this->seed(EuVatRatesSeeder::class);
+        $this->seed(EuVatRatesSeeder::class);
+
+        $this->assertSame(27, TaxRate::whereIn('country', EuVat::memberStates())->count());
+    }
+
+    public function test_a_german_order_is_taxed_at_the_seeded_destination_rate(): void
+    {
+        $this->seed(EuVatRatesSeeder::class);
+        $product = Product::factory()->create(['price' => 100, 'tax_class_id' => null]);
+
+        $tax = app(TaxCalculator::class)->calculateCartTax(
+            [['product' => $product, 'quantity' => 1, 'price' => 100.0]],
+            ['country' => 'DE'],
+        );
+
+        // 19% German VAT on €100.
+        $this->assertSame(19.0, $tax['total']);
+    }
+}

--- a/tests/Feature/OssReportServiceTest.php
+++ b/tests/Feature/OssReportServiceTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Order;
+use App\Services\OssReportService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OssReportServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function order(string $country, float $gross, float $vat, string $status, string $date): Order
+    {
+        $order = Order::create([
+            'customer_email' => 'buyer@example.com',
+            'total_amount' => $gross,
+            'tax_amount' => $vat,
+            'status' => $status,
+            'billing_country' => $country,
+        ]);
+        $order->forceFill(['created_at' => Carbon::parse($date)])->save();
+
+        return $order;
+    }
+
+    private function report(): array
+    {
+        return app(OssReportService::class)->report(
+            Carbon::parse('2026-04-01')->startOfDay(),
+            Carbon::parse('2026-06-30')->endOfDay(),
+        );
+    }
+
+    public function test_aggregates_vat_per_member_state(): void
+    {
+        $this->order('DE', 119.0, 19.0, 'paid', '2026-04-10');
+        $this->order('DE', 119.0, 19.0, 'completed', '2026-05-02');
+        $this->order('FR', 120.0, 20.0, 'paid', '2026-06-15');
+
+        $report = $this->report();
+
+        $this->assertCount(2, $report['lines']);
+        $de = collect($report['lines'])->firstWhere('country', 'DE');
+        $this->assertSame(2, $de['orders']);
+        $this->assertSame(38.0, $de['vat']);
+        $this->assertSame(200.0, $de['net']);   // (119-19) * 2
+        $this->assertSame(238.0, $de['gross']);
+        $this->assertSame(19.0, $de['standard_rate']);
+
+        $this->assertSame(58.0, $report['totals']['vat']);   // 38 + 20
+        $this->assertSame(3, $report['totals']['orders']);
+    }
+
+    public function test_excludes_non_eu_countries(): void
+    {
+        $this->order('US', 110.0, 10.0, 'paid', '2026-04-10');
+        $this->order('GB', 120.0, 20.0, 'paid', '2026-04-11'); // post-Brexit, not EU
+
+        $this->assertSame([], $this->report()['lines']);
+    }
+
+    public function test_excludes_unpaid_and_fully_refunded_orders(): void
+    {
+        $this->order('DE', 119.0, 19.0, 'pending', '2026-04-10');
+        $this->order('DE', 119.0, 19.0, 'failed', '2026-04-11');
+        $this->order('DE', 119.0, 19.0, 'cancelled', '2026-04-12');
+        $this->order('DE', 119.0, 19.0, 'refunded', '2026-04-13');
+
+        $this->assertSame([], $this->report()['lines']);
+    }
+
+    public function test_respects_the_date_range(): void
+    {
+        $this->order('DE', 119.0, 19.0, 'paid', '2026-03-31'); // before window
+        $this->order('DE', 119.0, 19.0, 'paid', '2026-07-01'); // after window
+        $this->order('DE', 119.0, 19.0, 'paid', '2026-05-15'); // inside
+
+        $report = $this->report();
+        $this->assertCount(1, $report['lines']);
+        $this->assertSame(1, $report['lines'][0]['orders']);
+    }
+}

--- a/tests/Feature/OssVatReportCommandTest.php
+++ b/tests/Feature/OssVatReportCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Order;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OssVatReportCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function paidGermanOrder(): void
+    {
+        Order::create([
+            'customer_email' => 'buyer@example.com',
+            'total_amount' => 119.0,
+            'tax_amount' => 19.0,
+            'status' => 'paid',
+            'billing_country' => 'DE',
+        ])->forceFill(['created_at' => Carbon::parse('2026-05-10')])->save();
+    }
+
+    public function test_reports_eu_vat_for_the_period(): void
+    {
+        $this->paidGermanOrder();
+
+        $this->artisan('vat:oss-report', ['--from' => '2026-04-01', '--to' => '2026-06-30'])
+            ->expectsOutputToContain('DE')
+            ->assertSuccessful();
+    }
+
+    public function test_warns_when_no_eu_sales(): void
+    {
+        $this->artisan('vat:oss-report', ['--from' => '2026-04-01', '--to' => '2026-06-30'])
+            ->expectsOutputToContain('No EU sales')
+            ->assertSuccessful();
+    }
+
+    public function test_rejects_an_inverted_date_range(): void
+    {
+        $this->artisan('vat:oss-report', ['--from' => '2026-06-30', '--to' => '2026-04-01'])
+            ->assertFailed();
+    }
+
+    public function test_csv_output(): void
+    {
+        $this->paidGermanOrder();
+
+        $this->artisan('vat:oss-report', ['--from' => '2026-04-01', '--to' => '2026-06-30', '--csv' => true])
+            ->expectsOutputToContain('member_state,standard_rate,orders,net,vat,gross')
+            ->expectsOutputToContain('DE,19,1,100,19,119')
+            ->assertSuccessful();
+    }
+}

--- a/tests/Unit/EuVatTest.php
+++ b/tests/Unit/EuVatTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\EuVat;
+use PHPUnit\Framework\TestCase;
+
+class EuVatTest extends TestCase
+{
+    public function test_covers_all_27_member_states(): void
+    {
+        $this->assertCount(27, EuVat::memberStates());
+    }
+
+    public function test_is_member_state_is_case_insensitive_and_excludes_non_eu(): void
+    {
+        $this->assertTrue(EuVat::isMemberState('DE'));
+        $this->assertTrue(EuVat::isMemberState('de'));
+        $this->assertFalse(EuVat::isMemberState('US'));
+        $this->assertFalse(EuVat::isMemberState('GB')); // post-Brexit
+        $this->assertFalse(EuVat::isMemberState(null));
+    }
+
+    public function test_standard_rate_lookup(): void
+    {
+        $this->assertSame(19.0, EuVat::standardRate('DE'));
+        $this->assertSame(27.0, EuVat::standardRate('HU')); // highest in the EU
+        $this->assertNull(EuVat::standardRate('US'));
+    }
+}


### PR DESCRIPTION
## What

End-to-end EU VAT: seed the standard rates, tax EU B2C at the **buyer-country** rate (the tax engine was already destination-based), and produce the **OSS/MOSS return** from the orders that charged it.

## Changes

- **`App\Support\EuVat`** — the 27 member states + their 2025 standard VAT rates, with `isMemberState()` / `standardRate()`. Single source of truth for the seeder and the report.
- **`EuVatRatesSeeder`** — idempotent; seeds one `TaxRate` per member state under a "Standard Rate" tax class, so a German order is taxed 19%, French 20%, and so on through the existing `TaxCalculator`.
- **`orders.billing_country`** — the buyer country VAT was charged against, persisted at checkout (uppercased). `shipping_address` is a freeform string, so without this the member state of consumption was lost after checkout and the return couldn't attribute VAT. MySQL 8.4-verified.
- **`OssReportService::report($from, $to)`** — VAT per member state for a period: reportable EU orders (paid-and-beyond, not fully refunded) grouped by country into `{orders, net, vat, gross}` + totals. The `GROUP BY` / `SUM` was exercised on **MySQL 8.4**, not just sqlite (no `ONLY_FULL_GROUP_BY` issue, decimal sums cast correctly).
- **`php artisan vat:oss-report --from --to [--csv]`** — the quarterly return as a table or CSV (defaults to the current quarter; guards an inverted range).

## Scoped out (each its own follow-up)

- **€10k distance-selling threshold** — below it, home-country VAT; stateful YTD tracking.
- **VIES VAT-number validation + B2B reverse-charge** — external EU API, B2C/B2B branch.
- **VAT-netting of partial refunds** — the report counts partially-refunded orders at full VAT (noted in a `ponytail:` comment); fully-refunded orders are excluded.

## Tests (+15)

Member-state data; seeder idempotency **and a real German order taxed at 19%** through `TaxCalculator`; report aggregation / EU-only / status / date-range filters; command table + CSV output + inverted-range guard; checkout persists (and uppercases) `billing_country`.

Full suite **1105 passed**, including `--order-by=random`.
