### PR TITLE
fix(user): drop withTimestamps on customerSegments (pivot has no timestamp columns)

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -169,9 +169,11 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
 
     public function customerSegments(): BelongsToMany
     {
+        // The pivot tracks membership with its own `added_at` column and has no
+        // created_at/updated_at — so withPivot('added_at'), NOT withTimestamps()
+        // (which would select/write pivot timestamp columns that don't exist and error).
         return $this->belongsToMany(CustomerSegment::class, 'customer_segment_members', 'user_id', 'segment_id')
-            ->withPivot('added_at')
-            ->withTimestamps();
+            ->withPivot('added_at');
     }
 
     public function customerMetric(): HasOne

--- a/app/Services/GdprExportService.php
+++ b/app/Services/GdprExportService.php
@@ -2,7 +2,6 @@
 
 namespace App\Services;
 
-use App\Models\CustomerSegment;
 use App\Models\GiftRegistry;
 use App\Models\Order;
 use App\Models\ProductRating;
@@ -78,21 +77,13 @@ class GdprExportService
         ])->all();
     }
 
-    /**
-     * Segment memberships — the segment names only, not the internal matching rules.
-     *
-     * Queried via a direct join rather than the User::customerSegments() relation: that
-     * relation declares withTimestamps() but the customer_segment_members pivot has no
-     * created_at/updated_at, so using it errors. (Left for a separate fix.)
-     */
+    /** Segment memberships — the segment names only, not the internal matching rules. */
     private function segments(User $user): array
     {
-        return CustomerSegment::query()
-            ->join('customer_segment_members', 'customer_segments.id', '=', 'customer_segment_members.segment_id')
-            ->where('customer_segment_members.user_id', $user->id)
-            ->get(['customer_segments.name', 'customer_segments.description'])
-            ->map(fn ($s) => ['name' => $s->name, 'description' => $s->description])
-            ->all();
+        return $user->customerSegments()->get()->map(fn ($s) => [
+            'name' => $s->name,
+            'description' => $s->description,
+        ])->all();
     }
 
     private function reviews(User $user): array

--- a/tests/Feature/CustomerSegmentMembershipTest.php
+++ b/tests/Feature/CustomerSegmentMembershipTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\CustomerSegment;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The customerSegments() pivot has its own `added_at` and no created_at/updated_at, so
+ * the relation must not declare withTimestamps() — otherwise attaching or reading a
+ * membership errors on the missing pivot timestamp columns.
+ */
+class CustomerSegmentMembershipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_user_can_be_attached_to_and_read_from_a_segment(): void
+    {
+        $user = User::factory()->create();
+        $segment = CustomerSegment::create(['name' => 'VIP', 'match_type' => 'all', 'conditions' => []]);
+
+        $user->customerSegments()->attach($segment->id);
+
+        $this->assertTrue($user->customerSegments()->where('customer_segments.id', $segment->id)->exists());
+        $this->assertNotNull($user->customerSegments()->first()->pivot->added_at);
+    }
+}

--- a/tests/Feature/GdprDataExportTest.php
+++ b/tests/Feature/GdprDataExportTest.php
@@ -17,7 +17,6 @@ use App\Models\Rating;
 use App\Models\Review;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 /**
@@ -141,11 +140,7 @@ class GdprDataExportTest extends TestCase
             'conditions' => [['field' => 'lifetime_value', 'operator' => '>', 'value' => 'SECRET-RULE-9000']],
             'match_type' => 'all',
         ]);
-        // Insert the pivot directly — the customerSegments() relation's withTimestamps()
-        // is incompatible with the pivot table (no created_at/updated_at).
-        DB::table('customer_segment_members')->insert([
-            'user_id' => $user->id, 'segment_id' => $segment->id, 'added_at' => now(),
-        ]);
+        $user->customerSegments()->attach($segment->id);
 
         $response = $this->actingAs($user)->getJson(route('account.data-export'));
 


### PR DESCRIPTION
## Bug

The `customer_segment_members` pivot tracks membership with its own `added_at` column and has **no** `created_at`/`updated_at`, but `User::customerSegments()` declared `->withTimestamps()`. So Laravel selected and wrote pivot timestamp columns that don’t exist — **any use of the relation, including `attach()`, threw a SQL error**. Surfaced while adding segment memberships to the GDPR export (#787), which worked around it with a direct join.

## Fix

`withPivot(added_at)` only, no `withTimestamps()`. The GDPR export drops its join workaround and uses the relation again.

## Tests (+1)

Attach a user to a segment, read it back, confirm the pivot `added_at` is populated.

Full suite **1150 passed**.
