### PR TITLE
refactor(checkout): share money mechanics between web and headless

### DIFF
--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -2,15 +2,15 @@
 
 namespace App\Http\Controllers;
 
-use App\Factories\PaymentGatewayFactory;
+use App\Exceptions\CheckoutException;
 use App\Jobs\DispatchDropshippingOrder;
 use App\Models\Coupon;
-use App\Models\InventoryLog;
 use App\Models\Order;
 use App\Models\Product;
 use App\Models\ShippingMethod;
 use App\Notifications\OrderConfirmationNotification;
 use App\Notifications\SupplierFailureNotification;
+use App\Services\CheckoutService;
 use App\Services\CouponService;
 use App\Services\ShippingService;
 use App\Services\TaxCalculator;
@@ -24,20 +24,20 @@ use Illuminate\Support\Str;
 
 class CheckoutController extends Controller
 {
-    /** Sentinel thrown inside the reservation transaction to roll it back on insufficient stock. */
-    private const OUT_OF_STOCK = 'OUT_OF_STOCK';
-
     protected $shippingService;
 
     protected $taxCalculator;
 
     protected $couponService;
 
-    public function __construct(ShippingService $shippingService, TaxCalculator $taxCalculator, CouponService $couponService)
+    protected $checkoutService;
+
+    public function __construct(ShippingService $shippingService, TaxCalculator $taxCalculator, CouponService $couponService, CheckoutService $checkoutService)
     {
         $this->shippingService = $shippingService;
         $this->taxCalculator = $taxCalculator;
         $this->couponService = $couponService;
+        $this->checkoutService = $checkoutService;
     }
 
     public function initiateCheckout(Request $request)
@@ -259,9 +259,14 @@ class CheckoutController extends Controller
         // If any line can't be reserved (e.g. a concurrent buyer took the last
         // unit), the whole transaction rolls back and no payment is taken — this
         // is what prevents charging a customer for stock we can't fulfil.
+        $lineItems = [];
+        foreach ($cart as $productId => $item) {
+            $lineItems[] = ['product_id' => $productId, 'quantity' => $item['quantity'], 'price' => $item['price']];
+        }
+
         $order = null;
         try {
-            DB::transaction(function () use (&$order, $cart, $request, $totalAmount, $shippingCost, $taxAmount, $taxLines, $discountAmount, $couponCode, $shippingCarrier, $shippingServiceName, $shippingQuoteId) {
+            DB::transaction(function () use (&$order, $lineItems, $request, $totalAmount, $shippingCost, $taxAmount, $taxLines, $discountAmount, $couponCode, $shippingCarrier, $shippingServiceName, $shippingQuoteId) {
                 $order = Order::create([
                     'user_id' => auth()->id(),
                     'customer_email' => $request->email,
@@ -287,42 +292,11 @@ class CheckoutController extends Controller
                     'gift_message' => $request->gift_message,
                 ]);
 
-                foreach ($cart as $productId => $item) {
-                    $order->items()->create([
-                        'product_id' => $productId,
-                        'quantity' => $item['quantity'],
-                        'price' => $item['price'],
-                    ]);
-
-                    $before = Product::where('id', $productId)->value('inventory_count');
-
-                    // Atomic, guarded decrement: only succeeds while enough stock remains.
-                    $affected = Product::where('id', $productId)
-                        ->where('inventory_count', '>=', $item['quantity'])
-                        ->decrement('inventory_count', $item['quantity']);
-
-                    if ($affected === 0) {
-                        // Not enough stock (or product gone) — abort the whole order.
-                        throw new \RuntimeException(self::OUT_OF_STOCK);
-                    }
-
-                    InventoryLog::create([
-                        'product_id' => $productId,
-                        'quantity_change' => -$item['quantity'],
-                        'old_quantity' => $before,
-                        'new_quantity' => $before - $item['quantity'],
-                        'reason' => 'order',
-                        'reference_id' => $order->id,
-                        'reference_type' => Order::class,
-                    ]);
-                }
+                // Reserve stock atomically before charging (shared with headless checkout).
+                $this->checkoutService->reserveStock($order, $lineItems);
             });
-        } catch (\RuntimeException $e) {
-            if ($e->getMessage() === self::OUT_OF_STOCK) {
-                return redirect()->back()
-                    ->with('error', 'Some items in your cart are no longer available in the requested quantity.');
-            }
-            throw $e;
+        } catch (CheckoutException $e) {
+            return redirect()->back()->with('error', $e->getMessage());
         }
 
         /** @var Order $order */
@@ -331,11 +305,11 @@ class CheckoutController extends Controller
         // we can't fulfil. If the charge fails, release the reservation.
         if ($totalAmount > 0) {
             if ($request->payment_method === 'stripe' && $request->has('stripeToken')) {
-                $paymentResult = $this->processStripePayment($order, $request->stripeToken);
+                $paymentResult = $this->checkoutService->capturePayment($order, 'stripe', ['token' => $request->stripeToken]);
             } elseif ($request->payment_method === 'paypal' && $request->has('paypal_payment_id')) {
-                $paymentResult = $this->processPayPalPayment($order, $request->paypal_payment_id);
+                $paymentResult = $this->checkoutService->capturePayment($order, 'paypal', ['payment_id' => $request->paypal_payment_id]);
             } else {
-                $this->releaseInventory($order, $cart);
+                $this->checkoutService->releaseStock($order, $lineItems);
                 $order->transitionTo(Order::STATUS_FAILED, notes: 'Invalid payment information');
 
                 return redirect()->back()
@@ -343,7 +317,7 @@ class CheckoutController extends Controller
             }
 
             if (! $paymentResult['success']) {
-                $this->releaseInventory($order, $cart);
+                $this->checkoutService->releaseStock($order, $lineItems);
                 $order->transitionTo(Order::STATUS_FAILED, notes: 'Payment failed: '.($paymentResult['error'] ?? 'unknown'));
 
                 return redirect()->back()
@@ -449,42 +423,6 @@ class CheckoutController extends Controller
         return redirect()->route('checkout.initiate');
     }
 
-    protected function processPayment($order, $paymentMethod)
-    {
-        $paymentGateway = PaymentGatewayFactory::create($paymentMethod);
-
-        return $paymentGateway->processPayment($order->total_amount, [
-            'order_id' => $order->id,
-            'customer_email' => $order->customer_email,
-        ]);
-    }
-
-    /**
-     * Return reserved stock to inventory when a payment fails after the order was
-     * created. Keeps an audit row so the reserve/release pair is traceable.
-     */
-    private function releaseInventory($order, array $cart): void
-    {
-        foreach ($cart as $productId => $item) {
-            $before = Product::where('id', $productId)->value('inventory_count');
-            if ($before === null) {
-                continue;
-            }
-
-            Product::where('id', $productId)->increment('inventory_count', $item['quantity']);
-
-            InventoryLog::create([
-                'product_id' => $productId,
-                'quantity_change' => $item['quantity'],
-                'old_quantity' => $before,
-                'new_quantity' => $before + $item['quantity'],
-                'reason' => 'payment_failed_release',
-                'reference_id' => $order->id,
-                'reference_type' => Order::class,
-            ]);
-        }
-    }
-
     private function hasPhysicalProducts($cart)
     {
         foreach ($cart as $item) {
@@ -494,27 +432,5 @@ class CheckoutController extends Controller
         }
 
         return false;
-    }
-
-    protected function processStripePayment($order, $stripeToken)
-    {
-        $paymentGateway = PaymentGatewayFactory::create('stripe');
-
-        return $paymentGateway->processPayment($order->total_amount, [
-            'order_id' => $order->id,
-            'customer_email' => $order->customer_email,
-            'token' => $stripeToken,
-        ]);
-    }
-
-    protected function processPayPalPayment($order, $paypalPaymentId)
-    {
-        $paymentGateway = PaymentGatewayFactory::create('paypal');
-
-        return $paymentGateway->processPayment($order->total_amount, [
-            'order_id' => $order->id,
-            'customer_email' => $order->customer_email,
-            'payment_id' => $paypalPaymentId,
-        ]);
     }
 }

--- a/app/Services/CheckoutService.php
+++ b/app/Services/CheckoutService.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\CheckoutException;
+use App\Factories\PaymentGatewayFactory;
+use App\Models\InventoryLog;
+use App\Models\Order;
+use App\Models\Product;
+
+/**
+ * The shared money mechanics behind both checkout entry points — the web checkout
+ * (session cart) and the headless GraphQL checkout (CartItem cart). Keeping stock
+ * reservation, release and payment capture in one place stops the two paths from
+ * drifting on the parts that are dangerous to get wrong.
+ *
+ * Each caller keeps its own orchestration (cart source, tax/coupon/shipping, error
+ * presentation) and calls these primitives; they do not encode any web- or
+ * GraphQL-specific behaviour.
+ *
+ * @phpstan-type LineItem array{product_id: int, quantity: int, price: float|string}
+ */
+class CheckoutService
+{
+    /**
+     * Create the order's line items and RESERVE their stock with a guarded atomic
+     * decrement. Call inside a transaction: on the first shortfall this throws, the
+     * transaction rolls back, and no payment is taken. Reserving before charging is
+     * what prevents charging a customer for stock we can't fulfil.
+     *
+     * @param  array<int, LineItem>  $lineItems
+     *
+     * @throws CheckoutException when any line can't be fully reserved
+     */
+    public function reserveStock(Order $order, array $lineItems): void
+    {
+        foreach ($lineItems as $line) {
+            $order->items()->create([
+                'product_id' => $line['product_id'],
+                'quantity' => $line['quantity'],
+                'price' => $line['price'],
+            ]);
+
+            $before = Product::where('id', $line['product_id'])->value('inventory_count');
+
+            $affected = Product::where('id', $line['product_id'])
+                ->where('inventory_count', '>=', $line['quantity'])
+                ->decrement('inventory_count', $line['quantity']);
+
+            if ($affected === 0) {
+                throw new CheckoutException('Some items in your cart are no longer available in the requested quantity.');
+            }
+
+            InventoryLog::create([
+                'product_id' => $line['product_id'],
+                'quantity_change' => -$line['quantity'],
+                'old_quantity' => $before,
+                'new_quantity' => $before - $line['quantity'],
+                'reason' => 'order',
+                'reference_id' => $order->id,
+                'reference_type' => Order::class,
+            ]);
+        }
+    }
+
+    /**
+     * Return reserved stock when a charge fails after the order was created. Keeps an
+     * audit row so the reserve/release pair is traceable.
+     *
+     * @param  array<int, LineItem>  $lineItems
+     */
+    public function releaseStock(Order $order, array $lineItems): void
+    {
+        foreach ($lineItems as $line) {
+            $before = Product::where('id', $line['product_id'])->value('inventory_count');
+            if ($before === null) {
+                continue;
+            }
+
+            Product::where('id', $line['product_id'])->increment('inventory_count', $line['quantity']);
+
+            InventoryLog::create([
+                'product_id' => $line['product_id'],
+                'quantity_change' => $line['quantity'],
+                'old_quantity' => $before,
+                'new_quantity' => $before + $line['quantity'],
+                'reason' => 'payment_failed_release',
+                'reference_id' => $order->id,
+                'reference_type' => Order::class,
+            ]);
+        }
+    }
+
+    /**
+     * Charge the order total through the given gateway. $paymentExtra carries the
+     * gateway-specific token/id (e.g. ['token' => ...] for Stripe, ['payment_id' => ...]
+     * for PayPal); order_id and customer_email are always included.
+     */
+    public function capturePayment(Order $order, string $gateway, array $paymentExtra): array
+    {
+        return PaymentGatewayFactory::create($gateway)->processPayment((float) $order->total_amount, [
+            'order_id' => $order->id,
+            'customer_email' => $order->customer_email,
+        ] + $paymentExtra);
+    }
+}

--- a/app/Services/HeadlessCheckoutService.php
+++ b/app/Services/HeadlessCheckoutService.php
@@ -3,30 +3,28 @@
 namespace App\Services;
 
 use App\Exceptions\CheckoutException;
-use App\Factories\PaymentGatewayFactory;
 use App\Models\CartItem;
-use App\Models\InventoryLog;
 use App\Models\Order;
-use App\Models\Product;
 use App\Models\User;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 /**
  * Places an order from a user's persistent (CartItem) cart for headless/API clients —
- * the GraphQL checkout mutation's engine. Reuses the same money-safe mechanics as the
- * web checkout: stock is reserved with a guarded atomic decrement inside a transaction
- * BEFORE charging, and shipping is billed from the STORED shipping quote (never a
- * client-supplied price — the #775 quote-trust property).
+ * the GraphQL checkout mutation's engine. The money mechanics (reserve stock before
+ * charging, release on failure, capture payment) are the shared CheckoutService; this
+ * class handles the headless-specific orchestration: loading the persistent cart,
+ * billing the STORED shipping quote (never a client price — #775), and clearing the
+ * cart on success.
  *
- * v1 is intentionally lean: no coupon, dropship, or downloadable-link handling. Those
- * live in the web checkout and can be lifted into a shared service later.
+ * v1 is intentionally lean: no coupon, dropship, or downloadable-link handling.
  */
 class HeadlessCheckoutService
 {
     public function __construct(
         private ShippingService $shippingService,
         private TaxCalculator $taxCalculator,
+        private CheckoutService $checkoutService,
     ) {}
 
     public function place(User $user, array $input): Order
@@ -44,9 +42,12 @@ class HeadlessCheckoutService
         [$taxAmount, $taxLines] = $this->calculateTax($cart, $input, $shippingCost);
 
         $total = max(0, round($subtotal + $shippingCost + $taxAmount, 2));
+        $lineItems = $cart->map(fn (CartItem $i) => [
+            'product_id' => $i->product_id, 'quantity' => $i->quantity, 'price' => $i->price,
+        ])->all();
 
         $order = null;
-        DB::transaction(function () use (&$order, $cart, $user, $paymentMethod, $country, $total, $shippingCost, $carrier, $service, $quoteId, $taxAmount, $taxLines) {
+        DB::transaction(function () use (&$order, $lineItems, $user, $paymentMethod, $country, $total, $shippingCost, $carrier, $service, $quoteId, $taxAmount, $taxLines) {
             $order = Order::create([
                 'user_id' => $user->id,
                 'customer_email' => $user->email,
@@ -62,38 +63,11 @@ class HeadlessCheckoutService
                 'status' => Order::STATUS_PENDING,
             ]);
 
-            foreach ($cart as $item) {
-                $order->items()->create([
-                    'product_id' => $item->product_id,
-                    'quantity' => $item->quantity,
-                    'price' => $item->price,
-                ]);
-
-                $before = Product::where('id', $item->product_id)->value('inventory_count');
-
-                // Atomic guarded decrement: succeeds only while enough stock remains.
-                $affected = Product::where('id', $item->product_id)
-                    ->where('inventory_count', '>=', $item->quantity)
-                    ->decrement('inventory_count', $item->quantity);
-
-                if ($affected === 0) {
-                    throw new CheckoutException('Some items in your cart are no longer available in the requested quantity.');
-                }
-
-                InventoryLog::create([
-                    'product_id' => $item->product_id,
-                    'quantity_change' => -$item->quantity,
-                    'old_quantity' => $before,
-                    'new_quantity' => $before - $item->quantity,
-                    'reason' => 'order',
-                    'reference_id' => $order->id,
-                    'reference_type' => Order::class,
-                ]);
-            }
+            $this->checkoutService->reserveStock($order, $lineItems);
         });
 
         /** @var Order $order */
-        $this->charge($order, $cart, $paymentMethod, $input['stripeToken'] ?? null, $total);
+        $this->charge($order, $lineItems, $paymentMethod, $input['stripeToken'] ?? null, $total);
 
         $order->transitionTo(Order::STATUS_PAID, notes: 'Payment captured (headless checkout)');
 
@@ -142,20 +116,16 @@ class HeadlessCheckoutService
         return [$result['total'], $result['lines']];
     }
 
-    private function charge(Order $order, Collection $cart, string $paymentMethod, ?string $token, float $total): void
+    private function charge(Order $order, array $lineItems, string $paymentMethod, ?string $token, float $total): void
     {
         if ($total <= 0) {
             return;
         }
 
-        $result = PaymentGatewayFactory::create($paymentMethod)->processPayment($total, [
-            'order_id' => $order->id,
-            'customer_email' => $order->customer_email,
-            'token' => $token,
-        ]);
+        $result = $this->checkoutService->capturePayment($order, $paymentMethod, ['token' => $token]);
 
         if (! ($result['success'] ?? false)) {
-            $this->releaseInventory($order, $cart);
+            $this->checkoutService->releaseStock($order, $lineItems);
             $order->transitionTo(Order::STATUS_FAILED, notes: 'Payment failed: '.($result['error'] ?? 'unknown'));
 
             throw new CheckoutException('Payment failed: '.($result['error'] ?? 'please try again.'));
@@ -163,29 +133,6 @@ class HeadlessCheckoutService
 
         if (isset($result['transaction_id'])) {
             $order->update(['transaction_id' => $result['transaction_id']]);
-        }
-    }
-
-    /** Return reserved stock when a charge fails after the order was created. */
-    private function releaseInventory(Order $order, Collection $cart): void
-    {
-        foreach ($cart as $item) {
-            $before = Product::where('id', $item->product_id)->value('inventory_count');
-            if ($before === null) {
-                continue;
-            }
-
-            Product::where('id', $item->product_id)->increment('inventory_count', $item->quantity);
-
-            InventoryLog::create([
-                'product_id' => $item->product_id,
-                'quantity_change' => $item->quantity,
-                'old_quantity' => $before,
-                'new_quantity' => $before + $item->quantity,
-                'reason' => 'payment_failed_release',
-                'reference_id' => $order->id,
-                'reference_type' => Order::class,
-            ]);
         }
     }
 }

--- a/tests/Feature/CheckoutServiceTest.php
+++ b/tests/Feature/CheckoutServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Exceptions\CheckoutException;
+use App\Interfaces\PaymentGatewayInterface;
+use App\Models\Order;
+use App\Models\Product;
+use App\Services\CheckoutService;
+use App\Services\PaymentGateways\StripeGateway;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The money mechanics shared by the web and headless checkout paths. Both are also
+ * exercised end-to-end through their callers; these lock the contract directly.
+ */
+class CheckoutServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function order(float $total = 100): Order
+    {
+        return Order::create(['customer_email' => 'b@c.com', 'total_amount' => $total, 'status' => 'pending']);
+    }
+
+    public function test_reserve_stock_creates_items_and_decrements_inventory(): void
+    {
+        $product = Product::factory()->create(['inventory_count' => 5, 'price' => 10]);
+        $order = $this->order();
+
+        app(CheckoutService::class)->reserveStock($order, [
+            ['product_id' => $product->id, 'quantity' => 2, 'price' => 10],
+        ]);
+
+        $this->assertSame(3, $product->fresh()->inventory_count);
+        $this->assertSame(1, $order->items()->count());
+        $this->assertDatabaseHas('inventory_logs', ['product_id' => $product->id, 'quantity_change' => -2, 'reason' => 'order']);
+    }
+
+    public function test_reserve_stock_throws_and_leaves_a_transaction_to_roll_back_on_shortfall(): void
+    {
+        $product = Product::factory()->create(['inventory_count' => 1]);
+        $order = $this->order();
+
+        $this->expectException(CheckoutException::class);
+        app(CheckoutService::class)->reserveStock($order, [
+            ['product_id' => $product->id, 'quantity' => 3, 'price' => 10],
+        ]);
+    }
+
+    public function test_release_stock_restores_inventory(): void
+    {
+        $product = Product::factory()->create(['inventory_count' => 3]);
+        $order = $this->order();
+
+        app(CheckoutService::class)->releaseStock($order, [
+            ['product_id' => $product->id, 'quantity' => 2, 'price' => 10],
+        ]);
+
+        $this->assertSame(5, $product->fresh()->inventory_count);
+        $this->assertDatabaseHas('inventory_logs', ['product_id' => $product->id, 'quantity_change' => 2, 'reason' => 'payment_failed_release']);
+    }
+
+    public function test_capture_payment_charges_the_order_total_through_the_gateway(): void
+    {
+        $spy = new class implements PaymentGatewayInterface
+        {
+            public array $details = [];
+
+            public ?float $amount = null;
+
+            public function processPayment(float $amount, array $paymentDetails): array
+            {
+                $this->amount = $amount;
+                $this->details = $paymentDetails;
+
+                return ['success' => true, 'transaction_id' => 'ch_1'];
+            }
+
+            public function processSubscription(string $planId, array $subscriptionDetails): array
+            {
+                return [];
+            }
+
+            public function refundPayment(string $transactionId, float $amount): array
+            {
+                return [];
+            }
+        };
+        $this->app->instance(StripeGateway::class, $spy);
+
+        $order = $this->order(total: 150);
+        $result = app(CheckoutService::class)->capturePayment($order, 'stripe', ['token' => 'tok_x']);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(150.0, $spy->amount);
+        $this->assertSame($order->id, $spy->details['order_id']);
+        $this->assertSame('tok_x', $spy->details['token']);
+    }
+}


### PR DESCRIPTION
## What

Dedupes the money-critical mechanics that the web checkout (session cart) and the headless GraphQL checkout (`CartItem` cart, #781) had each grown their own copy of.

## Extracted into a shared `CheckoutService`

| method | does |
|---|---|
| `reserveStock(order, lineItems)` | creates order items + reserves stock with the guarded atomic decrement; throws `CheckoutException` on any shortfall (call inside a txn → rolls back, no charge) |
| `releaseStock(order, lineItems)` | returns reserved stock after a failed charge |
| `capturePayment(order, gateway, extra)` | charges the order total; `extra` carries the gateway token/id |

Each caller keeps its **own orchestration** — cart source, tax/coupon/shipping, and error presentation (the web **redirects**; the GraphQL layer surfaces **errors**). Only the shared primitives moved. The web controller also sheds four now-dead payment helpers (`processPayment` / `processStripePayment` / `processPayPalPayment` / `releaseInventory`) and the `OUT_OF_STOCK` sentinel.

## Behaviour-preserving

**Net −137 lines** across the two callers. Payment `details` are byte-identical to before (`order_id` + `customer_email` + gateway token/id). No test changed its expectations:

- Web: oversell rollback, coupon revalidation, tax engine, live-rate quote-trust, billing-country persistence, invalid-payment + payment-failure release.
- Headless: place + reserve + clear, stored-quote billing, stock-shortfall rollback, payment-failure release.

Plus **+4** direct `CheckoutService` tests (reserve decrements + throws on shortfall, release restores, capture charges the total through the gateway).

Full suite **1133 passed**, including `--order-by=random` (fully green).
