### PR TITLE
feat(shipping): prune expired shipping quotes on a daily schedule

### DIFF
--- a/app/Console/Commands/PruneShippingQuotes.php
+++ b/app/Console/Commands/PruneShippingQuotes.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ShippingQuote;
+use Illuminate\Console\Command;
+
+/**
+ * Delete stale shipping quotes. Each live-rate lookup persists one row per rate; once
+ * expired they are never usable again (checkout only resolves un-expired quotes), so
+ * they are pure churn. A short grace window keeps recently-expired rows for a moment in
+ * case a checkout is mid-flight.
+ */
+class PruneShippingQuotes extends Command
+{
+    protected $signature = 'shipping:prune-quotes {--days=1 : Delete quotes that expired more than this many days ago}';
+
+    protected $description = 'Delete expired shipping quotes';
+
+    public function handle(): int
+    {
+        $cutoff = now()->subDays((int) $this->option('days'));
+
+        $deleted = ShippingQuote::where('expires_at', '<', $cutoff)->delete();
+
+        $this->info("Pruned {$deleted} expired shipping quote(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,7 +12,8 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        // $schedule->command('inspire')->hourly();
+        // Clear out expired shipping quotes daily so the table doesn't grow unbounded.
+        $schedule->command('shipping:prune-quotes')->daily();
     }
 
     /**

--- a/tests/Feature/PruneShippingQuotesTest.php
+++ b/tests/Feature/PruneShippingQuotesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ShippingQuote;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PruneShippingQuotesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function quote(string $expiresAt): ShippingQuote
+    {
+        return ShippingQuote::create([
+            'user_id' => User::factory()->create()->id,
+            'session_id' => 'api',
+            'carrier' => 'USPS', 'service' => 'Priority', 'amount' => 5, 'currency' => 'USD',
+            'expires_at' => $expiresAt,
+        ]);
+    }
+
+    public function test_prunes_quotes_past_the_grace_window_and_keeps_the_rest(): void
+    {
+        $old = $this->quote(now()->subDays(3));       // long expired
+        $recent = $this->quote(now()->subHours(1));   // expired, within the 1-day grace
+        $active = $this->quote(now()->addHour());     // still valid
+
+        $this->artisan('shipping:prune-quotes')       // default --days=1
+            ->expectsOutputToContain('Pruned 1 expired shipping quote(s).')
+            ->assertSuccessful();
+
+        $this->assertDatabaseMissing('shipping_quotes', ['id' => $old->id]);
+        $this->assertDatabaseHas('shipping_quotes', ['id' => $recent->id]);
+        $this->assertDatabaseHas('shipping_quotes', ['id' => $active->id]);
+    }
+
+    public function test_days_zero_prunes_everything_already_expired(): void
+    {
+        $this->quote(now()->subHours(1));
+        $active = $this->quote(now()->addHour());
+
+        $this->artisan('shipping:prune-quotes', ['--days' => 0])->assertSuccessful();
+
+        $this->assertSame(1, ShippingQuote::count());
+        $this->assertDatabaseHas('shipping_quotes', ['id' => $active->id]);
+    }
+}


### PR DESCRIPTION
## What

Each live-rate lookup persists one `ShippingQuote` per rate. Once expired they can never be used again (checkout resolves only un-expired quotes), so they accumulate as pure churn.

Adds **`shipping:prune-quotes`** — deletes quotes expired past a grace window (`--days`, default 1) — **scheduled daily** in the console kernel. The grace keeps recently-expired rows for a moment in case a checkout is mid-flight.

## Tests (+2)

- Prunes rows past the grace window; keeps recently-expired (within grace) and still-active rows.
- `--days=0` clears everything already expired.

Full suite **1146 passed**, including `--order-by=random` (fully green).
