### PR TITLE
feat(gdpr): export behavioural data (browsing, interactions, segments)

### DIFF
--- a/app/Services/GdprExportService.php
+++ b/app/Services/GdprExportService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\CustomerSegment;
 use App\Models\GiftRegistry;
 use App\Models\Order;
 use App\Models\ProductRating;
@@ -22,9 +23,10 @@ use App\Models\User;
  * Registry access codes (a private-registry secret) and registry purchases (a third
  * party's PII) are deliberately excluded.
  *
- * ponytail: covers identity, transactional data, and user-authored content. Behavioural
- * /tracking data (browsing history, product interactions, customer segments) is personal
- * data too — add it here when a user actually asks for it; it is high-volume and derived.
+ * Covers identity, transactional data, user-authored content, and behavioural/tracking
+ * data (browsing history, product interactions, segment memberships). Behavioural data
+ * is high-volume; it is exported in full rather than capped, since Art. 15 asks for
+ * completeness — trim with a date range here if volume becomes a problem.
  */
 class GdprExportService
 {
@@ -51,7 +53,46 @@ class GdprExportService
             'product_reviews' => $customer ? $this->productReviews($customer->id) : [],
             'product_ratings' => $customer ? $this->productRatings($customer->id) : [],
             'gift_registries' => $this->giftRegistries($user),
+            'browsing_history' => $this->browsingHistory($user),
+            'product_interactions' => $this->productInteractions($user),
+            'segments' => $this->segments($user),
         ];
+    }
+
+    private function browsingHistory(User $user): array
+    {
+        return $user->browsingHistory()->latest('id')->get()->map(fn ($h) => [
+            'product_id' => $h->product_id,
+            'viewed_at' => optional($h->created_at)->toIso8601String(),
+        ])->all();
+    }
+
+    private function productInteractions(User $user): array
+    {
+        return $user->productInteractions()->latest('id')->get()->map(fn ($i) => [
+            'product_id' => $i->product_id,
+            'interaction_type' => $i->interaction_type,
+            'duration' => $i->duration,
+            'metadata' => $i->metadata,
+            'interacted_at' => optional($i->interacted_at)->toIso8601String(),
+        ])->all();
+    }
+
+    /**
+     * Segment memberships — the segment names only, not the internal matching rules.
+     *
+     * Queried via a direct join rather than the User::customerSegments() relation: that
+     * relation declares withTimestamps() but the customer_segment_members pivot has no
+     * created_at/updated_at, so using it errors. (Left for a separate fix.)
+     */
+    private function segments(User $user): array
+    {
+        return CustomerSegment::query()
+            ->join('customer_segment_members', 'customer_segments.id', '=', 'customer_segment_members.segment_id')
+            ->where('customer_segment_members.user_id', $user->id)
+            ->get(['customer_segments.name', 'customer_segments.description'])
+            ->map(fn ($s) => ['name' => $s->name, 'description' => $s->description])
+            ->all();
     }
 
     private function reviews(User $user): array

--- a/tests/Feature/GdprDataExportTest.php
+++ b/tests/Feature/GdprDataExportTest.php
@@ -2,18 +2,22 @@
 
 namespace Tests\Feature;
 
+use App\Models\BrowsingHistory;
+use App\Models\CustomerSegment;
 use App\Models\GiftRegistry;
 use App\Models\GiftRegistryItem;
 use App\Models\GiftRegistryPurchase;
 use App\Models\Order;
 use App\Models\PaymentMethod;
 use App\Models\Product;
+use App\Models\ProductInteraction;
 use App\Models\ProductRating;
 use App\Models\ProductReview;
 use App\Models\Rating;
 use App\Models\Review;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 /**
@@ -119,5 +123,39 @@ class GdprDataExportTest extends TestCase
         $this->assertStringNotContainsString('SECRETCODE123', $body, 'Registry access code leaked in export');
         // Registry purchases carry a third party's PII — not the exporting user's data.
         $this->assertStringNotContainsString('THIRDPARTY-BUYER', $body, "Third-party purchaser PII leaked in the user's export");
+    }
+
+    public function test_export_includes_behavioural_data_but_not_internal_segment_rules(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create();
+
+        BrowsingHistory::create(['user_id' => $user->id, 'product_id' => $product->id]);
+        ProductInteraction::create([
+            'user_id' => $user->id, 'product_id' => $product->id,
+            'interaction_type' => 'add_to_cart', 'duration' => 12, 'metadata' => ['ref' => 'HOMEPAGE'],
+            'interacted_at' => now(),
+        ]);
+        $segment = CustomerSegment::create([
+            'name' => 'VIP', 'description' => 'Top spenders',
+            'conditions' => [['field' => 'lifetime_value', 'operator' => '>', 'value' => 'SECRET-RULE-9000']],
+            'match_type' => 'all',
+        ]);
+        // Insert the pivot directly — the customerSegments() relation's withTimestamps()
+        // is incompatible with the pivot table (no created_at/updated_at).
+        DB::table('customer_segment_members')->insert([
+            'user_id' => $user->id, 'segment_id' => $segment->id, 'added_at' => now(),
+        ]);
+
+        $response = $this->actingAs($user)->getJson(route('account.data-export'));
+
+        $response->assertOk();
+        $response->assertJsonPath('browsing_history.0.product_id', $product->id);
+        $response->assertJsonPath('product_interactions.0.interaction_type', 'add_to_cart');
+        $response->assertJsonPath('product_interactions.0.metadata.ref', 'HOMEPAGE');
+        $response->assertJsonPath('segments.0.name', 'VIP');
+
+        // The segment's internal matching rules are not the user's data — never exported.
+        $this->assertStringNotContainsString('SECRET-RULE-9000', $response->getContent());
     }
 }


### PR DESCRIPTION
## What

Completes the Art. 15 export deferred in #770: the download now also includes the user’s **behavioural/tracking data** — browsing history, product interactions (type, duration, metadata, timestamp), and segment memberships.

## Whitelisted

Segments export their **name + description only**, never the internal matching rules (`conditions`) — that’s business logic, not the user’s data (a test asserts the rule value never appears). Exported in full for Art. 15 completeness rather than capped; trim with a date range if volume becomes a problem.

## Sidesteps a latent bug

Segment memberships are read via a **direct join**, not `User::customerSegments()`: that relation declares `withTimestamps()` but the `customer_segment_members` pivot has no `created_at`/`updated_at`, so using it (or `attach()`) errors. Left for a separate fix; the join avoids it. Flagged in a code comment.

## Tests (+1)

Browsing history / interaction / segment all exported; interaction `metadata` included; the segment’s matching rule is **not** leaked.

Full suite **1145 passed**, including `--order-by=random` (fully green).

---

GDPR export now covers identity, orders, payment metadata, user-authored content (#780), and behavioural data (this) — in symmetry with erasure.
