### PR TITLE
refactor(vat): loop instead of array_map in OSS report command (quiet SAST)

### DIFF
--- a/app/Console/Commands/GenerateOssVatReport.php
+++ b/app/Console/Commands/GenerateOssVatReport.php
@@ -40,13 +40,15 @@ class GenerateOssVatReport extends Command
             return self::SUCCESS;
         }
 
-        $this->table(
-            ['Member state', 'Std rate %', 'Orders', 'Net', 'VAT', 'Gross'],
-            array_map(fn ($l) => [
+        $rows = [];
+        foreach ($report['lines'] as $l) {
+            $rows[] = [
                 $l['country'], $l['standard_rate'], $l['orders'],
                 number_format($l['net'], 2), number_format($l['vat'], 2), number_format($l['gross'], 2),
-            ], $report['lines']),
-        );
+            ];
+        }
+
+        $this->table(['Member state', 'Std rate %', 'Orders', 'Net', 'VAT', 'Gross'], $rows);
 
         $t = $report['totals'];
         $this->info("Totals — orders: {$t['orders']}, net: ".number_format($t['net'], 2)


### PR DESCRIPTION
## What

Rewrites one `array_map(closure, ...)` in the OSS report command as a `foreach`.

## Why

A static scanner flags `array_map()` calls that take a callback as HIGH severity ("insecure module / callback"). That rule targets the real risk of a **user-controlled callback** (e.g. `array_map($_GET["fn"], ...)` → arbitrary function execution). Here the callback was a hardcoded closure `fn ($l) => [...]` over the trusted in-memory report array — no user input, no injection surface, so it was a **false positive**.

Still, a `foreach` is equally clear and removes the recurring alert. No behaviour change; command tests unchanged and green.
