### PR TITLE
feat(api): GraphQL shippingRates mutation for headless clients

### DIFF
--- a/app/GraphQL/StorefrontSchema.php
+++ b/app/GraphQL/StorefrontSchema.php
@@ -8,6 +8,7 @@ use App\Models\Order;
 use App\Models\Product;
 use App\Models\ProductCollection;
 use App\Services\HeadlessCheckoutService;
+use App\Services\ShippingService;
 use GraphQL\Error\Error;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
@@ -93,6 +94,13 @@ class StorefrontSchema
                     'type' => Type::nonNull($order),
                     'args' => ['input' => Type::nonNull($this->checkoutInputType())],
                     'resolve' => fn ($root, array $args, array $context) => $this->checkout($args['input'], $context),
+                ],
+                // A mutation (not a query): it persists a ShippingQuote per rate so the
+                // returned ids can be passed to checkout, where the STORED amount is billed.
+                'shippingRates' => [
+                    'type' => Type::nonNull(Type::listOf(Type::nonNull($this->shippingRateType()))),
+                    'args' => ['input' => Type::nonNull($this->shippingRatesInputType())],
+                    'resolve' => fn ($root, array $args, array $context) => $this->shippingRates($args['input'], $context),
                 ],
             ],
         ]);
@@ -299,6 +307,62 @@ class StorefrontSchema
             // surfaced; anything else bubbles and webonyx masks it as an internal error.
             throw new Error($e->getMessage());
         }
+    }
+
+    private function shippingRateType(): ObjectType
+    {
+        return new ObjectType([
+            'name' => 'ShippingRate',
+            'fields' => [
+                'id' => Type::nonNull(Type::int()),   // the persisted quote id — pass to checkout
+                'carrier' => Type::nonNull(Type::string()),
+                'service' => Type::nonNull(Type::string()),
+                'amount' => ['type' => Type::nonNull(Type::float()), 'resolve' => fn ($q) => (float) $q->amount],
+                'currency' => Type::nonNull(Type::string()),
+                'deliveryDays' => ['type' => Type::int(), 'resolve' => fn ($q) => $q->delivery_days],
+            ],
+        ]);
+    }
+
+    private function shippingRatesInputType(): InputObjectType
+    {
+        return new InputObjectType([
+            'name' => 'ShippingRatesInput',
+            'fields' => [
+                'country' => Type::nonNull(Type::string()),
+                'state' => Type::string(),
+                'city' => Type::string(),
+                'postalCode' => Type::string(),
+            ],
+        ]);
+    }
+
+    private function shippingRates(array $input, array $context): array
+    {
+        $user = $this->requireUser($context);
+
+        $cart = CartItem::where('user_id', $user->id)->get();
+        if ($cart->isEmpty()) {
+            return [];
+        }
+
+        $cartByProduct = [];
+        foreach ($cart as $item) {
+            $cartByProduct[$item->product_id] = ['quantity' => $item->quantity];
+        }
+
+        $to = [
+            'country' => $input['country'],
+            'state' => $input['state'] ?? null,
+            'city' => $input['city'] ?? null,
+            'zip' => $input['postalCode'] ?? null,
+        ];
+
+        // Persist quotes scoped to this user (headless clients have no session), so the
+        // returned ids resolve in checkout by user_id.
+        return app(ShippingService::class)
+            ->quoteLiveRates($cartByProduct, $to, 'api', $user->id)
+            ->all();
     }
 
     private function requireUser(array $context)

