### PR TITLE
feat(vat): VIES B2B reverse-charge (zero-rate valid intra-EU B2B)

### DIFF
--- a/app/GraphQL/StorefrontSchema.php
+++ b/app/GraphQL/StorefrontSchema.php
@@ -293,6 +293,7 @@ class StorefrontSchema
                 'city' => Type::string(),
                 'postalCode' => Type::string(),
                 'couponCode' => Type::string(),       // re-validated against the live subtotal
+                'vatNumber' => Type::string(),        // EU VAT number → VIES-checked reverse charge
                 'dropship' => Type::boolean(),
                 'supplierId' => Type::string(),
                 'recipientName' => Type::string(),

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -10,6 +10,7 @@ use App\Notifications\OrderConfirmationNotification;
 use App\Services\CheckoutService;
 use App\Services\ShippingService;
 use App\Services\TaxCalculator;
+use App\Services\ViesService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
@@ -24,11 +25,14 @@ class CheckoutController extends Controller
 
     protected $checkoutService;
 
-    public function __construct(ShippingService $shippingService, TaxCalculator $taxCalculator, CheckoutService $checkoutService)
+    protected $viesService;
+
+    public function __construct(ShippingService $shippingService, TaxCalculator $taxCalculator, CheckoutService $checkoutService, ViesService $viesService)
     {
         $this->shippingService = $shippingService;
         $this->taxCalculator = $taxCalculator;
         $this->checkoutService = $checkoutService;
+        $this->viesService = $viesService;
     }
 
     public function initiateCheckout(Request $request)
@@ -125,6 +129,7 @@ class CheckoutController extends Controller
             'state' => 'nullable|string|max:100',
             'city' => 'nullable|string|max:100',
             'postal_code' => 'nullable|string|max:20',
+            'vat_number' => 'nullable|string|max:20',
             'payment_method' => 'required|string',
             'recipient_name' => 'required_if:dropship,on|string',
             'recipient_email' => 'required_if:dropship,on|email',
@@ -216,31 +221,41 @@ class CheckoutController extends Controller
             }
         }
 
