### PR TITLE
feat(vat): EC Sales List for zero-rated intra-EU B2B supplies

### DIFF
--- a/app/Console/Commands/GenerateEcSalesList.php
+++ b/app/Console/Commands/GenerateEcSalesList.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\EcSalesListService;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class GenerateEcSalesList extends Command
+{
+    protected $signature = 'vat:ec-sales-list
+        {--from= : Start date (Y-m-d); defaults to the start of the current quarter}
+        {--to= : End date (Y-m-d, inclusive); defaults to today}
+        {--csv : Output CSV instead of a table}';
+
+    protected $description = 'EC Sales List: zero-rated intra-EU B2B supplies per customer VAT number for a period';
+
+    public function handle(EcSalesListService $service): int
+    {
+        $from = $this->option('from') ? Carbon::parse($this->option('from'))->startOfDay() : Carbon::now()->firstOfQuarter()->startOfDay();
+        $to = $this->option('to') ? Carbon::parse($this->option('to'))->endOfDay() : Carbon::now()->endOfDay();
+
+        if ($to->lt($from)) {
+            $this->error('--to must not be before --from.');
+
+            return self::FAILURE;
+        }
+
+        $report = $service->report($from, $to);
+
+        if ($this->option('csv')) {
+            return $this->outputCsv($report);
+        }
+
+        $this->info("EC Sales List — {$report['from']} to {$report['to']} ({$report['currency']})");
+
+        if (empty($report['lines'])) {
+            $this->warn('No reverse-charge B2B supplies in this period.');
+
+            return self::SUCCESS;
+        }
+
+        $rows = [];
+        foreach ($report['lines'] as $l) {
+            $rows[] = [$l['country'], $l['vat_number'], $l['orders'], number_format($l['value'], 2)];
+        }
+
+        $this->table(['Country', 'Customer VAT no.', 'Orders', 'Value'], $rows);
+
+        $t = $report['totals'];
+        $this->info("Totals — customers: {$t['customers']}, orders: {$t['orders']}, value: ".number_format($t['value'], 2));
+
+        return self::SUCCESS;
+    }
+
+    private function outputCsv(array $report): int
+    {
+        $this->line('country,vat_number,orders,value');
+        foreach ($report['lines'] as $l) {
+            $this->line("{$l['country']},{$l['vat_number']},{$l['orders']},{$l['value']}");
+        }
+        $t = $report['totals'];
+        $this->line("TOTAL,,{$t['orders']},{$t['value']}");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Services/EcSalesListService.php
+++ b/app/Services/EcSalesListService.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Order;
+use Carbon\CarbonInterface;
+
+/**
+ * EC Sales List (ESL): the zero-rated intra-EU B2B supplies made to each VAT-registered
+ * customer over a period, declared per customer VAT number. The exact complement of the
+ * OSS return — a supply either charged VAT (OssReportService) or was reverse-charged
+ * (here), never both.
+ *
+ * Values are net by construction: a reverse-charge supply charges no VAT, so the order
+ * total IS the declarable supply value.
+ *
+ * ponytail: no goods/services indicator (0/3/2) — every line is one customer's total.
+ * Splitting per indicator needs a per-line goods-vs-digital-services classification and
+ * a decision on mixed orders; add it when a member state's filing format demands it.
+ */
+class EcSalesListService
+{
+    /**
+     * Statuses that count as a completed supply. Mirrors OssReportService: excludes
+     * pending/failed/cancelled (no supply) and fully refunded (supply reversed).
+     * Partially-refunded supplies are netted by refund_total in the query below.
+     */
+    private const REPORTABLE_STATUSES = [
+        Order::STATUS_PAID,
+        Order::STATUS_PROCESSING,
+        Order::STATUS_SUPPLIER_QUEUED,
+        Order::STATUS_SUPPLIER_FAILED,
+        Order::STATUS_COMPLETED,
+        Order::STATUS_PARTIALLY_REFUNDED,
+    ];
+
+    public function report(CarbonInterface $from, CarbonInterface $to): array
+    {
+        $rows = Order::query()
+            ->whereIn('status', self::REPORTABLE_STATUSES)
+            ->where('reverse_charge', true)
+            // A supply with no customer number can't be declared — and shouldn't exist,
+            // since reverse_charge is only set once a number validates against VIES.
+            ->whereNotNull('vat_number')
+            ->whereBetween('created_at', [$from, $to])
+            ->selectRaw('vat_number, COUNT(*) as orders, '
+                .'SUM(total_amount - COALESCE(refund_total, 0)) as value')
+            ->groupBy('vat_number')
+            // vat_number carries its country prefix, so this sorts by country then number.
+            ->orderBy('vat_number')
+            ->get();
+
+        // The country prefix is split off in PHP rather than SQL: an ESL line declares
+        // the country code and the number separately, and SUBSTRING dialects differ.
+        $lines = $rows->map(fn ($row) => [
+            'country' => substr((string) $row->vat_number, 0, 2),
+            'vat_number' => substr((string) $row->vat_number, 2),
+            'orders' => (int) $row->orders,
+            'value' => round((float) $row->value, 2),
+        ])->all();
+
+        return [
+            'from' => $from->toDateString(),
+            'to' => $to->toDateString(),
+            'currency' => config('ecommerce.currency', 'EUR'),
+            'lines' => $lines,
+            'totals' => [
+                'customers' => count($lines),
+                'orders' => array_sum(array_column($lines, 'orders')),
+                'value' => round(array_sum(array_column($lines, 'value')), 2),
+            ],
+        ];
+    }
+}

--- a/tests/Feature/EcSalesListCommandTest.php
+++ b/tests/Feature/EcSalesListCommandTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Order;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EcSalesListCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function reverseChargedFrenchOrder(): void
+    {
+        Order::create([
+            'customer_email' => 'buyer@example.com',
+            'total_amount' => 100.0,
+            'tax_amount' => 0.0,
+            'status' => 'paid',
+            'billing_country' => 'FR',
+            'vat_number' => 'FR12345678',
+            'reverse_charge' => true,
+        ])->forceFill(['created_at' => Carbon::parse('2026-05-10')])->save();
+    }
+
+    public function test_reports_b2b_supplies_for_the_period(): void
+    {
+        $this->reverseChargedFrenchOrder();
+
+        $this->artisan('vat:ec-sales-list', ['--from' => '2026-04-01', '--to' => '2026-06-30'])
+            ->expectsOutputToContain('12345678')
+            ->assertSuccessful();
+    }
+
+    public function test_warns_when_no_b2b_supplies(): void
+    {
+        $this->artisan('vat:ec-sales-list', ['--from' => '2026-04-01', '--to' => '2026-06-30'])
+            ->expectsOutputToContain('No reverse-charge B2B supplies')
+            ->assertSuccessful();
+    }
+
+    public function test_rejects_an_inverted_date_range(): void
+    {
+        $this->artisan('vat:ec-sales-list', ['--from' => '2026-06-30', '--to' => '2026-04-01'])
+            ->assertFailed();
+    }
+
+    public function test_csv_output(): void
+    {
+        $this->reverseChargedFrenchOrder();
+
+        $this->artisan('vat:ec-sales-list', ['--from' => '2026-04-01', '--to' => '2026-06-30', '--csv' => true])
+            ->expectsOutputToContain('country,vat_number,orders,value')
+            ->expectsOutputToContain('FR,12345678,1,100')
+            ->assertSuccessful();
+    }
+}

--- a/tests/Feature/EcSalesListServiceTest.php
+++ b/tests/Feature/EcSalesListServiceTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Order;
+use App\Services\EcSalesListService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EcSalesListServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function order(?string $vatNumber, float $value, string $status, string $date, bool $reverseCharge = true): Order
+    {
+        $order = Order::create([
+            'customer_email' => 'buyer@example.com',
+            'total_amount' => $value,
+            'tax_amount' => $reverseCharge ? 0.0 : round($value * 0.2, 2),
+            'status' => $status,
+            'billing_country' => $vatNumber !== null ? substr($vatNumber, 0, 2) : 'DE',
+            'vat_number' => $vatNumber,
+            'reverse_charge' => $reverseCharge,
+        ]);
+        $order->forceFill(['created_at' => Carbon::parse($date)])->save();
+
+        return $order;
+    }
+
+    private function report(): array
+    {
+        return app(EcSalesListService::class)->report(
+            Carbon::parse('2026-04-01')->startOfDay(),
+            Carbon::parse('2026-06-30')->endOfDay(),
+        );
+    }
+
+    public function test_aggregates_net_supplies_per_customer_vat_number(): void
+    {
+        $this->order('FR12345678', 100.0, 'paid', '2026-04-10');
+        $this->order('FR12345678', 250.0, 'completed', '2026-05-02');
+        $this->order('IE9876543A', 400.0, 'paid', '2026-06-15');
+
+        $report = $this->report();
+
+        $this->assertCount(2, $report['lines']);
+
+        $fr = collect($report['lines'])->firstWhere('vat_number', '12345678');
+        $this->assertSame('FR', $fr['country']);
+        $this->assertSame(2, $fr['orders']);
+        $this->assertSame(350.0, $fr['value']);
+
+        $this->assertSame(750.0, $report['totals']['value']);
+        $this->assertSame(3, $report['totals']['orders']);
+        $this->assertSame(2, $report['totals']['customers']);
+    }
+
+    public function test_splits_the_country_prefix_off_the_vat_number(): void
+    {
+        // An ESL line declares the country code and the number separately.
+        $this->order('IE9876543A', 400.0, 'paid', '2026-06-15');
+
+        $line = $this->report()['lines'][0];
+
+        $this->assertSame('IE', $line['country']);
+        $this->assertSame('9876543A', $line['vat_number']);
+    }
+
+    public function test_excludes_b2c_orders_that_charged_vat(): void
+    {
+        // Normal VAT-charged B2C sale — belongs on the OSS return, not the ESL.
+        $this->order(null, 120.0, 'paid', '2026-04-10', reverseCharge: false);
+
+        $this->assertSame([], $this->report()['lines']);
+    }
+
+    public function test_excludes_an_order_that_supplied_a_vat_number_but_was_still_charged_vat(): void
+    {
+        // A number that VIES couldn't confirm is persisted, but fails closed to normal
+        // VAT — so the order is an OSS supply despite carrying a vat_number. Selecting
+        // on the number alone would wrongly zero-rate it on the return.
+        $this->order('FR12345678', 120.0, 'paid', '2026-04-10', reverseCharge: false);
+
+        $this->assertSame([], $this->report()['lines']);
+    }
+
+    public function test_excludes_unpaid_and_fully_refunded_orders(): void
+    {
+        $this->order('FR12345678', 100.0, 'pending', '2026-04-10');
+        $this->order('FR12345678', 100.0, 'failed', '2026-04-11');
+        $this->order('FR12345678', 100.0, 'cancelled', '2026-04-12');
+        $this->order('FR12345678', 100.0, 'refunded', '2026-04-13');
+
+        $this->assertSame([], $this->report()['lines']);
+    }
+
+    public function test_respects_the_date_range(): void
+    {
+        $this->order('FR12345678', 100.0, 'paid', '2026-03-31'); // before window
+        $this->order('FR12345678', 100.0, 'paid', '2026-07-01'); // after window
+        $this->order('FR12345678', 100.0, 'paid', '2026-05-15'); // inside
+
+        $report = $this->report();
+
+        $this->assertCount(1, $report['lines']);
+        $this->assertSame(100.0, $report['lines'][0]['value']);
+    }
+
+    public function test_partially_refunded_supplies_are_netted_by_the_refunded_amount(): void
+    {
+        // €200 supply, €50 refunded → €150 declared.
+        $this->order('FR12345678', 200.0, 'partially_refunded', '2026-05-10')
+            ->update(['refund_total' => 50.0]);
+
+        $this->assertSame(150.0, $this->report()['lines'][0]['value']);
+    }
+
+    public function test_ignores_a_reverse_charge_order_with_no_vat_number(): void
+    {
+        // Can't be declared without a customer number — and shouldn't exist (ViesService
+        // only sets reverse_charge when a number validated), so it must not silently
+        // land on the return as a blank line.
+        $this->order(null, 100.0, 'paid', '2026-04-10');
+
+        $this->assertSame([], $this->report()['lines']);
+    }
+}


