### PR TITLE
feat(vat): net partial refunds out of the OSS/MOSS report

### DIFF
--- a/app/Services/OssReportService.php
+++ b/app/Services/OssReportService.php
@@ -16,9 +16,8 @@ class OssReportService
      * Statuses that count as a completed sale with VAT due. Excludes pending/failed/
      * cancelled (no sale) and fully refunded (VAT reversed).
      *
-     * ponytail: partially-refunded orders are counted at their full VAT — netting a
-     * partial VAT refund needs per-line refund data; revisit if partial refunds of EU
-     * orders become common.
+     * Partially-refunded orders are netted (see the query below): the report bills only
+     * the un-refunded fraction of the order and its VAT, using refund_total.
      */
     private const REPORTABLE_STATUSES = [
         Order::STATUS_PAID,
@@ -35,7 +34,12 @@ class OssReportService
             ->whereIn('status', self::REPORTABLE_STATUSES)
             ->whereIn('billing_country', EuVat::memberStates())
             ->whereBetween('created_at', [$from, $to])
-            ->selectRaw('billing_country, COUNT(*) as orders, SUM(total_amount) as gross, SUM(tax_amount) as vat')
+            // Net out partial refunds: bill only the un-refunded fraction of each order,
+            // and the same fraction of its VAT. Non-refunded orders (refund_total 0/null)
+            // are unaffected; fully-refunded orders are already excluded by status.
+            ->selectRaw('billing_country, COUNT(*) as orders, '
+                .'SUM(total_amount - COALESCE(refund_total, 0)) as gross, '
+                .'SUM(tax_amount * (total_amount - COALESCE(refund_total, 0)) / NULLIF(total_amount, 0)) as vat')
             ->groupBy('billing_country')
             ->orderBy('billing_country')
             ->get();

--- a/tests/Feature/OssReportServiceTest.php
+++ b/tests/Feature/OssReportServiceTest.php
@@ -82,4 +82,19 @@ class OssReportServiceTest extends TestCase
         $this->assertCount(1, $report['lines']);
         $this->assertSame(1, $report['lines'][0]['orders']);
     }
+
+    public function test_partially_refunded_orders_are_netted_by_the_refunded_fraction(): void
+    {
+        // €120 order (€20 VAT), half of it refunded → net €60 gross, €10 VAT, €50 net.
+        $order = $this->order('DE', 120.0, 20.0, 'partially_refunded', '2026-05-10');
+        $order->update(['refund_total' => 60.0]);
+        // A second, un-refunded order confirms the netting is per-order.
+        $this->order('DE', 60.0, 10.0, 'paid', '2026-05-11');
+
+        $de = collect($this->report()['lines'])->firstWhere('country', 'DE');
+
+        $this->assertSame(120.0, $de['gross']);   // 60 (netted order1) + 60 (order2)
+        $this->assertSame(20.0, $de['vat']);      // 10 (netted order1) + 10 (order2)
+        $this->assertSame(100.0, $de['net']);
+    }
 }


### PR DESCRIPTION
## What

The OSS/MOSS report counted **partially-refunded** orders at their **full VAT** (flagged as a `ponytail:` note in #776). Now it bills only the un-refunded fraction of each order, and the same fraction of its VAT, using `refund_total`:

```sql
gross = SUM(total_amount - COALESCE(refund_total, 0))
vat   = SUM(tax_amount * (total_amount - COALESCE(refund_total, 0)) / NULLIF(total_amount, 0))
```

- Non-refunded orders (`refund_total` 0/null) are unaffected.
- Fully-refunded orders stay excluded by status.
- `NULLIF` guards a zero-total order against divide-by-zero.

**Verified on MySQL 8.4** (division + `NULLIF` + `GROUP BY`) as well as sqlite — same netted result.

## Tests (+1)

A half-refunded €120 / €20-VAT order nets to €60 / €10 alongside a full order (confirms per-order netting).

Full suite **1150 passed**; the lone `--order-by=random` failure is the pre-existing Socialstream flake.
