### PR TITLE
feat(gdpr): export reviews, ratings and registries (symmetry with erasure)

### DIFF
--- a/app/Services/GdprExportService.php
+++ b/app/Services/GdprExportService.php
@@ -2,7 +2,12 @@
 
 namespace App\Services;
 
+use App\Models\GiftRegistry;
 use App\Models\Order;
+use App\Models\ProductRating;
+use App\Models\ProductReview;
+use App\Models\Rating;
+use App\Models\Review;
 use App\Models\User;
 
 /**
@@ -12,15 +17,21 @@ use App\Models\User;
  * raw payment-method `details` must never leave the system, and a future column added
  * to one of these tables must not silently start appearing in exports.
  *
- * ponytail: covers the core identity + transactional data. Behavioural/tracking data
- * (browsing history, product interactions, customer segments) is personal data too —
- * add it here when a user actually asks for it; it is high-volume, derived, and not
- * needed for the first slice.
+ * Kept in symmetry with GdprErasureService: the content it deletes (reviews, ratings,
+ * gift registries) is exported here, so a user can see everything erasure will remove.
+ * Registry access codes (a private-registry secret) and registry purchases (a third
+ * party's PII) are deliberately excluded.
+ *
+ * ponytail: covers identity, transactional data, and user-authored content. Behavioural
+ * /tracking data (browsing history, product interactions, customer segments) is personal
+ * data too — add it here when a user actually asks for it; it is high-volume and derived.
  */
 class GdprExportService
 {
     public function export(User $user): array
     {
+        $customer = $user->customer;
+
         return [
             'exported_at' => now()->toIso8601String(),
             'user' => [
@@ -35,7 +46,85 @@ class GdprExportService
                 'name' => $pm->name,
                 'is_default' => (bool) $pm->is_default,
             ])->all(),
+            'reviews' => $this->reviews($user),
+            'ratings' => $this->ratings($user),
+            'product_reviews' => $customer ? $this->productReviews($customer->id) : [],
+            'product_ratings' => $customer ? $this->productRatings($customer->id) : [],
+            'gift_registries' => $this->giftRegistries($user),
         ];
+    }
+
+    private function reviews(User $user): array
+    {
+        return Review::where('user_id', $user->id)->latest('id')->get()->map(fn (Review $r) => [
+            'product_id' => $r->product_id,
+            'rating' => $r->rating,
+            'review' => $r->review,
+            'created_at' => optional($r->created_at)->toIso8601String(),
+        ])->all();
+    }
+
+    private function ratings(User $user): array
+    {
+        return Rating::where('user_id', $user->id)->latest('id')->get()->map(fn (Rating $r) => [
+            'product_id' => $r->product_id,
+            'rating' => $r->rating,
+            'overall_rating' => $r->overall_rating,
+            'quality_rating' => $r->quality_rating,
+            'value_rating' => $r->value_rating,
+            'price_rating' => $r->price_rating,
+            'created_at' => optional($r->created_at)->toIso8601String(),
+        ])->all();
+    }
+
+    private function productReviews(int $customerId): array
+    {
+        return ProductReview::where('customer_id', $customerId)->latest('id')->get()->map(fn (ProductReview $r) => [
+            'product_id' => $r->product_id,
+            'comments' => $r->comments,
+            'is_verified_purchase' => (bool) $r->is_verified_purchase,
+            'created_at' => optional($r->created_at)->toIso8601String(),
+        ])->all();
+    }
+
+    private function productRatings(int $customerId): array
+    {
+        return ProductRating::where('customer_id', $customerId)->latest('id')->get()->map(fn (ProductRating $r) => [
+            'product_id' => $r->product_id,
+            'rating' => $r->rating,
+            'overall_rating' => $r->overall_rating,
+            'quality_rating' => $r->quality_rating,
+            'value_rating' => $r->value_rating,
+            'price_rating' => $r->price_rating,
+            'created_at' => optional($r->created_at)->toIso8601String(),
+        ])->all();
+    }
+
+    private function giftRegistries(User $user): array
+    {
+        // access_code (private-registry secret) and purchases (third-party purchaser
+        // PII) are intentionally excluded.
+        return GiftRegistry::where('user_id', $user->id)->with('items')->latest('id')->get()->map(fn (GiftRegistry $g) => [
+            'name' => $g->name,
+            'type' => $g->type,
+            'event_date' => optional($g->event_date)->toDateString(),
+            'message' => $g->message,
+            'location' => $g->location,
+            'privacy' => $g->privacy,
+            'shipping_name' => $g->shipping_name,
+            'shipping_address' => $g->shipping_address,
+            'shipping_city' => $g->shipping_city,
+            'shipping_state' => $g->shipping_state,
+            'shipping_postal_code' => $g->shipping_postal_code,
+            'shipping_country' => $g->shipping_country,
+            'items' => $g->items->map(fn ($i) => [
+                'product_id' => $i->product_id,
+                'quantity_requested' => $i->quantity_requested,
+                'quantity_purchased' => $i->quantity_purchased,
+                'priority' => $i->priority,
+                'notes' => $i->notes,
+            ])->all(),
+        ])->all();
     }
 
     private function customer(User $user): ?array

