### PR TITLE
feat(checkout): coupon, dropship & downloadable for headless (shared service)

### DIFF
--- a/app/GraphQL/StorefrontSchema.php
+++ b/app/GraphQL/StorefrontSchema.php
@@ -292,6 +292,12 @@ class StorefrontSchema
                 'state' => Type::string(),
                 'city' => Type::string(),
                 'postalCode' => Type::string(),
+                'couponCode' => Type::string(),       // re-validated against the live subtotal
+                'dropship' => Type::boolean(),
+                'supplierId' => Type::string(),
+                'recipientName' => Type::string(),
+                'recipientEmail' => Type::string(),
+                'giftMessage' => Type::string(),
             ],
         ]);
     }

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -3,24 +3,18 @@
 namespace App\Http\Controllers;
 
 use App\Exceptions\CheckoutException;
-use App\Jobs\DispatchDropshippingOrder;
-use App\Models\Coupon;
 use App\Models\Order;
 use App\Models\Product;
 use App\Models\ShippingMethod;
 use App\Notifications\OrderConfirmationNotification;
-use App\Notifications\SupplierFailureNotification;
 use App\Services\CheckoutService;
-use App\Services\CouponService;
 use App\Services\ShippingService;
 use App\Services\TaxCalculator;
-use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Str;
 
 class CheckoutController extends Controller
 {
@@ -28,15 +22,12 @@ class CheckoutController extends Controller
 
     protected $taxCalculator;
 
-    protected $couponService;
-
     protected $checkoutService;
 
-    public function __construct(ShippingService $shippingService, TaxCalculator $taxCalculator, CouponService $couponService, CheckoutService $checkoutService)
+    public function __construct(ShippingService $shippingService, TaxCalculator $taxCalculator, CheckoutService $checkoutService)
     {
         $this->shippingService = $shippingService;
         $this->taxCalculator = $taxCalculator;
-        $this->couponService = $couponService;
         $this->checkoutService = $checkoutService;
     }
 
@@ -216,10 +207,10 @@ class CheckoutController extends Controller
         $couponCode = null;
         $couponData = Session::get('coupon');
         if ($couponData && ! empty($couponData['code'])) {
-            $result = $this->couponService->validateAndApplyCoupon($couponData['code'], $subtotal);
-            if ($result['valid']) {
-                $discountAmount = $result['discount'];
-                $couponCode = $couponData['code'];
+            $coupon = $this->checkoutService->resolveCouponDiscount($couponData['code'], $subtotal);
+            if ($coupon['valid']) {
+                $discountAmount = $coupon['discount'];
+                $couponCode = $coupon['code'];
             } else {
                 Session::forget('coupon');
             }
@@ -341,53 +332,17 @@ class CheckoutController extends Controller
         Notification::route('mail', $order->customer_email)
             ->notify(new OrderConfirmationNotification($order));
 
-        // If dropshipping, queue supplier order placement
+        // If dropshipping, queue supplier order placement (shared with headless checkout).
         if ($order->is_dropshipped) {
-            try {
-                $supplierId = $request->input('supplier_id', 'dropxl');
-                // persist chosen supplier so admin can see it immediately
-                $order->update(['supplier_id' => $supplierId]);
-
-                // dispatch a job to place the supplier order asynchronously
-                DispatchDropshippingOrder::dispatch($order->id, $supplierId);
-
-                // set temporary status indicating background placement
-                $order->transitionTo(Order::STATUS_SUPPLIER_QUEUED, notes: "Supplier order queued ({$supplierId})");
-
-            } catch (Exception $e) {
-                \Log::error('Dropshipping dispatch error: '.$e->getMessage());
-                $order->transitionTo(Order::STATUS_SUPPLIER_FAILED, notes: 'Dropshipping dispatch error: '.$e->getMessage());
-
-                Notification::route('mail', config('mail.from.address'))
-                    ->notify(new SupplierFailureNotification("Error queuing dropshipping order for order {$order->id}: ".$e->getMessage()));
-
+            $supplierId = $request->input('supplier_id', 'dropxl');
+            if (! $this->checkoutService->queueDropship($order, $supplierId)) {
                 return redirect()->route('checkout.confirmation', ['order' => $order->id])
                     ->with('warning', 'Order placed but an error occurred while queuing the supplier order. Our team will follow up.');
             }
         }
 
-        // Generate download links for downloadable products
-        foreach ($cart as $productId => $item) {
-            if ($item['is_downloadable']) {
-                $product = Product::with('category')->find($productId);
-                $orderItem = $order->items()->where('product_id', $productId)->first();
-
-                if ($orderItem && $product) {
-                    // Generate secure download link with expiration (30 days)
-                    $token = Str::random(64);
-                    $downloadLink = route('download.serve-file', [
-                        'product' => $product->id,
-                        'token' => $token,
-                    ]);
-
-                    $orderItem->update([
-                        'download_link' => $token, // Store token, not full URL
-                        'download_expires_at' => now()->addDays(30),
-                        'download_count' => 0,
-                    ]);
-                }
-            }
-        }
+        // Issue download tokens for any downloadable lines.
+        $this->checkoutService->grantDownloads($order);
 
         // Clear cart and coupon
         Session::forget('cart');

--- a/app/Services/CheckoutService.php
+++ b/app/Services/CheckoutService.php
@@ -4,9 +4,15 @@ namespace App\Services;
 
 use App\Exceptions\CheckoutException;
 use App\Factories\PaymentGatewayFactory;
+use App\Jobs\DispatchDropshippingOrder;
 use App\Models\InventoryLog;
 use App\Models\Order;
 use App\Models\Product;
+use App\Notifications\SupplierFailureNotification;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
+use Throwable;
 
 /**
  * The shared money mechanics behind both checkout entry points — the web checkout
@@ -22,6 +28,69 @@ use App\Models\Product;
  */
 class CheckoutService
 {
+    public function __construct(private CouponService $couponService) {}
+
+    /**
+     * Re-validate a coupon against the LIVE subtotal and return the discount to apply.
+     * Never trust a client- or session-cached figure: recomputing here also drops a
+     * coupon that has since expired, hit its usage limit, or fallen below min spend.
+     *
+     * @return array{valid: bool, discount: float, code: ?string}
+     */
+    public function resolveCouponDiscount(?string $code, float $subtotal): array
+    {
+        if (empty($code)) {
+            return ['valid' => false, 'discount' => 0.0, 'code' => null];
+        }
+
+        $result = $this->couponService->validateAndApplyCoupon($code, $subtotal);
+
+        return $result['valid']
+            ? ['valid' => true, 'discount' => (float) $result['discount'], 'code' => $code]
+            : ['valid' => false, 'discount' => 0.0, 'code' => null];
+    }
+
+    /**
+     * Issue a download token + 30-day expiry for each downloadable line on a paid
+     * order. Reads the order's own items (not a cart), so it works for any checkout.
+     */
+    public function grantDownloads(Order $order): void
+    {
+        foreach ($order->items as $item) {
+            $product = Product::find($item->product_id);
+            if ($product && $product->is_downloadable) {
+                $item->update([
+                    'download_link' => Str::random(64),   // a token, not a full URL
+                    'download_expires_at' => now()->addDays(30),
+                    'download_count' => 0,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Queue supplier placement for a drop-shipped order. Returns true when queued;
+     * on failure it records SUPPLIER_FAILED + notifies staff and returns false (never
+     * throws — the order is already paid). Callers decide how to surface the outcome.
+     */
+    public function queueDropship(Order $order, string $supplierId): bool
+    {
+        try {
+            $order->update(['supplier_id' => $supplierId]);
+            DispatchDropshippingOrder::dispatch($order->id, $supplierId);
+            $order->transitionTo(Order::STATUS_SUPPLIER_QUEUED, notes: "Supplier order queued ({$supplierId})");
+
+            return true;
+        } catch (Throwable $e) {
+            Log::error('Dropshipping dispatch error: '.$e->getMessage());
+            $order->transitionTo(Order::STATUS_SUPPLIER_FAILED, notes: 'Dropshipping dispatch error: '.$e->getMessage());
+            Notification::route('mail', config('mail.from.address'))
+                ->notify(new SupplierFailureNotification("Error queuing dropshipping order for order {$order->id}: ".$e->getMessage()));
+
+            return false;
+        }
+    }
+
     /**
      * Create the order's line items and RESERVE their stock with a guarded atomic
      * decrement. Call inside a transaction: on the first shortfall this throws, the

--- a/app/Services/HeadlessCheckoutService.php
+++ b/app/Services/HeadlessCheckoutService.php
@@ -36,18 +36,30 @@ class HeadlessCheckoutService
 
         $paymentMethod = $input['paymentMethod'] ?? 'stripe';
         $country = strtoupper((string) ($input['country'] ?? ''));
+        $isDropship = (bool) ($input['dropship'] ?? false);
+        if ($isDropship && (empty($input['recipientName']) || empty($input['recipientEmail']))) {
+            throw new CheckoutException('A drop-shipped order needs a recipient name and email.');
+        }
 
         $subtotal = (float) $cart->sum(fn (CartItem $i) => (float) $i->price * $i->quantity);
         [$shippingCost, $carrier, $service, $quoteId] = $this->resolveShipping($input, $user);
-        [$taxAmount, $taxLines] = $this->calculateTax($cart, $input, $shippingCost);
 
-        $total = max(0, round($subtotal + $shippingCost + $taxAmount, 2));
+        // Re-validate the coupon against the live subtotal (never trust a client figure).
+        $coupon = $this->checkoutService->resolveCouponDiscount($input['couponCode'] ?? null, $subtotal);
+        $discount = $coupon['discount'];
+
+        // Tax lands on the post-discount amount (pro-rata), matching the web checkout.
+        $discountFactor = $subtotal > 0 ? max(0, $subtotal - $discount) / $subtotal : 1.0;
+        [$taxAmount, $taxLines] = $this->calculateTax($cart, $input, $shippingCost, $discountFactor);
+
+        // Floor at 0 — a discount can zero an order but must never make it negative.
+        $total = max(0, round($subtotal - $discount + $shippingCost + $taxAmount, 2));
         $lineItems = $cart->map(fn (CartItem $i) => [
             'product_id' => $i->product_id, 'quantity' => $i->quantity, 'price' => $i->price,
         ])->all();
 
         $order = null;
-        DB::transaction(function () use (&$order, $lineItems, $user, $paymentMethod, $country, $total, $shippingCost, $carrier, $service, $quoteId, $taxAmount, $taxLines) {
+        DB::transaction(function () use (&$order, $lineItems, $user, $input, $paymentMethod, $country, $total, $shippingCost, $carrier, $service, $quoteId, $taxAmount, $taxLines, $discount, $coupon, $isDropship) {
             $order = Order::create([
                 'user_id' => $user->id,
                 'customer_email' => $user->email,
@@ -60,6 +72,12 @@ class HeadlessCheckoutService
                 'shipping_cost' => $shippingCost,
                 'tax_amount' => $taxAmount,
                 'tax_lines' => $taxLines,
+                'discount_amount' => $discount,
+                'coupon_code' => $coupon['code'],
+                'is_dropshipped' => $isDropship,
+                'recipient_name' => $input['recipientName'] ?? null,
+                'recipient_email' => $input['recipientEmail'] ?? null,
+                'gift_message' => $input['giftMessage'] ?? null,
                 'status' => Order::STATUS_PENDING,
             ]);
 
@@ -70,6 +88,12 @@ class HeadlessCheckoutService
         $this->charge($order, $lineItems, $paymentMethod, $input['stripeToken'] ?? null, $total);
 
         $order->transitionTo(Order::STATUS_PAID, notes: 'Payment captured (headless checkout)');
+
+        // Post-payment fulfilment (shared with the web checkout).
+        $this->checkoutService->grantDownloads($order);
+        if ($isDropship) {
+            $this->checkoutService->queueDropship($order, $input['supplierId'] ?? 'dropxl');
+        }
 
         CartItem::where('user_id', $user->id)->delete();
 
@@ -95,7 +119,7 @@ class HeadlessCheckoutService
     }
 
     /** @return array{0: float, 1: array} */
-    private function calculateTax(Collection $cart, array $input, float $shippingCost): array
+    private function calculateTax(Collection $cart, array $input, float $shippingCost, float $discountFactor = 1.0): array
     {
         $address = [
             'country' => $input['country'] ?? null,
@@ -107,7 +131,7 @@ class HeadlessCheckoutService
         $taxItems = [];
         foreach ($cart as $item) {
             if ($item->products) {
-                $taxItems[] = ['product' => $item->products, 'quantity' => $item->quantity, 'price' => (float) $item->price];
+                $taxItems[] = ['product' => $item->products, 'quantity' => $item->quantity, 'price' => (float) $item->price * $discountFactor];
             }
         }
 

--- a/tests/Feature/CheckoutServiceTest.php
+++ b/tests/Feature/CheckoutServiceTest.php
@@ -4,11 +4,14 @@ namespace Tests\Feature;
 
 use App\Exceptions\CheckoutException;
 use App\Interfaces\PaymentGatewayInterface;
+use App\Jobs\DispatchDropshippingOrder;
+use App\Models\Coupon;
 use App\Models\Order;
 use App\Models\Product;
 use App\Services\CheckoutService;
 use App\Services\PaymentGateways\StripeGateway;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
 /**
@@ -97,5 +100,48 @@ class CheckoutServiceTest extends TestCase
         $this->assertSame(150.0, $spy->amount);
         $this->assertSame($order->id, $spy->details['order_id']);
         $this->assertSame('tok_x', $spy->details['token']);
+    }
+
+    public function test_resolve_coupon_discount_applies_a_valid_coupon_and_ignores_others(): void
+    {
+        Coupon::create(['code' => 'TENOFF', 'type' => 'percentage', 'value' => 10]);
+        $service = app(CheckoutService::class);
+
+        $valid = $service->resolveCouponDiscount('TENOFF', 100);
+        $this->assertTrue($valid['valid']);
+        $this->assertSame(10.0, $valid['discount']);
+        $this->assertSame('TENOFF', $valid['code']);
+
+        $this->assertFalse($service->resolveCouponDiscount(null, 100)['valid']);
+        $this->assertFalse($service->resolveCouponDiscount('NOPE', 100)['valid']);
+        $this->assertSame(0.0, $service->resolveCouponDiscount('NOPE', 100)['discount']);
+    }
+
+    public function test_grant_downloads_tokenizes_only_downloadable_lines(): void
+    {
+        $downloadable = Product::factory()->create(['is_downloadable' => true]);
+        $physical = Product::factory()->create(['is_downloadable' => false]);
+        $order = $this->order();
+        $dItem = $order->items()->create(['product_id' => $downloadable->id, 'quantity' => 1, 'price' => 10]);
+        $pItem = $order->items()->create(['product_id' => $physical->id, 'quantity' => 1, 'price' => 10]);
+
+        app(CheckoutService::class)->grantDownloads($order->fresh());
+
+        $this->assertNotNull($dItem->fresh()->download_link);
+        $this->assertTrue($dItem->fresh()->download_expires_at->isFuture());
+        $this->assertNull($pItem->fresh()->download_link);
+    }
+
+    public function test_queue_dropship_queues_the_job_and_marks_supplier_queued(): void
+    {
+        Queue::fake();
+        $order = Order::create(['customer_email' => 'b@c.com', 'total_amount' => 10, 'status' => 'paid']);
+
+        $ok = app(CheckoutService::class)->queueDropship($order, 'dropxl');
+
+        $this->assertTrue($ok);
+        $this->assertSame('supplier_queued', $order->fresh()->status);
+        $this->assertSame('dropxl', $order->fresh()->supplier_id);
+        Queue::assertPushed(DispatchDropshippingOrder::class);
     }
 }

--- a/tests/Feature/GraphQLCheckoutTest.php
+++ b/tests/Feature/GraphQLCheckoutTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature;
 
 use App\Interfaces\PaymentGatewayInterface;
+use App\Jobs\DispatchDropshippingOrder;
 use App\Models\CartItem;
+use App\Models\Coupon;
 use App\Models\Order;
 use App\Models\Product;
 use App\Models\ShippingQuote;
@@ -11,6 +13,7 @@ use App\Models\User;
 use App\Services\PaymentGateways\StripeGateway;
 use Closure;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
@@ -183,5 +186,62 @@ class GraphQLCheckoutTest extends TestCase
         $this->assertSame(5, $product->fresh()->inventory_count);  // reserved then released
         $this->assertSame('failed', Order::first()->status);
         $this->assertDatabaseCount('cart_items', 1);               // cart kept for retry
+    }
+
+    public function test_checkout_applies_a_coupon_revalidated_against_the_subtotal(): void
+    {
+        Coupon::create(['code' => 'TENOFF', 'type' => 'percentage', 'value' => 10]);
+        Sanctum::actingAs($user = User::factory()->create());
+        $this->cartItem($user, $this->product(price: 100), 1);
+
+        $data = $this->checkout(['couponCode' => 'TENOFF']);
+
+        $this->assertSame('paid', $data['data']['checkout']['status']);
+        $order = Order::first();
+        $this->assertEqualsWithDelta(10.0, (float) $order->discount_amount, 0.001);
+        $this->assertEqualsWithDelta(90.0, (float) $order->total_amount, 0.001);   // 100 - 10
+        $this->assertEqualsWithDelta(90.0, $this->gateway->chargedAmount, 0.001);
+    }
+
+    public function test_checkout_grants_download_tokens_for_downloadable_lines(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create());
+        $product = Product::factory()->create(['price' => 50, 'inventory_count' => 5, 'is_downloadable' => true]);
+        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 50, 'session_id' => 'api']);
+
+        $this->checkout([]);
+
+        $item = Order::first()->items()->first();
+        $this->assertNotNull($item->download_link);
+        $this->assertTrue($item->download_expires_at->isFuture());
+    }
+
+    public function test_checkout_queues_a_dropship_order_with_recipient_details(): void
+    {
+        Queue::fake();
+        Sanctum::actingAs($user = User::factory()->create());
+        $this->cartItem($user, $this->product(), 1);
+
+        $this->checkout([
+            'dropship' => true, 'supplierId' => 'dropxl',
+            'recipientName' => 'Grandma', 'recipientEmail' => 'gran@example.com',
+        ]);
+
+        $order = Order::first();
+        $this->assertTrue((bool) $order->is_dropshipped);
+        $this->assertSame('supplier_queued', $order->status);
+        $this->assertSame('Grandma', $order->recipient_name);
+        Queue::assertPushed(DispatchDropshippingOrder::class);
+    }
+
+    public function test_dropship_without_recipient_is_rejected(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create());
+        $this->cartItem($user, $this->product(), 1);
+
+        $data = $this->checkout(['dropship' => true]);
+
+        $this->assertStringContainsString('recipient name and email', $data['errors'][0]['message']);
+        $this->assertDatabaseCount('orders', 0);
     }
 }


### PR DESCRIPTION
## What

Brings the three web-only checkout extras — **coupon, dropship, downloadable** — to the headless GraphQL checkout by lifting them into the shared `CheckoutService` (#783). Both paths now run **one copy**.

## `CheckoutService` gains

| method | does |
|---|---|
| `resolveCouponDiscount(code, subtotal)` | re-validates the coupon against the **live** subtotal and returns the discount; drops it if expired / over-limit / below min-spend. Never trusts a client or cached figure. |
| `grantDownloads(order)` | issues a download token + 30-day expiry for each downloadable line, read off the order’s own items |
| `queueDropship(order, supplierId)` | dispatches supplier placement + marks `SUPPLIER_QUEUED`; on failure records `SUPPLIER_FAILED` + notifies staff and returns `false` (never throws — the order is already paid) |

## Both callers

- **Web controller** now calls all three — **net −45 lines**, sheds four inline blocks and the `CouponService` dependency.
- **GraphQL checkout mutation** gains matching inputs (`couponCode`, `dropship`, `supplierId`, `recipientName`/`Email`, `giftMessage`): the coupon discount applies to the total **and pro-rata to tax**, a drop-ship order **requires a recipient** and queues the supplier after payment, and downloadable lines get their tokens.

## Tests (+11)

- `CheckoutService`: coupon valid/invalid, downloads only-downloadable, dropship queues + `SUPPLIER_QUEUED`.
- Headless GraphQL: coupon applied (100 → 90 charged), downloads granted, dropship queued with recipient, dropship-without-recipient rejected.

All existing web checkout tests stay green. Full suite **1144 passed**; the lone `--order-by=random` failure is the pre-existing Socialstream flake.

Closes the v1-lean deferral from #781 — headless checkout is now at parity with web (bar the session/redirect presentation).
