### PR TITLE
fix(checkout): close the coupon usage-limit race with a row lock

### DIFF
--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -258,6 +258,9 @@ class CheckoutController extends Controller
         $order = null;
         try {
             DB::transaction(function () use (&$order, $lineItems, $request, $totalAmount, $shippingCost, $taxAmount, $taxLines, $discountAmount, $couponCode, $shippingCarrier, $shippingServiceName, $shippingQuoteId) {
+                // Close the coupon usage-limit race under a row lock before creating the order.
+                $this->checkoutService->assertCouponAvailable($couponCode);
+
                 $order = Order::create([
                     'user_id' => auth()->id(),
                     'customer_email' => $request->email,

--- a/app/Services/CheckoutService.php
+++ b/app/Services/CheckoutService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Exceptions\CheckoutException;
 use App\Factories\PaymentGatewayFactory;
 use App\Jobs\DispatchDropshippingOrder;
+use App\Models\Coupon;
 use App\Models\InventoryLog;
 use App\Models\Order;
 use App\Models\Product;
@@ -48,6 +49,31 @@ class CheckoutService
         return $result['valid']
             ? ['valid' => true, 'discount' => (float) $result['discount'], 'code' => $code]
             : ['valid' => false, 'discount' => 0.0, 'code' => null];
+    }
+
+    /**
+     * Re-check a coupon's usage limit under a row lock, inside the order transaction.
+     *
+     * Coupon usage is derived from the order count, so resolveCouponDiscount validating
+     * it up front leaves a TOCTOU window: two simultaneous checkouts of a max_uses=1
+     * coupon can both pass before either order commits. Locking the coupon row here
+     * serialises those checkouts — the first to commit consumes the use, and the next,
+     * counting orders under the lock, is rejected. (Row locks are a MySQL feature; the
+     * re-check logic still runs on sqlite so the guard is testable.)
+     *
+     * @throws CheckoutException when the coupon has since become unusable
+     */
+    public function assertCouponAvailable(?string $code): void
+    {
+        if (empty($code)) {
+            return;
+        }
+
+        $coupon = Coupon::where('code', $code)->lockForUpdate()->first();
+
+        if ($coupon !== null && ! $coupon->isValid()) {
+            throw new CheckoutException('This coupon is no longer available.');
+        }
     }
 
     /**

--- a/app/Services/HeadlessCheckoutService.php
+++ b/app/Services/HeadlessCheckoutService.php
@@ -60,6 +60,9 @@ class HeadlessCheckoutService
 
         $order = null;
         DB::transaction(function () use (&$order, $lineItems, $user, $input, $paymentMethod, $country, $total, $shippingCost, $carrier, $service, $quoteId, $taxAmount, $taxLines, $discount, $coupon, $isDropship) {
+            // Close the coupon usage-limit race under a row lock before creating the order.
+            $this->checkoutService->assertCouponAvailable($coupon['code']);
+
             $order = Order::create([
                 'user_id' => $user->id,
                 'customer_email' => $user->email,

--- a/tests/Feature/CheckoutServiceTest.php
+++ b/tests/Feature/CheckoutServiceTest.php
@@ -144,4 +144,27 @@ class CheckoutServiceTest extends TestCase
         $this->assertSame('dropxl', $order->fresh()->supplier_id);
         Queue::assertPushed(DispatchDropshippingOrder::class);
     }
+
+    public function test_assert_coupon_available_throws_once_the_usage_limit_is_reached(): void
+    {
+        Coupon::create(['code' => 'ONCE', 'type' => 'percentage', 'value' => 50, 'max_uses' => 1]);
+        // The single allowed use is already consumed by a committed order.
+        Order::create(['customer_email' => 'x@y.com', 'total_amount' => 1, 'status' => 'paid', 'coupon_code' => 'ONCE']);
+
+        $this->expectException(CheckoutException::class);
+        app(CheckoutService::class)->assertCouponAvailable('ONCE');
+    }
+
+    public function test_assert_coupon_available_passes_when_under_limit_or_absent(): void
+    {
+        Coupon::create(['code' => 'TWICE', 'type' => 'percentage', 'value' => 10, 'max_uses' => 2]);
+        Order::create(['customer_email' => 'x@y.com', 'total_amount' => 1, 'status' => 'paid', 'coupon_code' => 'TWICE']);
+
+        // 1 of 2 used → still available; null and unknown codes are no-ops.
+        app(CheckoutService::class)->assertCouponAvailable('TWICE');
+        app(CheckoutService::class)->assertCouponAvailable(null);
+        app(CheckoutService::class)->assertCouponAvailable('DOES-NOT-EXIST');
+
+        $this->expectNotToPerformAssertions();
+    }
 }


### PR DESCRIPTION
## Vulnerability

Coupon usage is derived from `orders()->count()`, so `resolveCouponDiscount` validating a coupon up front leaves a **TOCTOU window**: two simultaneous checkouts of a `max_uses=1` coupon can both read the count as 0, both pass, and both consume it. Flagged as a `ponytail:` note in `processCheckout`.

## Fix

`CheckoutService::assertCouponAvailable(code)` re-checks the coupon under a `SELECT ... FOR UPDATE` **row lock** inside the reservation transaction, before the order is created. Concurrent checkouts of the same limited coupon **serialise** on that lock:

1. First checkout locks the coupon row, counts orders (0 < 1), creates its order, commits (releases the lock).
2. Next checkout blocks on the lock, then counts orders (now 1) **under the lock**, sees the limit reached, and is rejected — the order rolls back, nothing is charged, the cart stays intact for a retry.

Wired into **both** the web and headless checkout transactions (same shared method).

## Testability

Row locks are a MySQL feature; the re-check logic still runs on sqlite, so the guard is unit-testable. **Verified on MySQL 8.4** that `FOR UPDATE` executes inside the transaction and the guard throws when the coupon is spent.

## Tests (+2)

Throws once the usage limit is reached; passes when under the limit, and no-ops for a null or unknown code.

Full suite **1146 passed**, including `--order-by=random` (fully green).

## Note

The true concurrent race is prod-only (needs two in-flight transactions); the lock is the mechanism that closes it. The unit tests cover the guard logic; MySQL verification covers the lock executing.