--- a/tests/Feature/GdprDataExportTest.php
+++ b/tests/Feature/GdprDataExportTest.php
@@ -2,8 +2,16 @@
 
 namespace Tests\Feature;
 
+use App\Models\GiftRegistry;
+use App\Models\GiftRegistryItem;
+use App\Models\GiftRegistryPurchase;
 use App\Models\Order;
 use App\Models\PaymentMethod;
+use App\Models\Product;
+use App\Models\ProductRating;
+use App\Models\ProductReview;
+use App\Models\Rating;
+use App\Models\Review;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -72,5 +80,44 @@ class GdprDataExportTest extends TestCase
         // Payment-method metadata is fine, but the raw stored details must not be.
         $this->assertStringNotContainsString('tok_live_RAWCARDTOKEN', $body, 'Raw payment details leaked in export');
         $response->assertJsonPath('payment_methods.0.name', 'Visa ending 4242');
+    }
+
+    public function test_export_includes_reviews_ratings_and_registries_in_symmetry_with_erasure(): void
+    {
+        $user = User::factory()->create();
+        $customer = $user->getOrCreateCustomer();
+        $product = Product::factory()->create();
+
+        Review::create(['user_id' => $user->id, 'product_id' => $product->id, 'rating' => 5, 'review' => 'MY-REVIEW-TEXT']);
+        Rating::create(['user_id' => $user->id, 'product_id' => $product->id, 'rating' => 4]);
+        (new ProductReview)->forceFill(['product_id' => $product->id, 'customer_id' => $customer->id, 'comments' => 'MY-COMMENT'])->save();
+        (new ProductRating)->forceFill(['product_id' => $product->id, 'customer_id' => $customer->id, 'rating' => 3, 'overall_rating' => 3])->save();
+
+        $registry = GiftRegistry::create([
+            'user_id' => $user->id, 'name' => 'MyRegistry', 'slug' => 'my-registry',
+            'access_code' => 'SECRETCODE123', 'shipping_name' => 'Jane',
+        ]);
+        $item = GiftRegistryItem::create(['registry_id' => $registry->id, 'product_id' => $product->id, 'quantity_requested' => 1, 'notes' => 'ITEM-NOTE']);
+        $order = Order::create(['customer_email' => 'x@y.com', 'total_amount' => 10, 'status' => 'paid']);
+        GiftRegistryPurchase::create([
+            'registry_item_id' => $item->id, 'order_id' => $order->id, 'quantity' => 1,
+            'purchaser_name' => 'THIRDPARTY-BUYER', 'purchaser_email' => 'buyer@third.com',
+        ]);
+
+        $response = $this->actingAs($user)->getJson(route('account.data-export'));
+
+        $response->assertOk();
+        $response->assertJsonPath('reviews.0.review', 'MY-REVIEW-TEXT');
+        $response->assertJsonPath('ratings.0.rating', 4);
+        $response->assertJsonPath('product_reviews.0.comments', 'MY-COMMENT');
+        $response->assertJsonPath('product_ratings.0.overall_rating', 3);
+        $response->assertJsonPath('gift_registries.0.name', 'MyRegistry');
+        $response->assertJsonPath('gift_registries.0.items.0.notes', 'ITEM-NOTE');
+
+        $body = $response->getContent();
+        // A private registry's access code is a secret — never exported.
+        $this->assertStringNotContainsString('SECRETCODE123', $body, 'Registry access code leaked in export');
+        // Registry purchases carry a third party's PII — not the exporting user's data.
+        $this->assertStringNotContainsString('THIRDPARTY-BUYER', $body, "Third-party purchaser PII leaked in the user's export");
     }
 }


### PR DESCRIPTION
## What

Closes the Art. 15 symmetry gap noted in #779: the GDPR **export** now includes the same user-authored content the **erasure** service deletes, so a user can see everything erasure will remove.

## Added (field-whitelisted, like the rest of the export)

| key | source |
|---|---|
| `reviews` | `Review` (by `user_id`) |
| `ratings` | `Rating` (by `user_id`) |
| `product_reviews` | `ProductReview` (by `customer_id`) — free-text comments |
| `product_ratings` | `ProductRating` (by `customer_id`) |
| `gift_registries` | `GiftRegistry` + their `items` |

## Deliberately excluded

- **Registry `access_code`** — a private-registry secret, treated like a credential (same principle as password / 2FA / raw payment `details`).
- **Registry purchases** — they carry a *third party's* PII (the gift buyer's name/email), which is not the exporting user's own data.

## Tests (+1)

Seeds every content type plus a registry access code and a purchase, then asserts the content appears in the export while the access code and the third-party purchaser name never do.

Full suite **1122 passed**. The lone `--order-by=random` failure is the pre-existing `SocialstreamRegistrationTest` Socialite flake — unrelated.

## Symmetry, not identity

Erasure (#779) *deletes* registry purchases (they cascade); export *omits* them — correct, because export returns the user's own data (Art. 15) while erasure removes all linked personal data including third-party-in-registry.