--- a/tests/Feature/GraphQLShippingRatesTest.php
+++ b/tests/Feature/GraphQLShippingRatesTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Interfaces\PaymentGatewayInterface;
+use App\Models\CartItem;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\User;
+use App\Services\PaymentGateways\StripeGateway;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * GraphQL shippingRates mutation: fetches live carrier rates for the user's persistent
+ * cart and persists each as a user-scoped ShippingQuote, so the returned id can be
+ * passed to checkout (where the STORED amount is billed — #775 quote-trust end to end).
+ */
+class GraphQLShippingRatesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['shipping.carrier' => 'easypost', 'shipping.easypost.api_key' => 'ek_test']);
+    }
+
+    private function fakeEasyPost(string $amount = '12.50'): void
+    {
+        Http::fake(['api.easypost.com/*' => Http::response([
+            'rates' => [['id' => 'rate_1', 'carrier' => 'USPS', 'service' => 'Priority', 'rate' => $amount, 'currency' => 'USD', 'delivery_days' => 3]],
+        ])]);
+    }
+
+    private function gql(string $query, array $variables = []): array
+    {
+        return $this->postJson('/api/graphql', ['query' => $query, 'variables' => $variables])->json();
+    }
+
+    private function cartItem(User $user): Product
+    {
+        $product = Product::factory()->create(['price' => 100, 'inventory_count' => 5, 'is_downloadable' => false]);
+        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 100, 'session_id' => 'api']);
+
+        return $product;
+    }
+
+    private const RATES = 'mutation($i: ShippingRatesInput!) { shippingRates(input: $i) { id carrier service amount deliveryDays } }';
+
+    public function test_shipping_rates_requires_authentication(): void
+    {
+        $this->fakeEasyPost();
+
+        $data = $this->gql(self::RATES, ['i' => ['country' => 'US']]);
+
+        $this->assertSame('Unauthenticated.', $data['errors'][0]['message']);
+    }
+
+    public function test_returns_and_persists_user_scoped_quotes(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create());
+        $this->cartItem($user);
+        $this->fakeEasyPost('12.50');
+
+        $data = $this->gql(self::RATES, ['i' => ['country' => 'US', 'postalCode' => '10001']]);
+
+        $this->assertSame('USPS', $data['data']['shippingRates'][0]['carrier']);
+        $this->assertEqualsWithDelta(12.5, $data['data']['shippingRates'][0]['amount'], 0.001);
+        $this->assertDatabaseHas('shipping_quotes', ['user_id' => $user->id, 'carrier' => 'USPS', 'amount' => 12.50]);
+    }
+
+    public function test_empty_cart_returns_no_rates(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+        $this->fakeEasyPost();
+
+        $data = $this->gql(self::RATES, ['i' => ['country' => 'US']]);
+
+        $this->assertSame([], $data['data']['shippingRates']);
+    }
+
+    public function test_returned_rate_id_bills_its_stored_amount_at_checkout(): void
+    {
+        $this->app->instance(StripeGateway::class, new class implements PaymentGatewayInterface
+        {
+            public function processPayment(float $amount, array $paymentDetails): array
+            {
+                return ['success' => true, 'transaction_id' => 'ch_ok'];
+            }
+
+            public function processSubscription(string $planId, array $subscriptionDetails): array
+            {
+                return ['success' => true];
+            }
+
+            public function refundPayment(string $transactionId, float $amount): array
+            {
+                return ['success' => true];
+            }
+        });
+
+        Sanctum::actingAs($user = User::factory()->create());
+        $this->cartItem($user);
+        $this->fakeEasyPost('12.50');
+
+        // 1) Fetch rates → get a persisted quote id.
+        $rates = $this->gql(self::RATES, ['i' => ['country' => 'US']]);
+        $quoteId = $rates['data']['shippingRates'][0]['id'];
+
+        // 2) Check out with that id → the stored 12.50 is billed.
+        $checkout = $this->gql(
+            'mutation($i: CheckoutInput!) { checkout(input: $i) { shippingCost shippingCarrier } }',
+            ['i' => ['country' => 'US', 'paymentMethod' => 'stripe', 'stripeToken' => 'tok', 'shippingQuoteId' => $quoteId]],
+        );
+
+        $this->assertEqualsWithDelta(12.5, $checkout['data']['checkout']['shippingCost'], 0.001);
+        $this->assertSame('USPS', $checkout['data']['checkout']['shippingCarrier']);
+        $this->assertEqualsWithDelta(12.5, (float) Order::first()->shipping_cost, 0.001);
+    }
+}


### PR DESCRIPTION
## What

Gives headless GraphQL clients a way to obtain a shipping quote for the checkout mutation (#781). Adds a **`shippingRates`** mutation that fetches live carrier rates for the authenticated user's **persistent cart** and persists each as a **user-scoped `ShippingQuote`**, returning the ids the client selects.

## Why a mutation, not a query

It has a side effect: it **persists a `ShippingQuote` per rate**. Those ids are what `checkout(shippingQuoteId:)` resolves, and checkout bills the **stored** amount (never a client price) — the #775 quote-trust property, now reachable end-to-end from a token client.

- Auth required; quotes scoped to the **user** (headless clients have no session), so `resolveQuote` matches them by `user_id` at checkout.
- Empty cart → no rates. Reuses `ShippingService::quoteLiveRates` (same EasyPost path as the web endpoint).

## Tests (+4)

Auth required · returns + persists user-scoped quotes · empty cart · **end-to-end**: fetch rates → take the id → `checkout` bills the stored 12.50.

Full suite **1133 passed**, including `--order-by=random` (fully green).