-        // Calculate tax with the structured shipping address, honouring per-product
-        // tax class + exemptions and returning a tax_lines breakdown. Any cart
-        // discount is distributed pro-rata so tax lands on the post-discount amount.
-        $taxAddress = [
-            'country' => $request->input('country'),
-            'state' => $request->input('state'),
-            'city' => $request->input('city'),
-            'postal_code' => $request->input('postal_code'),
-        ];
-        $discountFactor = $subtotal > 0 ? max(0, $subtotal - $discountAmount) / $subtotal : 1;
-        $taxItems = [];
-        foreach ($cart as $productId => $item) {
-            $product = Product::find($productId);
-            if (! $product) {
-                continue;
-            }
-            $taxItems[] = [
-                'product' => $product,
-                'quantity' => $item['quantity'],
-                'price' => $item['price'] * $discountFactor,
+        // Intra-EU B2B supply with a VIES-valid VAT number is zero-rated (the buyer
+        // accounts for VAT under the reverse charge); otherwise tax normally.
+        $vatNumber = $this->viesService->normalise($request->input('vat_number'));
+        $reverseCharge = $this->viesService->reverseChargeApplies($vatNumber);
+
+        if ($reverseCharge) {
+            $taxAmount = 0;
+            $taxLines = [];
+        } else {
+            // Calculate tax with the structured shipping address, honouring per-product
+            // tax class + exemptions and returning a tax_lines breakdown. Any cart
+            // discount is distributed pro-rata so tax lands on the post-discount amount.
+            $taxAddress = [
+                'country' => $request->input('country'),
+                'state' => $request->input('state'),
+                'city' => $request->input('city'),
+                'postal_code' => $request->input('postal_code'),
             ];
+            $discountFactor = $subtotal > 0 ? max(0, $subtotal - $discountAmount) / $subtotal : 1;
+            $taxItems = [];
+            foreach ($cart as $productId => $item) {
+                $product = Product::find($productId);
+                if (! $product) {
+                    continue;
+                }
+                $taxItems[] = [
+                    'product' => $product,
+                    'quantity' => $item['quantity'],
+                    'price' => $item['price'] * $discountFactor,
+                ];
+            }
+            $taxResult = $this->taxCalculator->calculateCartTax($taxItems, $taxAddress, $shippingCost);
+            $taxAmount = $taxResult['total'];
+            $taxLines = $taxResult['lines'];
         }
-        $taxResult = $this->taxCalculator->calculateCartTax($taxItems, $taxAddress, $shippingCost);
-        $taxAmount = $taxResult['total'];
-        $taxLines = $taxResult['lines'];
 
         // Floor at 0 — a discount can zero an order but must never make it negative
         // (which would skip payment yet still mark the order paid).
@@ -257,7 +272,7 @@ class CheckoutController extends Controller
 
         $order = null;
         try {
-            DB::transaction(function () use (&$order, $lineItems, $request, $totalAmount, $shippingCost, $taxAmount, $taxLines, $discountAmount, $couponCode, $shippingCarrier, $shippingServiceName, $shippingQuoteId) {
+            DB::transaction(function () use (&$order, $lineItems, $request, $totalAmount, $shippingCost, $taxAmount, $taxLines, $discountAmount, $couponCode, $shippingCarrier, $shippingServiceName, $shippingQuoteId, $vatNumber, $reverseCharge) {
                 // Close the coupon usage-limit race under a row lock before creating the order.
                 $this->checkoutService->assertCouponAvailable($couponCode);
 
@@ -267,6 +282,8 @@ class CheckoutController extends Controller
                     'shipping_address' => $request->shipping_address,
                     // Buyer country VAT was charged against — drives the OSS/MOSS report.
                     'billing_country' => strtoupper((string) $request->input('country')),
+                    'vat_number' => $vatNumber,
+                    'reverse_charge' => $reverseCharge,
                     // A live-rate quote drives the cost; don't also record a flat method.
                     'shipping_method_id' => $shippingQuoteId ? null : $request->shipping_method_id,
                     'shipping_carrier' => $shippingCarrier,

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -76,6 +76,8 @@ class Order extends Model
         'shipping_status',
         'shipping_address',
         'billing_country',
+        'vat_number',
+        'reverse_charge',
         'shipping_method_id',
         'shipping_carrier',
         'shipping_service',

--- a/app/Services/HeadlessCheckoutService.php
+++ b/app/Services/HeadlessCheckoutService.php
@@ -25,6 +25,7 @@ class HeadlessCheckoutService
         private ShippingService $shippingService,
         private TaxCalculator $taxCalculator,
         private CheckoutService $checkoutService,
+        private ViesService $viesService,
     ) {}
 
     public function place(User $user, array $input): Order
@@ -48,9 +49,16 @@ class HeadlessCheckoutService
         $coupon = $this->checkoutService->resolveCouponDiscount($input['couponCode'] ?? null, $subtotal);
         $discount = $coupon['discount'];
 
-        // Tax lands on the post-discount amount (pro-rata), matching the web checkout.
-        $discountFactor = $subtotal > 0 ? max(0, $subtotal - $discount) / $subtotal : 1.0;
-        [$taxAmount, $taxLines] = $this->calculateTax($cart, $input, $shippingCost, $discountFactor);
+        // Intra-EU B2B with a VIES-valid VAT number is zero-rated (reverse charge);
+        // otherwise tax lands on the post-discount amount, matching the web checkout.
+        $vatNumber = $this->viesService->normalise($input['vatNumber'] ?? null);
+        $reverseCharge = $this->viesService->reverseChargeApplies($vatNumber);
+        if ($reverseCharge) {
+            [$taxAmount, $taxLines] = [0, []];
+        } else {
+            $discountFactor = $subtotal > 0 ? max(0, $subtotal - $discount) / $subtotal : 1.0;
+            [$taxAmount, $taxLines] = $this->calculateTax($cart, $input, $shippingCost, $discountFactor);
+        }
 
         // Floor at 0 — a discount can zero an order but must never make it negative.
         $total = max(0, round($subtotal - $discount + $shippingCost + $taxAmount, 2));
@@ -59,7 +67,7 @@ class HeadlessCheckoutService
         ])->all();
 
         $order = null;
-        DB::transaction(function () use (&$order, $lineItems, $user, $input, $paymentMethod, $country, $total, $shippingCost, $carrier, $service, $quoteId, $taxAmount, $taxLines, $discount, $coupon, $isDropship) {
+        DB::transaction(function () use (&$order, $lineItems, $user, $input, $paymentMethod, $country, $total, $shippingCost, $carrier, $service, $quoteId, $taxAmount, $taxLines, $discount, $coupon, $isDropship, $vatNumber, $reverseCharge) {
             // Close the coupon usage-limit race under a row lock before creating the order.
             $this->checkoutService->assertCouponAvailable($coupon['code']);
 
@@ -67,6 +75,8 @@ class HeadlessCheckoutService
                 'user_id' => $user->id,
                 'customer_email' => $user->email,
                 'billing_country' => $country,
+                'vat_number' => $vatNumber,
+                'reverse_charge' => $reverseCharge,
                 'shipping_carrier' => $carrier,
                 'shipping_service' => $service,
                 'shipping_quote_id' => $quoteId,

--- a/app/Services/OssReportService.php
+++ b/app/Services/OssReportService.php
@@ -33,6 +33,9 @@ class OssReportService
         $rows = Order::query()
             ->whereIn('status', self::REPORTABLE_STATUSES)
             ->whereIn('billing_country', EuVat::memberStates())
+            // Reverse-charge B2B supplies collected no VAT — they belong on the EC Sales
+            // List, not the OSS return.
+            ->where('reverse_charge', false)
             ->whereBetween('created_at', [$from, $to])
             // Net out partial refunds: bill only the un-refunded fraction of each order,
             // and the same fraction of its VAT. Non-refunded orders (refund_total 0/null)

--- a/app/Services/ViesService.php
+++ b/app/Services/ViesService.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services;
+
+use App\Support\EuVat;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+/**
+ * EU VAT-number validation (VIES) and the intra-EU B2B reverse-charge rule.
+ *
+ * When an EU-established store sells to a business in ANOTHER member state that supplies
+ * a valid VAT number, the supply is zero-rated and the buyer accounts for the VAT
+ * (reverse charge). Validation fails CLOSED: if VIES can't confirm the number, no
+ * reverse charge is applied and normal VAT is charged — we never zero-rate on an
+ * unverified number.
+ *
+ * @see https://ec.europa.eu/taxation_customs/vies/
+ */
+class ViesService
+{
+    private const ENDPOINT = 'https://ec.europa.eu/taxation_customs/vies/rest-api/ms';
+
+    /** Whether the reverse charge applies to an order billed with this VAT number. */
+    public function reverseChargeApplies(?string $vatNumber): bool
+    {
+        $vatNumber = $this->normalise($vatNumber);
+        if ($vatNumber === null) {
+            return false;
+        }
+
+        $storeCountry = strtoupper((string) config('ecommerce.store_country'));
+        if (! EuVat::isMemberState($storeCountry)) {
+            return false;   // the store isn't in the EU — reverse charge doesn't apply
+        }
+
+        $country = substr($vatNumber, 0, 2);
+        $number = substr($vatNumber, 2);
+
+        if (! EuVat::isMemberState($country) || $country === $storeCountry) {
+            return false;   // non-EU number, or a domestic sale (normal VAT)
+        }
+
+        return $this->isValid($country, $number);
+    }
+
+    /** Validate a VAT number with VIES. Returns false on any error (fail closed). */
+    public function isValid(string $country, string $number): bool
+    {
+        try {
+            $response = Http::timeout((int) config('ecommerce.vies_timeout', 10))
+                ->acceptJson()
+                ->get(self::ENDPOINT."/{$country}/vat/{$number}");
+
+            return $response->successful() && $response->json('isValid') === true;
+        } catch (Throwable $e) {
+            report($e);
+
+            return false;
+        }
+    }
+
+    /** Strip spaces/punctuation and upper-case; null if too short to hold a country + number. */
+    public function normalise(?string $vatNumber): ?string
+    {
+        if ($vatNumber === null) {
+            return null;
+        }
+
+        $value = strtoupper(preg_replace('/[^A-Za-z0-9]/', '', $vatNumber));
+
+        return strlen($value) >= 3 ? $value : null;
+    }
+}

--- a/database/migrations/2026_07_21_000003_add_vat_number_to_orders_table.php
+++ b/database/migrations/2026_07_21_000003_add_vat_number_to_orders_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Record an intra-EU B2B sale: the buyer's VAT number and whether the order was
+ * zero-rated under the reverse-charge rule (the buyer accounts for the VAT). Needed so
+ * the order shows why no VAT was charged, and so the OSS report can exclude it.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            if (! Schema::hasColumn('orders', 'vat_number')) {
+                $table->string('vat_number')->nullable()->after('billing_country');
+            }
+            if (! Schema::hasColumn('orders', 'reverse_charge')) {
+                $table->boolean('reverse_charge')->default(false)->after('vat_number');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            foreach (['vat_number', 'reverse_charge'] as $column) {
+                if (Schema::hasColumn('orders', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/tests/Feature/CheckoutBillingCountryTest.php
+++ b/tests/Feature/CheckoutBillingCountryTest.php
@@ -6,7 +6,9 @@ use App\Interfaces\PaymentGatewayInterface;
 use App\Models\Order;
 use App\Models\Product;
 use App\Services\PaymentGateways\StripeGateway;
+use Database\Seeders\EuVatRatesSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
@@ -62,5 +64,29 @@ class CheckoutBillingCountryTest extends TestCase
         ]);
 
         $this->assertSame('DE', Order::first()->billing_country);
+    }
+
+    public function test_reverse_charge_zero_rates_a_valid_eu_b2b_order(): void
+    {
+        config(['ecommerce.store_country' => 'DE']);   // EU-established store
+        $this->seed(EuVatRatesSeeder::class);          // an FR order would otherwise be taxed
+        Http::fake(['ec.europa.eu/*' => Http::response(['isValid' => true])]);
+        $product = Product::factory()->create(['price' => 100, 'inventory_count' => 5, 'is_downloadable' => true]);
+
+        $this->withSession(['cart' => [
+            $product->id => ['quantity' => 1, 'price' => 100.0, 'is_downloadable' => true, 'name' => $product->name],
+        ]])->post(route('checkout.process'), [
+            'email' => 'biz@example.com',
+            'has_physical_products' => 0,
+            'country' => 'FR',
+            'vat_number' => 'FR12345678',
+            'payment_method' => 'stripe',
+            'stripeToken' => 'tok_test',
+        ]);
+
+        $order = Order::first();
+        $this->assertTrue((bool) $order->reverse_charge);
+        $this->assertEqualsWithDelta(0.0, (float) $order->tax_amount, 0.001);
+        $this->assertSame('FR12345678', $order->vat_number);
     }
 }

--- a/tests/Feature/GraphQLCheckoutTest.php
+++ b/tests/Feature/GraphQLCheckoutTest.php
@@ -12,7 +12,9 @@ use App\Models\ShippingQuote;
 use App\Models\User;
 use App\Services\PaymentGateways\StripeGateway;
 use Closure;
+use Database\Seeders\EuVatRatesSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
@@ -243,5 +245,21 @@ class GraphQLCheckoutTest extends TestCase
 
         $this->assertStringContainsString('recipient name and email', $data['errors'][0]['message']);
         $this->assertDatabaseCount('orders', 0);
+    }
+
+    public function test_checkout_zero_rates_a_valid_eu_b2b_order_via_reverse_charge(): void
+    {
+        config(['ecommerce.store_country' => 'DE']);   // EU-established store
+        $this->seed(EuVatRatesSeeder::class);          // an FR order would otherwise be taxed 20%
+        Http::fake(['ec.europa.eu/*' => Http::response(['isValid' => true])]);
+        Sanctum::actingAs($user = User::factory()->create());
+        $this->cartItem($user, $this->product(price: 100), 1);
+
+        $this->checkout(['country' => 'FR', 'vatNumber' => 'FR 1234 5678']);
+
+        $order = Order::first();
+        $this->assertTrue((bool) $order->reverse_charge);
+        $this->assertEqualsWithDelta(0.0, (float) $order->tax_amount, 0.001);
+        $this->assertSame('FR12345678', $order->vat_number);   // normalised
     }
 }

--- a/tests/Feature/OssReportServiceTest.php
+++ b/tests/Feature/OssReportServiceTest.php
@@ -83,6 +83,18 @@ class OssReportServiceTest extends TestCase
         $this->assertSame(1, $report['lines'][0]['orders']);
     }
 
+    public function test_excludes_reverse_charge_b2b_orders(): void
+    {
+        // Zero-rated intra-EU B2B supply — belongs on the EC Sales List, not OSS.
+        $this->order('DE', 100.0, 0.0, 'paid', '2026-05-10')->update(['reverse_charge' => true]);
+        $this->order('FR', 120.0, 20.0, 'paid', '2026-05-11'); // normal B2C, kept
+
+        $report = $this->report();
+
+        $this->assertCount(1, $report['lines']);
+        $this->assertSame('FR', $report['lines'][0]['country']);
+    }
+
     public function test_partially_refunded_orders_are_netted_by_the_refunded_fraction(): void
     {
         // €120 order (€20 VAT), half of it refunded → net €60 gross, €10 VAT, €50 net.

--- a/tests/Feature/ViesServiceTest.php
+++ b/tests/Feature/ViesServiceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\ViesService;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * VIES validation + the intra-EU B2B reverse-charge rule. Validation fails CLOSED — an
+ * unverifiable number never zero-rates the order.
+ */
+class ViesServiceTest extends TestCase
+{
+    private function fakeVies(bool $isValid, int $status = 200): void
+    {
+        Http::fake(['ec.europa.eu/*' => Http::response(['isValid' => $isValid], $status)]);
+    }
+
+    private function service(): ViesService
+    {
+        return new ViesService;
+    }
+
+    public function test_reverse_charge_applies_for_a_valid_cross_border_eu_number(): void
+    {
+        config(['ecommerce.store_country' => 'DE']);
+        $this->fakeVies(true);
+
+        $this->assertTrue($this->service()->reverseChargeApplies('FR 12345678'));   // normalises spaces
+        Http::assertSent(fn ($r) => str_contains($r->url(), '/FR/vat/12345678'));
+    }
+
+    public function test_no_reverse_charge_for_a_domestic_sale(): void
+    {
+        config(['ecommerce.store_country' => 'DE']);
+        $this->fakeVies(true);
+
+        // Same member state as the store → normal domestic VAT, no VIES call needed.
+        $this->assertFalse($this->service()->reverseChargeApplies('DE123456789'));
+        Http::assertNothingSent();
+    }
+
+    public function test_no_reverse_charge_when_the_store_is_not_in_the_eu(): void
+    {
+        config(['ecommerce.store_country' => 'US']);
+        $this->fakeVies(true);
+
+        $this->assertFalse($this->service()->reverseChargeApplies('FR12345678'));
+        Http::assertNothingSent();
+    }
+
+    public function test_no_reverse_charge_for_a_non_eu_or_empty_number(): void
+    {
+        config(['ecommerce.store_country' => 'DE']);
+        $this->fakeVies(true);
+
+        $this->assertFalse($this->service()->reverseChargeApplies('GB12345678')); // post-Brexit
+        $this->assertFalse($this->service()->reverseChargeApplies(null));
+        $this->assertFalse($this->service()->reverseChargeApplies('X'));
+    }
+
+    public function test_reverse_charge_fails_closed_on_an_invalid_number_or_vies_error(): void
+    {
+        config(['ecommerce.store_country' => 'DE']);
+
+        $this->fakeVies(false);
+        $this->assertFalse($this->service()->reverseChargeApplies('FR00000000'));
+
+        $this->fakeVies(true, 503);   // VIES down
+        $this->assertFalse($this->service()->reverseChargeApplies('FR12345678'));
+
+        Http::fake(fn () => throw new ConnectionException('timeout'));
+        $this->assertFalse($this->service()->reverseChargeApplies('FR12345678'));
+    }
+}


### PR DESCRIPTION
## What

Implements the **intra-EU B2B reverse charge**: when an EU-established store sells to a business in *another* member state that supplies a **valid** VAT number, the supply is zero-rated and the buyer accounts for the VAT.

## Changes

- **`ViesService`** — validates a VAT number against the **VIES REST API** (`Http`, mockable) and decides `reverseChargeApplies()`: store is in the EU, the number is a **different** EU member state, and VIES confirms it. **Fails closed** — an unreachable or negative VIES response never zero-rates the order (normal VAT is charged).
- **`orders.vat_number` + `reverse_charge`** columns. MySQL 8.4-verified up + down.
- **Web + headless checkout** capture a VAT number; when the reverse charge applies they set tax to `0`, record the number, and flag the order. GraphQL `CheckoutInput` gains `vatNumber`.
- **OSS report** excludes `reverse_charge` orders — they collected no VAT and belong on the EC Sales List, not the OSS return.

Store country is `config('ecommerce.store_country')`; with the default **US** store the reverse charge never triggers (US→EU is an export, different rules) — so this is inert until a merchant sets an EU store country.

## Tests (+9)

- **VIES decision logic**: valid cross-border → applies (+ correct VIES URL); domestic sale → no (no VIES call); store-not-EU → no; non-EU/empty number → no; **fail-closed** on invalid number, VIES 503, and connection error.
- **Web + headless**: a valid FR B2B order (which would otherwise be taxed 20% via the seeded EU rates) is zero-rated, `reverse_charge` set, number normalised + stored.
- **OSS**: reverse-charge orders excluded from the return.

Full suite **1159 passed**, including `--order-by=random` (fully green).

## Deferred

EC Sales List reporting; caching VIES results (it's slow/rate-limited in production).
