### PR TITLE
feat(gdpr): erase user-authored content (reviews, ratings, registries)

### DIFF
--- a/app/Services/GdprErasureService.php
+++ b/app/Services/GdprErasureService.php
@@ -3,6 +3,9 @@
 namespace App\Services;
 
 use App\Models\Order;
+use App\Models\ProductRating;
+use App\Models\ProductReview;
+use App\Models\Review;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -13,9 +16,10 @@ use Illuminate\Support\Str;
  * their orders remain intact for accounting/legal retention while every identifying
  * field is scrubbed. All writes happen in one transaction.
  *
- * ponytail: scrubs the core identity, order PII, saved payment methods and behavioural
- * tracking. User-generated content (reviews/ratings) and gift registries are left for a
- * follow-up — deleting them changes public product aggregates and needs its own call.
+ * Scrubs the core identity, order PII, saved payment methods, behavioural tracking, and
+ * user-authored content (reviews, ratings, gift registries). Content is DELETED rather
+ * than anonymised: user_id/customer_id are NOT NULL and reviews carry free text, so
+ * there is no clean row to keep — product rating/review aggregates simply recompute.
  */
 class GdprErasureService
 {
@@ -35,6 +39,16 @@ class GdprErasureService
             $user->browsingHistory()->delete();
             $user->productInteractions()->delete();
             $user->wishlist()->delete();
+
+            // User-authored content (Art. 17). Deleting registries cascades (DB FK) to
+            // their items and purchases.
+            Review::where('user_id', $user->id)->delete();
+            $user->ratings()->delete();
+            $user->giftRegistries()->delete();
+            if ($customer !== null) {
+                ProductReview::where('customer_id', $customer->id)->delete();
+                ProductRating::where('customer_id', $customer->id)->delete();
+            }
 
             if ($customer !== null) {
                 $customer->update([

--- a/tests/Feature/GdprContentErasureTest.php
+++ b/tests/Feature/GdprContentErasureTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\GiftRegistry;
+use App\Models\GiftRegistryItem;
+use App\Models\GiftRegistryPurchase;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\ProductRating;
+use App\Models\ProductReview;
+use App\Models\Rating;
+use App\Models\Review;
+use App\Models\User;
+use App\Services\GdprErasureService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * GDPR content-erasure (Art. 17 follow-up to the identity/PII erasure). The user's
+ * reviews, ratings and gift registries are user-authored content — user_id/customer_id
+ * are NOT NULL and reviews carry free text, so they are DELETED, not anonymised.
+ * Product rating/review aggregates recompute naturally. Another user's content must be
+ * untouched.
+ */
+class GdprContentErasureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Product $product;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->product = Product::factory()->create();
+    }
+
+    /** Seed one of every content type for a user; returns [user, customerId]. */
+    private function seedContentFor(string $slugPrefix): array
+    {
+        $user = User::factory()->create();
+        $customer = $user->getOrCreateCustomer();
+
+        Review::create(['user_id' => $user->id, 'product_id' => $this->product->id, 'rating' => 5, 'review' => 'My private thoughts']);
+        Rating::create(['user_id' => $user->id, 'product_id' => $this->product->id, 'rating' => 4]);
+
+        (new ProductReview)->forceFill(['product_id' => $this->product->id, 'customer_id' => $customer->id, 'comments' => 'Customer comment'])->save();
+        (new ProductRating)->forceFill(['product_id' => $this->product->id, 'customer_id' => $customer->id, 'rating' => 3, 'overall_rating' => 3])->save();
+
+        $registry = GiftRegistry::create([
+            'user_id' => $user->id, 'name' => 'Wedding', 'slug' => $slugPrefix.'-wedding',
+            'shipping_name' => 'Jane Doe', 'shipping_address' => '1 Test St',
+        ]);
+        $item = GiftRegistryItem::create(['registry_id' => $registry->id, 'product_id' => $this->product->id, 'quantity_requested' => 1]);
+        $order = Order::create(['customer_email' => 'buyer@example.com', 'total_amount' => 10, 'status' => 'paid']);
+        GiftRegistryPurchase::create([
+            'registry_item_id' => $item->id, 'order_id' => $order->id, 'quantity' => 1,
+            'purchaser_name' => 'Gift Buyer', 'purchaser_email' => 'buyer@example.com',
+        ]);
+
+        return [$user, $customer->id];
+    }
+
+    public function test_erasure_deletes_the_users_reviews_ratings_and_registries(): void
+    {
+        [$user, $customerId] = $this->seedContentFor('victim');
+        [$survivor, $survivorCustomerId] = $this->seedContentFor('survivor');
+
+        app(GdprErasureService::class)->erase($user);
+
+        // The erased user's content is gone.
+        $this->assertSame(0, Review::where('user_id', $user->id)->count());
+        $this->assertSame(0, Rating::where('user_id', $user->id)->count());
+        $this->assertSame(0, ProductReview::where('customer_id', $customerId)->count());
+        $this->assertSame(0, ProductRating::where('customer_id', $customerId)->count());
+        $this->assertSame(0, GiftRegistry::where('user_id', $user->id)->count());
+        // Registry children cascade away with the registry.
+        $this->assertSame(0, GiftRegistryItem::count() - GiftRegistryItem::whereHas('registry', fn ($q) => $q->where('user_id', $survivor->id))->count());
+        $this->assertSame(0, GiftRegistryPurchase::count() - 1); // only the survivor's purchase remains
+
+        // The other user's content is untouched.
+        $this->assertSame(1, Review::where('user_id', $survivor->id)->count());
+        $this->assertSame(1, Rating::where('user_id', $survivor->id)->count());
+        $this->assertSame(1, ProductReview::where('customer_id', $survivorCustomerId)->count());
+        $this->assertSame(1, ProductRating::where('customer_id', $survivorCustomerId)->count());
+        $this->assertSame(1, GiftRegistry::where('user_id', $survivor->id)->count());
+    }
+}


### PR DESCRIPTION
## What

Completes the GDPR erasure deferred in #771. `GdprErasureService::erase()` now also removes the user's **reviews, ratings, and gift registries** — the last personal data it left behind.

## Delete, not anonymise (schema-forced)

- `reviews.user_id` and `ratings.user_id` are **NOT NULL** with a cascade FK — they can't be nulled to de-identify the row.
- Reviews (`reviews.review`, `product_reviews.comments`) carry **free text** that can contain PII, so keeping an "anonymised" row isn't safe.

So the personal data is **deleted**. Product rating/review aggregates recompute naturally — exactly the trade-off flagged when this was deferred ("deleting them changes public product aggregates and needs its own call").

## Covers both link types

| linked by | models |
|---|---|
| `user_id` | `Review`, `Rating`, `GiftRegistry` |
| `customer_id` | `ProductReview` (free-text comments), `ProductRating` |

Deleting the user's `GiftRegistry` rows **cascades via DB FK** to their items and to the third-party purchase records (`purchaser_name`/`purchaser_email`). All of this runs inside the existing single erasure transaction.

## Tests (+1)

Seeds every content type for **two** users, erases one, and asserts its reviews / ratings / registries — and the cascaded registry items + purchases — are gone, while the **other user's content is untouched**. #771's identity/PII erasure test stays green.

Full suite **1121 passed**. The lone `--order-by=random` failure is the pre-existing `SocialstreamRegistrationTest` Socialite flake — unrelated.

## Note

Erasure removes this content; the GDPR **export** (#770) does not yet include reviews/ratings/registries in the Art. 15 data dump — a small symmetry follow-up if wanted.
