### PR TITLE
feat(api): GraphQL storefront endpoint (queries + cart mutations)

### DIFF
--- a/app/GraphQL/StorefrontSchema.php
+++ b/app/GraphQL/StorefrontSchema.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace App\GraphQL;
+
+use App\Models\CartItem;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\ProductCollection;
+use GraphQL\Error\Error;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+
+/**
+ * Code-first storefront GraphQL schema (webonyx). Read queries are public for the
+ * catalog and user-scoped for me/orders; cart mutations require an authenticated user
+ * and mirror the REST cart controller (same stock guard, same user_id scoping = IDOR
+ * guard). The authenticated user (or null) is passed in as the resolver $context.
+ */
+class StorefrontSchema
+{
+    public function build(): Schema
+    {
+        $product = $this->productType();
+        $collection = $this->collectionType($product);
+        $cartItem = $this->cartItemType($product);
+        $order = $this->orderType();
+        $user = $this->userType();
+        $productPage = $this->productPageType($product);
+
+        $query = new ObjectType([
+            'name' => 'Query',
+            'fields' => [
+                'products' => [
+                    'type' => Type::nonNull($productPage),
+                    'args' => [
+                        'search' => Type::string(),
+                        'page' => Type::int(),
+                        'perPage' => Type::int(),
+                    ],
+                    'resolve' => fn ($root, array $args) => $this->resolveProducts($args),
+                ],
+                'product' => [
+                    'type' => $product,
+                    'args' => ['id' => Type::int(), 'slug' => Type::string()],
+                    'resolve' => fn ($root, array $args) => $this->resolveProduct($args),
+                ],
+                'collections' => [
+                    'type' => Type::nonNull(Type::listOf(Type::nonNull($collection))),
+                    'resolve' => fn () => ProductCollection::query()->orderBy('name')->get(),
+                ],
+                'me' => [
+                    'type' => $user,
+                    'resolve' => fn ($root, array $args, array $context) => $context['user'] ?? null,
+                ],
+                'orders' => [
+                    'type' => Type::nonNull(Type::listOf(Type::nonNull($order))),
+                    'resolve' => fn ($root, array $args, array $context) => ($u = $context['user'] ?? null)
+                        ? Order::where('user_id', $u->id)->latest('id')->get()
+                        : [],
+                ],
+            ],
+        ]);
+
+        $mutation = new ObjectType([
+            'name' => 'Mutation',
+            'fields' => [
+                'addToCart' => [
+                    'type' => Type::nonNull($cartItem),
+                    'args' => [
+                        'productId' => Type::nonNull(Type::int()),
+                        'quantity' => Type::nonNull(Type::int()),
+                    ],
+                    'resolve' => fn ($root, array $args, array $context) => $this->addToCart($args, $context),
+                ],
+                'updateCartItem' => [
+                    'type' => Type::nonNull($cartItem),
+                    'args' => [
+                        'productId' => Type::nonNull(Type::int()),
+                        'quantity' => Type::nonNull(Type::int()),
+                    ],
+                    'resolve' => fn ($root, array $args, array $context) => $this->updateCartItem($args, $context),
+                ],
+                'removeCartItem' => [
+                    'type' => Type::nonNull(Type::boolean()),
+                    'args' => ['productId' => Type::nonNull(Type::int())],
+                    'resolve' => fn ($root, array $args, array $context) => $this->removeCartItem($args, $context),
+                ],
+            ],
+        ]);
+
+        return new Schema(['query' => $query, 'mutation' => $mutation]);
+    }
+
+    private function productType(): ObjectType
+    {
+        return new ObjectType([
+            'name' => 'Product',
+            'fields' => [
+                'id' => Type::nonNull(Type::int()),
+                'name' => Type::nonNull(Type::string()),
+                'slug' => Type::string(),
+                'description' => Type::string(),
+                'shortDescription' => ['type' => Type::string(), 'resolve' => fn (Product $p) => $p->short_description],
+                'price' => ['type' => Type::nonNull(Type::float()), 'resolve' => fn (Product $p) => (float) $p->price],
+                'inventoryCount' => ['type' => Type::int(), 'resolve' => fn (Product $p) => $p->inventory_count],
+                'isDownloadable' => ['type' => Type::boolean(), 'resolve' => fn (Product $p) => (bool) $p->is_downloadable],
+                'isFeatured' => ['type' => Type::boolean(), 'resolve' => fn (Product $p) => (bool) $p->is_featured],
+                'featuredImage' => ['type' => Type::string(), 'resolve' => fn (Product $p) => $p->featured_image],
+            ],
+        ]);
+    }
+
+    private function productPageType(ObjectType $product): ObjectType
+    {
+        return new ObjectType([
+            'name' => 'ProductPage',
+            'fields' => [
+                'data' => Type::nonNull(Type::listOf(Type::nonNull($product))),
+                'total' => Type::nonNull(Type::int()),
+                'currentPage' => Type::nonNull(Type::int()),
+                'perPage' => Type::nonNull(Type::int()),
+                'lastPage' => Type::nonNull(Type::int()),
+            ],
+        ]);
+    }
+
+    private function collectionType(ObjectType $product): ObjectType
+    {
+        return new ObjectType([
+            'name' => 'Collection',
+            'fields' => [
+                'id' => Type::nonNull(Type::int()),
+                'name' => Type::nonNull(Type::string()),
+                'slug' => Type::string(),
+                'products' => [
+                    'type' => Type::nonNull(Type::listOf(Type::nonNull($product))),
+                    'resolve' => fn (ProductCollection $c) => $c->products()->get(),
+                ],
+            ],
+        ]);
+    }
+
+    private function cartItemType(ObjectType $product): ObjectType
+    {
+        return new ObjectType([
+            'name' => 'CartItem',
+            'fields' => [
+                'id' => Type::nonNull(Type::int()),
+                'productId' => ['type' => Type::nonNull(Type::int()), 'resolve' => fn (CartItem $i) => $i->product_id],
+                'quantity' => Type::nonNull(Type::int()),
+                'price' => ['type' => Type::nonNull(Type::float()), 'resolve' => fn (CartItem $i) => (float) $i->price],
+                'lineTotal' => ['type' => Type::nonNull(Type::float()), 'resolve' => fn (CartItem $i) => round((float) $i->price * $i->quantity, 2)],
+                'product' => ['type' => $product, 'resolve' => fn (CartItem $i) => $i->products],
+            ],
+        ]);
+    }
+
+    private function orderType(): ObjectType
+    {
+        return new ObjectType([
+            'name' => 'Order',
+            'fields' => [
+                'id' => Type::nonNull(Type::int()),
+                'status' => Type::nonNull(Type::string()),
+                'totalAmount' => ['type' => Type::nonNull(Type::float()), 'resolve' => fn (Order $o) => (float) $o->total_amount],
+                'taxAmount' => ['type' => Type::float(), 'resolve' => fn (Order $o) => (float) $o->tax_amount],
+                'shippingCost' => ['type' => Type::float(), 'resolve' => fn (Order $o) => (float) $o->shipping_cost],
+                'billingCountry' => ['type' => Type::string(), 'resolve' => fn (Order $o) => $o->billing_country],
+                'createdAt' => ['type' => Type::string(), 'resolve' => fn (Order $o) => $o->created_at?->toIso8601String()],
+            ],
+        ]);
+    }
+
+    private function userType(): ObjectType
+    {
+        return new ObjectType([
+            'name' => 'User',
+            'fields' => [
+                'id' => Type::nonNull(Type::int()),
+                'name' => Type::nonNull(Type::string()),
+                'email' => Type::nonNull(Type::string()),
+            ],
+        ]);
+    }
+
+    private function resolveProducts(array $args): array
+    {
+        $perPage = min(max((int) ($args['perPage'] ?? 15), 1), 100);
+        $page = max((int) ($args['page'] ?? 1), 1);
+        $search = $args['search'] ?? null;
+
+        $paginator = Product::query()
+            ->when($search, fn ($q) => $q->where('name', 'like', '%'.$search.'%'))
+            ->orderBy('id')
+            ->paginate($perPage, ['*'], 'page', $page);
+
+        return [
+            'data' => $paginator->items(),
+            'total' => $paginator->total(),
+            'currentPage' => $paginator->currentPage(),
+            'perPage' => $paginator->perPage(),
+            'lastPage' => $paginator->lastPage(),
+        ];
+    }
+
+    private function resolveProduct(array $args): ?Product
+    {
+        if (! empty($args['id'])) {
+            return Product::find($args['id']);
+        }
+        if (! empty($args['slug'])) {
+            return Product::where('slug', $args['slug'])->first();
+        }
+
+        throw new Error('Provide either id or slug.');
+    }
+
+    private function addToCart(array $args, array $context): CartItem
+    {
+        $user = $this->requireUser($context);
+        $this->assertPositive($args['quantity']);
+
+        $product = $this->findProduct($args['productId']);
+        $item = CartItem::firstOrNew(['user_id' => $user->id, 'product_id' => $product->id]);
+        $quantity = ($item->quantity ?? 0) + $args['quantity'];
+
+        $this->assertStock($product, $quantity);
+
+        $item->fill([
+            'session_id' => $item->session_id ?? 'api',
+            'quantity' => $quantity,
+            'price' => $product->price,
+        ])->save();
+
+        return $item;
+    }
+
+    private function updateCartItem(array $args, array $context): CartItem
+    {
+        $user = $this->requireUser($context);
+        $this->assertPositive($args['quantity']);
+
+        $product = $this->findProduct($args['productId']);
+        $this->assertStock($product, $args['quantity']);
+
+        $item = CartItem::where('user_id', $user->id)->where('product_id', $product->id)->first();
+        if ($item === null) {
+            throw new Error('That product is not in your cart.');
+        }
+
+        $item->update(['quantity' => $args['quantity']]);
+
+        return $item;
+    }
+
+    private function removeCartItem(array $args, array $context): bool
+    {
+        $user = $this->requireUser($context);
+        CartItem::where('user_id', $user->id)->where('product_id', $args['productId'])->delete();
+
+        return true;
+    }
+
+    private function requireUser(array $context)
+    {
+        return $context['user'] ?? throw new Error('Unauthenticated.');
+    }
+
+    private function findProduct(int $productId): Product
+    {
+        return Product::find($productId) ?? throw new Error('Product not found.');
+    }
+
+    private function assertPositive(int $quantity): void
+    {
+        if ($quantity < 1) {
+            throw new Error('Quantity must be at least 1.');
+        }
+    }
+
+    private function assertStock(Product $product, int $quantity): void
+    {
+        if ($product->inventory_count < $quantity) {
+            throw new Error('Requested quantity exceeds available stock.');
+        }
+    }
+}