### PR DESCRIPTION
## What

The **EC Sales List** — the quarterly declaration of zero-rated intra-EU B2B supplies, per customer VAT number.

This is the exact complement of the OSS return (#776 / #789). A supply either charged VAT and lands on OSS, or it was reverse-charged (#790) and must be declared here. Never both. `OssReportService` already excluded reverse-charge orders with a comment pointing at this report — this closes that loop.

Pure aggregate over data #790 already persists: **no schema change, no external call, no new dependency.**

```bash
php artisan vat:ec-sales-list --from=2026-04-01 --to=2026-06-30
php artisan vat:ec-sales-list --csv        # defaults to the current quarter
```

| Country | Customer VAT no. | Orders | Value |
|---|---|---|---|
| FR | 12345678 | 2 | 350.00 |
| IE | 9876543A | 1 | 400.00 |

## How

`EcSalesListService::report(from, to)` — `reverse_charge` supplies grouped by customer `vat_number`, netted by `refund_total`, mirroring OSS's reportable statuses (excludes pending / failed / cancelled / fully-refunded).

Decisions worth flagging:

- **Values are net by construction.** A reverse-charge supply charges no VAT, so the order total *is* the declarable supply value.
- **The country prefix is split off in PHP, not SQL.** An ESL line declares country and number separately, and `SUBSTRING` dialects differ.
- **A `reverse_charge` order with no `vat_number` is skipped.** It can't be declared, and shouldn't exist — `ViesService` only sets the flag once a number validates — so it must not silently land as a blank line.

## Testing

12 tests. Full suite **1171 passed**.

Two findings worth surfacing:

**Mutation testing caught a weak test.** The tests went green on first run (Docker was down while I wrote them, so I never saw a real RED). Mutating the service to prove they bite showed that **deleting the `reverse_charge` filter broke nothing** — the B2C exclusion test used a null `vat_number`, so `whereNotNull` was catching it, not the filter under test. It passed for the wrong reason.

The gap was real, not cosmetic: a VIES-failed order persists `vat_number` **and** `reverse_charge = false` (validation fails closed → normal VAT charged). That order belongs on OSS, and selecting on the number alone would wrongly zero-rate it on the return. Added `test_excludes_an_order_that_supplied_a_vat_number_but_was_still_charged_vat`, which does fail against the mutant.

**MySQL-verified.** Ran against a disposable MySQL 8.4 with `ONLY_FULL_GROUP_BY` on — confirmed the `GROUP BY` holds and the refund netting is right (200 − 50 = 150). sqlite would catch neither.

## Deferred

No goods/services indicator (`0`/`3`/`2`) — every line is one customer's total. Splitting per indicator needs per-line goods-vs-digital-services classification plus a rule for mixed orders. Flagged with a `ponytail:` note on the service; add it when a member state's filing format demands it.