--- a/app/Http/Controllers/GraphQLController.php
+++ b/app/Http/Controllers/GraphQLController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\GraphQL\StorefrontSchema;
+use GraphQL\Error\DebugFlag;
+use GraphQL\GraphQL;
+use GraphQL\Validator\Rules\QueryComplexity;
+use GraphQL\Validator\Rules\QueryDepth;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Throwable;
+
+/**
+ * Single GraphQL endpoint for the storefront. Optional auth: the catalog is public, but
+ * me/orders and every mutation need a Sanctum token — the authenticated user (or null)
+ * is resolved here and handed to resolvers as $context['user']. Depth/complexity limits
+ * bound the cost of a single query (DoS guard) since this route is public.
+ */
+class GraphQLController extends Controller
+{
+    private const MAX_DEPTH = 10;
+
+    private const MAX_COMPLEXITY = 200;
+
+    public function __invoke(Request $request, StorefrontSchema $schema): JsonResponse
+    {
+        $query = $request->input('query');
+        if (! is_string($query) || trim($query) === '') {
+            return response()->json(['errors' => [['message' => 'No GraphQL query provided.']]], 400);
+        }
+
+        $variables = $request->input('variables');
+        $context = ['user' => auth('sanctum')->user()];
+
+        $rules = array_merge(GraphQL::getStandardValidationRules(), [
+            new QueryComplexity(self::MAX_COMPLEXITY),
+            new QueryDepth(self::MAX_DEPTH),
+        ]);
+
+        try {
+            $result = GraphQL::executeQuery(
+                schema: $schema->build(),
+                source: $query,
+                contextValue: $context,
+                variableValues: is_array($variables) ? $variables : null,
+                operationName: $request->input('operationName'),
+                validationRules: $rules,
+            );
+
+            $debug = config('app.debug') ? DebugFlag::INCLUDE_DEBUG_MESSAGE : DebugFlag::NONE;
+
+            return response()->json($result->toArray($debug));
+        } catch (Throwable $e) {
+            report($e);
+
+            return response()->json(['errors' => [['message' => 'Internal server error.']]], 500);
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "spatie/laravel-menu": "^4.2",
         "spatie/laravel-permission": "^6.0",
         "spatie/laravel-query-builder": "^7.0",
-        "srmklive/paypal": "^3.1"
+        "srmklive/paypal": "^3.1",
+        "webonyx/graphql-php": "^15.34"
     },
     "require-dev": {
         "driftingly/rector-laravel": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0907251f3dc706e87906806598ee01b",
+    "content-hash": "feb85dd249af7114ac7bb6eb5a5b11e7",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -11958,6 +11958,86 @@
                 }
             ],
             "time": "2026-04-26T05:33:54+00:00"
+        },
+        {
+            "name": "webonyx/graphql-php",
+            "version": "v15.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webonyx/graphql-php.git",
+                "reference": "c72fd0f82e7b992aaf35516ebf860a4729be206f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/c72fd0f82e7b992aaf35516ebf860a4729be206f",
+                "reference": "c72fd0f82e7b992aaf35516ebf860a4729be206f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.4 || ^8"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.6 || ^3",
+                "amphp/http-server": "^2.1 || ^3",
+                "dms/phpunit-arraysubset-asserts": "dev-master",
+                "ergebnis/composer-normalize": "^2.28",
+                "friendsofphp/php-cs-fixer": "3.95.11",
+                "mll-lab/php-cs-fixer-config": "5.13.0",
+                "nyholm/psr7": "^1.5",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "2.2.5",
+                "phpstan/phpstan-phpunit": "2.0.18",
+                "phpstan/phpstan-strict-rules": "2.0.11",
+                "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
+                "psr/http-message": "^1 || ^2",
+                "react/http": "^1.6",
+                "react/promise": "^2.0 || ^3.0",
+                "rector/rector": "^2.0",
+                "symfony/polyfill-php81": "^1.23",
+                "symfony/var-exporter": "^5 || ^6 || ^7 || ^8",
+                "thecodingmachine/safe": "^1.3 || ^2 || ^3",
+                "ticketswap/phpstan-error-formatter": "1.3.0"
+            },
+            "suggest": {
+                "amphp/amp": "To leverage async resolving on AMPHP platform (v3 with AmpFutureAdapter, v2 with AmpPromiseAdapter)",
+                "amphp/http-server": "To leverage async resolving with webserver on AMPHP platform",
+                "psr/http-message": "To use standard GraphQL server",
+                "react/promise": "To leverage async resolving on React PHP platform"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GraphQL\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP port of GraphQL reference implementation",
+            "homepage": "https://github.com/webonyx/graphql-php",
+            "keywords": [
+                "api",
+                "graphql"
+            ],
+            "support": {
+                "issues": "https://github.com/webonyx/graphql-php/issues",
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spawnia",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/webonyx-graphql-php",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2026-07-05T18:03:26+00:00"
         }
     ],
     "packages-dev": [

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Api\OrderStatusController;
 use App\Http\Controllers\Api\ProductController;
 use App\Http\Controllers\Api\ReturnRequestController;
 use App\Http\Controllers\Api\WebhookEndpointController;
+use App\Http\Controllers\GraphQLController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -27,6 +28,10 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+// Storefront GraphQL endpoint. Public route with optional Sanctum auth resolved in the
+// controller — the catalog is open, me/orders + mutations require a token.
+Route::post('/graphql', GraphQLController::class);
 
 // Dropshipping API routes
 Route::middleware('auth:sanctum')->prefix('dropshipping')->group(function () {

--- a/tests/Feature/GraphQLStorefrontTest.php
+++ b/tests/Feature/GraphQLStorefrontTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\CartItem;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\ProductCollection;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class GraphQLStorefrontTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @return array the decoded GraphQL response */
+    private function gql(string $query, array $variables = []): array
+    {
+        return $this->postJson('/api/graphql', ['query' => $query, 'variables' => $variables])->json();
+    }
+
+    private function product(array $overrides = []): Product
+    {
+        return Product::factory()->create(array_merge([
+            'price' => 10.0, 'inventory_count' => 5, 'is_downloadable' => false,
+        ], $overrides));
+    }
+
+    // --- Queries ---------------------------------------------------------
+
+    public function test_products_query_returns_a_paginated_catalogue(): void
+    {
+        $this->product(['name' => 'Alpha']);
+        $this->product(['name' => 'Beta']);
+        $this->product(['name' => 'Gamma']);
+
+        $data = $this->gql('{ products(perPage: 2) { data { id name price } total currentPage lastPage perPage } }');
+
+        $this->assertSame(3, $data['data']['products']['total']);
+        $this->assertSame(2, $data['data']['products']['lastPage']);
+        $this->assertCount(2, $data['data']['products']['data']);
+        $this->assertEqualsWithDelta(10.0, $data['data']['products']['data'][0]['price'], 0.001);
+    }
+
+    public function test_products_query_search_filters_by_name(): void
+    {
+        $this->product(['name' => 'Blue Widget']);
+        $this->product(['name' => 'Red Gadget']);
+
+        $data = $this->gql('{ products(search: "Widget") { data { name } total } }');
+
+        $this->assertSame(1, $data['data']['products']['total']);
+        $this->assertSame('Blue Widget', $data['data']['products']['data'][0]['name']);
+    }
+
+    public function test_product_by_slug_and_by_id(): void
+    {
+        $product = $this->product(['name' => 'Findable', 'slug' => 'findable']);
+
+        $bySlug = $this->gql('{ product(slug: "findable") { id name } }');
+        $this->assertSame('Findable', $bySlug['data']['product']['name']);
+
+        $byId = $this->gql('query($id: Int!) { product(id: $id) { slug } }', ['id' => $product->id]);
+        $this->assertSame('findable', $byId['data']['product']['slug']);
+    }
+
+    public function test_product_query_is_null_when_missing(): void
+    {
+        $data = $this->gql('{ product(slug: "nope") { id } }');
+
+        $this->assertNull($data['data']['product']);
+    }
+
+    public function test_collections_query_exposes_their_products(): void
+    {
+        $collection = ProductCollection::create(['name' => 'Summer', 'slug' => 'summer']);
+        $collection->products()->attach($this->product(['name' => 'Sunhat'])->id);
+
+        $data = $this->gql('{ collections { name products { name } } }');
+
+        $this->assertSame('Summer', $data['data']['collections'][0]['name']);
+        $this->assertSame('Sunhat', $data['data']['collections'][0]['products'][0]['name']);
+    }
+
+    public function test_me_is_null_for_guests_and_set_for_authenticated_users(): void
+    {
+        $this->assertNull($this->gql('{ me { id } }')['data']['me']);
+
+        Sanctum::actingAs($user = User::factory()->create());
+        $data = $this->gql('{ me { id email } }');
+        $this->assertSame($user->email, $data['data']['me']['email']);
+    }
+
+    public function test_orders_are_scoped_to_the_authenticated_user(): void
+    {
+        $mine = User::factory()->create();
+        $other = User::factory()->create();
+        Order::create(['user_id' => $mine->id, 'customer_email' => 'a@b.com', 'total_amount' => 50, 'status' => 'paid']);
+        Order::create(['user_id' => $other->id, 'customer_email' => 'c@d.com', 'total_amount' => 99, 'status' => 'paid']);
+
+        Sanctum::actingAs($mine);
+        $data = $this->gql('{ orders { id totalAmount } }');
+
+        $this->assertCount(1, $data['data']['orders']);
+        $this->assertEqualsWithDelta(50.0, $data['data']['orders'][0]['totalAmount'], 0.001);
+    }
+
+    public function test_orders_are_empty_for_guests(): void
+    {
+        Order::create(['user_id' => User::factory()->create()->id, 'customer_email' => 'a@b.com', 'total_amount' => 50, 'status' => 'paid']);
+
+        $this->assertSame([], $this->gql('{ orders { id } }')['data']['orders']);
+    }
+
+    // --- Mutations -------------------------------------------------------
+
+    public function test_add_to_cart_requires_authentication(): void
+    {
+        $product = $this->product();
+
+        $data = $this->gql('mutation($p: Int!) { addToCart(productId: $p, quantity: 1) { id } }', ['p' => $product->id]);
+
+        // webonyx omits the data key when a non-null root field errors; only errors remain.
+        $this->assertSame('Unauthenticated.', $data['errors'][0]['message']);
+        $this->assertDatabaseCount('cart_items', 0);
+    }
+
+    public function test_add_to_cart_persists_an_item(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create());
+        $product = $this->product(['inventory_count' => 10]);
+
+        $data = $this->gql('mutation($p: Int!) { addToCart(productId: $p, quantity: 2) { quantity lineTotal product { name } } }', ['p' => $product->id]);
+
+        $this->assertSame(2, $data['data']['addToCart']['quantity']);
+        $this->assertEqualsWithDelta(20.0, $data['data']['addToCart']['lineTotal'], 0.001);
+        $this->assertDatabaseHas('cart_items', ['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 2]);
+    }
+
+    public function test_add_to_cart_rejects_quantity_over_stock(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+        $product = $this->product(['inventory_count' => 1]);
+
+        $data = $this->gql('mutation($p: Int!) { addToCart(productId: $p, quantity: 5) { id } }', ['p' => $product->id]);
+
+        $this->assertStringContainsString('exceeds available stock', $data['errors'][0]['message']);
+        $this->assertDatabaseCount('cart_items', 0);
+    }
+
+    public function test_update_cart_item_changes_quantity(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create());
+        $product = $this->product(['inventory_count' => 10]);
+        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 10, 'session_id' => 'api']);
+
+        $this->gql('mutation($p: Int!) { updateCartItem(productId: $p, quantity: 4) { quantity } }', ['p' => $product->id]);
+
+        $this->assertDatabaseHas('cart_items', ['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 4]);
+    }
+
+    public function test_cart_mutations_are_user_scoped(): void
+    {
+        $owner = User::factory()->create();
+        $product = $this->product(['inventory_count' => 10]);
+        CartItem::create(['user_id' => $owner->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 10, 'session_id' => 'api']);
+
+        // A different user cannot touch the owner's line item.
+        Sanctum::actingAs(User::factory()->create());
+        $data = $this->gql('mutation($p: Int!) { updateCartItem(productId: $p, quantity: 9) { id } }', ['p' => $product->id]);
+
+        $this->assertStringContainsString('not in your cart', $data['errors'][0]['message']);
+        $this->assertDatabaseHas('cart_items', ['user_id' => $owner->id, 'product_id' => $product->id, 'quantity' => 1]);
+    }
+
+    public function test_remove_cart_item(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create());
+        $product = $this->product();
+        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 10, 'session_id' => 'api']);
+
+        $data = $this->gql('mutation($p: Int!) { removeCartItem(productId: $p) }', ['p' => $product->id]);
+
+        $this->assertTrue($data['data']['removeCartItem']);
+        $this->assertDatabaseCount('cart_items', 0);
+    }
+
+    public function test_empty_query_is_rejected(): void
+    {
+        $this->postJson('/api/graphql', ['query' => ''])->assertStatus(400);
+    }
+}


### PR DESCRIPTION
## What

A single **`POST /api/graphql`** storefront endpoint for headless clients, alongside the existing REST API. Code-first schema on **`webonyx/graphql-php`** (one dependency, no heavy conventions).

### Queries
| field | access |
|---|---|
| `products(search, page, perPage)` → paginated `ProductPage` | public |
| `product(id \| slug)` | public |
| `collections { products }` | public |
| `me` | authenticated (null for guests) |
| `orders` | authenticated — the caller's own orders only |

### Mutations (Sanctum token required; mirror the REST cart controller)
- `addToCart(productId, quantity)`
- `updateCartItem(productId, quantity)`
- `removeCartItem(productId)`

## Security

- **Optional auth.** The endpoint is public (open catalogue), but `me`/`orders` and every mutation resolve `auth('sanctum')->user()` and reject when absent (`"Unauthenticated."`). No token → no user data.
- **IDOR guard.** Every cart/order resolver is scoped by `user_id`, same as the REST controllers — one user can't read or mutate another's cart or orders. Covered by a cross-user test.
- **Stock guard.** Cart mutations reuse the inventory check (reject quantity over stock).
- **DoS guard.** Query **depth (10)** + **complexity (200)** limits bound a single query's cost, since the route is public. Introspection stays on; debug error messages only when `app.debug`.

## Notes

- Read + cart-write only. Checkout stays on the existing REST/session flow (with its live-rate quote persistence and stock reservation) — not reimplemented here.
- Float scalars: GraphQL `Float` values that happen to be whole numbers decode from JSON as ints, so tests compare with a delta (documented in-test).

## Tests (+15)

Catalogue pagination + search; product by id/slug + null; collections with products; `me` guest/authed; `orders` user-scoping + guest-empty; all three mutations including auth-required, over-stock rejection, and **cross-user (IDOR) rejection**.

Full suite **1120 passed**. The lone `--order-by=random` failure is the pre-existing `SocialstreamRegistrationTest` Socialite facade-mock flake — unrelated.
