### PR TITLE
Security: fix the OWASP audit findings (dropshipping RCE-equivalent, credential leaks, headers)

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -7,6 +7,7 @@ use Illuminate\Database\QueryException;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
@@ -75,15 +76,18 @@ class CreateNewUser implements CreatesNewUsers
         } catch (ValidationException $e) {
             Log::error('User creation validation failed', [
                 'errors' => $e->errors(),
-                'input' => array_diff_key($input, array_flip(['password'])),
+                // ponytail: allowlist, not a denylist. 'password_confirmation' holds the
+                // same plaintext as 'password'; a denylist leaks every field we forget.
+                'input' => Arr::only($input, ['name', 'email']),
             ]);
             throw $e;
         } catch (QueryException $e) {
+            // No 'message'/'bindings': QueryException::formatMessage() interpolates the
+            // bindings into the message, so both carry the bcrypt hash. getSql() keeps
+            // its '?' placeholders and is safe.
             Log::error('Database error during user creation', [
-                'message' => $e->getMessage(),
                 'code' => $e->getCode(),
                 'sql' => $e->getSql(),
-                'bindings' => $e->getBindings(),
             ]);
             throw new Exception($this->getDatabaseErrorMessage($e));
         } catch (RoleDoesNotExist $e) {

--- a/app/Http/Controllers/Api/DropshippingController.php
+++ b/app/Http/Controllers/Api/DropshippingController.php
@@ -2,30 +2,32 @@
 
 namespace App\Http\Controllers\Api;
 
-use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
 use App\Services\DropshippingService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 
 class DropshippingController extends Controller
 {
     protected $dropshippingService;
-    
+
     public function __construct(DropshippingService $dropshippingService)
     {
         $this->dropshippingService = $dropshippingService;
     }
-    
+
     /**
      * Get all available suppliers
      *
      * @return JsonResponse
      */
-    public function suppliers()
+    public function suppliers(Request $request)
     {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
         $suppliers = $this->dropshippingService->getSuppliers();
-        
+
         // Remove sensitive information like API keys
         $sanitizedSuppliers = [];
         foreach ($suppliers as $id => $supplier) {
@@ -34,86 +36,89 @@ class DropshippingController extends Controller
                 'description' => $supplier['description'],
             ];
         }
-        
+
         return response()->json(['suppliers' => $sanitizedSuppliers]);
     }
-    
+
     /**
      * Check product availability
      *
-     * @param Request $request
      * @return JsonResponse
      */
     public function checkAvailability(Request $request)
     {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
         $validator = Validator::make($request->all(), [
             'supplier_id' => 'required|string',
             'sku' => 'required|string',
             'quantity' => 'sometimes|integer|min:1',
         ]);
-        
+
         if ($validator->fails()) {
             return response()->json(['success' => false, 'errors' => $validator->errors()], 422);
         }
-        
+
         $result = $this->dropshippingService->checkAvailability(
             $request->supplier_id,
             $request->sku,
             $request->quantity ?? 1
         );
-        
+
         return response()->json($result, $result['success'] ? 200 : 400);
     }
-    
+
     /**
      * Place an order with a supplier
      *
-     * @param Request $request
      * @return JsonResponse
      */
     public function placeOrder(Request $request)
     {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
         $validator = Validator::make($request->all(), [
             'supplier_id' => 'required|string',
             'order_data' => 'required|array',
             'order_data.items' => 'required|array',
             'order_data.shipping_address' => 'required|array',
         ]);
-        
+
         if ($validator->fails()) {
             return response()->json(['success' => false, 'errors' => $validator->errors()], 422);
         }
-        
+
         $result = $this->dropshippingService->placeOrder(
             $request->supplier_id,
             $request->order_data
         );
-        
+
         return response()->json($result, $result['success'] ? 200 : 400);
     }
-    
+
     /**
      * Track an order
      *
-     * @param Request $request
      * @return JsonResponse
      */
     public function trackOrder(Request $request)
     {
+        abort_unless($request->user()?->hasRole(['super_admin', 'admin']), 403);
+
         $validator = Validator::make($request->all(), [
             'supplier_id' => 'required|string',
             'order_reference' => 'required|string',
         ]);
-        
+
         if ($validator->fails()) {
             return response()->json(['success' => false, 'errors' => $validator->errors()], 422);
         }
-        
+
         $result = $this->dropshippingService->trackOrder(
             $request->supplier_id,
             $request->order_reference
         );
-        
+
         return response()->json($result, $result['success'] ? 200 : 400);
     }
 }

--- a/app/Http/Controllers/Api/WebhookEndpointController.php
+++ b/app/Http/Controllers/Api/WebhookEndpointController.php
@@ -8,6 +8,7 @@ use Closure;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use Illuminate\Support\Uri;
 
 class WebhookEndpointController extends Controller
 {
@@ -90,7 +91,8 @@ class WebhookEndpointController extends Controller
     private function urlRules(string $presence): array
     {
         return [$presence, 'url:https', function (string $attribute, mixed $value, Closure $fail): void {
-            $host = trim((string) parse_url((string) $value, PHP_URL_HOST), '[]');
+            // trim('[]') unwraps bracketed IPv6 literals, which Uri::host() preserves.
+            $host = trim((string) Uri::of((string) $value)->host(), '[]');
 
             // ponytail: a host that doesn't resolve now is allowed through (test and
             // staging hostnames are routinely resolvable only from the delivery box).
@@ -100,7 +102,7 @@ class WebhookEndpointController extends Controller
 
             foreach ($ips as $ip) {
                 if (! filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
-                    $fail('The :attribute must not point at a private or reserved network address.');
+                    $fail("The {$attribute} must not point at a private or reserved network address.");
 
                     return;
                 }

--- a/app/Http/Controllers/Api/WebhookEndpointController.php
+++ b/app/Http/Controllers/Api/WebhookEndpointController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\WebhookEndpoint;
+use Closure;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -22,14 +23,15 @@ class WebhookEndpointController extends Controller
         $this->authorizeStaff($request);
 
         $validated = $request->validate([
-            'url' => 'required|url',
+            'url' => $this->urlRules('required'),
             'events' => 'required|array|min:1',
             'events.*' => 'required|string',
             'is_active' => 'sometimes|boolean',
         ]);
 
         // The signing secret is generated server-side and returned once, so the
-        // receiver can verify the X-Webhook-Signature.
+        // receiver can verify the X-Webhook-Signature. The model hides it from
+        // every other response, so this one has to opt back in.
         $endpoint = WebhookEndpoint::create([
             'url' => $validated['url'],
             'events' => $validated['events'],
@@ -37,7 +39,7 @@ class WebhookEndpointController extends Controller
             'secret' => 'whsec_'.Str::random(40),
         ]);
 
-        return response()->json($endpoint, 201);
+        return response()->json($endpoint->makeVisible('secret'), 201);
     }
 
     public function update(Request $request, WebhookEndpoint $webhookEndpoint): JsonResponse
@@ -45,7 +47,7 @@ class WebhookEndpointController extends Controller
         $this->authorizeStaff($request);
 
         $validated = $request->validate([
-            'url' => 'sometimes|url',
+            'url' => $this->urlRules('sometimes'),
             'events' => 'sometimes|array|min:1',
             'events.*' => 'required|string',
             'is_active' => 'sometimes|boolean',
@@ -76,6 +78,34 @@ class WebhookEndpointController extends Controller
             ->paginate(25);
 
         return response()->json($deliveries);
+    }
+
+    /**
+     * SendWebhookDelivery posts to this URL verbatim and logs the status code and
+     * error body back to the deliveries endpoint, so an unchecked host makes this
+     * an SSRF probe against anything the app can reach (cloud metadata, internal
+     * services). Require https and refuse hosts that resolve into private or
+     * reserved space.
+     */
+    private function urlRules(string $presence): array
+    {
+        return [$presence, 'url:https', function (string $attribute, mixed $value, Closure $fail): void {
+            $host = trim((string) parse_url((string) $value, PHP_URL_HOST), '[]');
+
+            // ponytail: a host that doesn't resolve now is allowed through (test and
+            // staging hostnames are routinely resolvable only from the delivery box).
+            // Resolution here can't be authoritative anyway — DNS can rebind between
+            // this check and the job. Block at egress if that gap ever matters.
+            $ips = filter_var($host, FILTER_VALIDATE_IP) ? [$host] : (gethostbynamel($host) ?: []);
+
+            foreach ($ips as $ip) {
+                if (! filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+                    $fail('The :attribute must not point at a private or reserved network address.');
+
+                    return;
+                }
+            }
+        }];
     }
 
     private function authorizeStaff(Request $request): void

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -6,6 +6,7 @@ use App\Http\Middleware\TrustProxies;
 use Illuminate\Http\Middleware\HandleCors;
 use App\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Foundation\Http\Middleware\ValidatePostSize;
+use App\Http\Middleware\SecurityHeaders;
 use App\Http\Middleware\TrimStrings;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use App\Http\Middleware\EncryptCookies;
@@ -45,6 +46,7 @@ class Kernel extends HttpKernel
         ValidatePostSize::class,
         TrimStrings::class,
         ConvertEmptyStringsToNull::class,
+        SecurityHeaders::class,
     ];
 
     /**

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+    /**
+     * Content-Security-Policy directives.
+     *
+     * 'unsafe-eval' + 'unsafe-inline' are required by Livewire/Alpine (which eval
+     * expressions from x-* attributes) and Filament (which injects inline styles).
+     * img-src allows https:/data: because product images come from arbitrary
+     * merchant URLs (seed data uses https://placehold.co).
+     */
+    private const CSP = [
+        "default-src 'self'",
+        "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data: https:",
+        "font-src 'self' data:",
+        "connect-src 'self' ws: wss:",
+        "frame-ancestors 'self'",
+        "base-uri 'self'",
+        "form-action 'self'",
+    ];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+
+        // ponytail: Report-Only until the violation reports come back clean. Filament,
+        // Livewire and Vite each pull in scripts/styles this policy has not been proven
+        // against, and a wrong CSP breaks checkout silently. Flip to the enforcing
+        // 'Content-Security-Policy' header once reports show no legitimate violations.
+        $response->headers->set('Content-Security-Policy-Report-Only', implode('; ', self::CSP));
+
+        // Never send HSTS over plain HTTP: a browser would pin the host to https and
+        // lock out local dev, which serves http://localhost:8000.
+        if ($request->secure()) {
+            $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+        }
+
+        return $response;
+    }
+}

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -10,9 +10,18 @@ class TrustProxies extends Middleware
     /**
      * The trusted proxies for this application.
      *
+     * '*' trusts the immediate caller (REMOTE_ADDR), which is safe here because the
+     * app is only ever reached through a proxy — nginx in dev, the k8s/Traefik ingress
+     * in prod — and never exposed directly. Trusting nothing was worse than it looked:
+     * X-Forwarded-For was ignored, so $request->ip() returned the proxy's IP for every
+     * client, collapsing per-IP throttles into one shared bucket (one attacker throttles
+     * all guests) and leaving $request->isSecure() false behind TLS termination.
+     *
+     * If the app is ever exposed directly, replace '*' with the ingress CIDRs.
+     *
      * @var array<int, string>|string|null
      */
-    protected $proxies;
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.

--- a/app/Listeners/LogAuthenticationFailure.php
+++ b/app/Listeners/LogAuthenticationFailure.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Lockout;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Records failed logins and throttle lockouts.
+ *
+ * Fortify throttles login at 5/min, but nothing was recording the attempts, so
+ * credential stuffing left no trace at all (OWASP A09). Without this, the first
+ * evidence of an attack is a support ticket.
+ */
+class LogAuthenticationFailure
+{
+    public function handleFailed(Failed $event): void
+    {
+        // Whitelist the email explicitly. $event->credentials also holds the
+        // submitted *password*, so this must never log the array wholesale.
+        Log::warning('Failed login attempt', [
+            'email' => $event->credentials['email'] ?? null,
+            'ip' => request()->ip(),
+            'user_agent' => mb_substr((string) request()->userAgent(), 0, 200),
+            // Separates "wrong password on a real account" (targeted) from
+            // "probing an address that doesn't exist" (spray).
+            'account_exists' => $event->user !== null,
+            'guard' => $event->guard,
+        ]);
+    }
+
+    public function handleLockout(Lockout $event): void
+    {
+        Log::warning('Login throttled after repeated failures', [
+            'email' => $event->request->input('email'),
+            'ip' => $event->request->ip(),
+        ]);
+    }
+}

--- a/app/Models/WebhookEndpoint.php
+++ b/app/Models/WebhookEndpoint.php
@@ -12,6 +12,9 @@ class WebhookEndpoint extends Model
 
     protected $fillable = ['url', 'secret', 'events', 'is_active'];
 
+    /** The signing secret is returned once at creation (see the controller's store) and never serialised again. */
+    protected $hidden = ['secret'];
+
     protected $casts = [
         'events' => 'array',
         'is_active' => 'boolean',

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,7 +2,10 @@
 
 namespace App\Providers;
 
+use App\Listeners\LogAuthenticationFailure;
 use App\Listeners\MergeGuestCartOnLogin;
+use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Lockout;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
@@ -22,6 +25,14 @@ class EventServiceProvider extends ServiceProvider
         ],
         Login::class => [
             MergeGuestCartOnLogin::class,
+        ],
+        // Nothing recorded authentication failures, so credential stuffing against
+        // Fortify's 5/min throttle left no trace at all (OWASP A09).
+        Failed::class => [
+            LogAuthenticationFailure::class.'@handleFailed',
+        ],
+        Lockout::class => [
+            LogAuthenticationFailure::class.'@handleLockout',
         ],
     ];
 

--- a/config/cors.php
+++ b/config/cors.php
@@ -17,13 +17,27 @@ return [
 
     'paths' => ['api/*', 'sanctum/csrf-cookie'],
 
-    'allowed_methods' => ['*'],
+    'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
 
-    'allowed_origins' => ['*'],
+    /*
+     * Was ['*'], which let any origin read every API response. supports_credentials
+     * is false (below), so this was never a cookie-auth data-theft hole — but a
+     * wildcard is still a bad default for an API that serves order and customer data
+     * to token-holders.
+     *
+     * Set CORS_ALLOWED_ORIGINS as a comma-separated list, e.g.
+     *   CORS_ALLOWED_ORIGINS=https://shop.example.com,https://admin.example.com
+     * Empty (the default) means no cross-origin browser access at all, which is
+     * correct for a same-origin storefront; server-to-server API clients are
+     * unaffected because CORS is a browser mechanism.
+     */
+    'allowed_origins' => array_values(array_filter(
+        array_map('trim', explode(',', (string) env('CORS_ALLOWED_ORIGINS', '')))
+    )),
 
     'allowed_origins_patterns' => [],
 
-    'allowed_headers' => ['*'],
+    'allowed_headers' => ['Accept', 'Authorization', 'Content-Type', 'X-Requested-With', 'X-XSRF-TOKEN'],
 
     'exposed_headers' => [],
 

--- a/config/cors.php
+++ b/config/cors.php
@@ -31,9 +31,9 @@ return [
      * correct for a same-origin storefront; server-to-server API clients are
      * unaffected because CORS is a browser mechanism.
      */
-    'allowed_origins' => array_values(array_filter(
-        array_map('trim', explode(',', (string) env('CORS_ALLOWED_ORIGINS', '')))
-    )),
+    'allowed_origins' => preg_split(
+        '/\s*,\s*/', (string) env('CORS_ALLOWED_ORIGINS', ''), -1, PREG_SPLIT_NO_EMPTY
+    ) ?: [],
 
     'allowed_origins_patterns' => [],
 

--- a/config/session.php
+++ b/config/session.php
@@ -168,7 +168,12 @@ return [
     |
     */
 
-    'secure' => env('SESSION_SECURE_COOKIE'),
+    // Secure-by-default outside local/testing. This was env('SESSION_SECURE_COOKIE')
+    // with no default, and nothing set that variable in .env.example, docker-compose
+    // or k8s/configmap.yaml — so the session cookie shipped without the Secure flag
+    // everywhere. The k8s ingress does an ssl-redirect, and the pre-redirect plaintext
+    // request carries the cookie. Opt out per-environment if you genuinely serve HTTP.
+    'secure' => env('SESSION_SECURE_COOKIE', ! in_array(env('APP_ENV', 'production'), ['local', 'testing'], true)),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/socialstream.php
+++ b/config/socialstream.php
@@ -37,9 +37,9 @@ return [
     | Note that `linkedin` and `linkedin-openid` both render as "LinkedIn"; pick one.
     |
     */
-    'providers' => array_values(array_filter(
-        array_map('trim', explode(',', (string) env('SOCIALSTREAM_PROVIDERS', '')))
-    )),
+    'providers' => preg_split(
+        '/\s*,\s*/', (string) env('SOCIALSTREAM_PROVIDERS', ''), -1, PREG_SPLIT_NO_EMPTY
+    ) ?: [],
     'features' => [
         Features::generateMissingEmails(),
         Features::createAccountOnFirstLogin(),

--- a/public/installer.php
+++ b/public/installer.php
@@ -3,9 +3,19 @@
 // Place this file at public/installer.php
 //
 // Security:
-// - Set INSTALLER_ENABLED=true in .env to enable this UI.
-// - Optionally set INSTALLER_KEY in .env and provide ?key=... or send key in POST to authenticate.
-// - Remove/disable after use.
+// - Set INSTALLER_ENABLED=true in .env to enable this UI. Disabled by default.
+// - INSTALLER_KEY is REQUIRED, not optional: enabling without one used to grant
+//   anonymous access to every action below, which includes shelling out
+//   (composer_install, npm_build, migrate_seed), rewriting .env (save_settings)
+//   and minting a user with any role (create_users). That is unauthenticated RCE.
+//   check_key() now fails closed: no key set, no access.
+// - Remove this file after use. Nothing in the docs or setup.sh needs it —
+//   setup.sh already performs the same install steps from the CLI.
+//
+// Residual risk, deliberately left alone here because fixing it is a UX change:
+// the key is read from $_REQUEST and this file redirects it into the query
+// string, so it lands in access logs, Referer headers and browser history.
+// Treat INSTALLER_KEY as burned after use.
 
 function dotenv_get($key) {
     // Try getenv first
@@ -43,7 +53,10 @@ function enabled() {
 
 function check_key() {
     $required = dotenv_get('INSTALLER_KEY');
-    if ($required === false || $required === '') return true; // not configured
+    // Fail closed. This previously returned true when no key was configured,
+    // so INSTALLER_ENABLED=true on its own exposed shell execution, .env rewrite
+    // and arbitrary-role user creation to anyone who found the URL.
+    if ($required === false || $required === '') return false;
     $provided = $_REQUEST['key'] ?? null;
     return is_string($provided) && hash_equals((string)$required, (string)$provided);
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,7 +33,8 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 // controller — the catalog is open, me/orders + mutations require a token.
 Route::post('/graphql', GraphQLController::class);
 
-// Dropshipping API routes
+// Dropshipping API routes (staff-only: these spend the merchant's supplier API key,
+// so every method role-checks in the controller — there is no `role:` middleware alias here).
 Route::middleware('auth:sanctum')->prefix('dropshipping')->group(function () {
     Route::get('/suppliers', [DropshippingController::class, 'suppliers']);
     Route::post('/check-availability', [DropshippingController::class, 'checkAvailability']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,7 +63,7 @@ Route::middleware('auth')->group(function () {
     Route::post('/wishlist/share', [WishlistController::class, 'share'])->name('wishlist.share');
 });
 Route::get('/products', [ProductController::class, 'index'])->name('products.index');
-Route::get('/products/search', [ProductController::class, 'search'])->name('products.search');
+Route::get('/products/search', [ProductController::class, 'search'])->name('products.search')->middleware('throttle:30,1');
 Route::get('/products/{product}', [ProductController::class, 'show'])->name('products.show');
 Route::post('/products/{product}/notify-me', [ProductController::class, 'notifyMe'])->name('products.notify-me')->middleware('throttle:10,1');
 
@@ -83,7 +83,9 @@ Route::get('/tags/{tag}', [ProductTagController::class, 'show'])->name('tags.sho
 
 // Checkout routes
 Route::get('/checkout', [CheckoutController::class, 'initiateCheckout'])->name('checkout.initiate');
-Route::post('/checkout/process', [CheckoutController::class, 'processCheckout'])->name('checkout.process');
+// Throttled: guest checkout captures payment with a posted card token, so an
+// unbounded route is a card-testing / BIN-enumeration oracle on our Stripe account.
+Route::post('/checkout/process', [CheckoutController::class, 'processCheckout'])->name('checkout.process')->middleware('throttle:10,1');
 // Live carrier rates for the current cart + destination — each is persisted as a
 // session-scoped quote the buyer then selects by id (server bills the stored amount).
 Route::post('/checkout/shipping-rates', [CheckoutController::class, 'shippingRates'])->name('checkout.shipping-rates');

--- a/tests/Feature/Api/DropshippingAuthorizationTest.php
+++ b/tests/Feature/Api/DropshippingAuthorizationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * The dropshipping endpoints spend the merchant's supplier API key on a caller-supplied
+ * payload — they are staff-only. Any authenticated customer reaching them means real goods
+ * ship anywhere, billed to the merchant.
+ */
+class DropshippingAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        return User::factory()->create()->assignRole('super_admin');
+    }
+
+    /**
+     * Valid payloads, so a 403 proves the role guard fired — not the validator.
+     *
+     * @return array<string, array{0: string, 1: string, 2: array<string, mixed>}>
+     */
+    public static function endpoints(): array
+    {
+        return [
+            'suppliers' => ['getJson', '/api/dropshipping/suppliers', []],
+            'check-availability' => ['postJson', '/api/dropshipping/check-availability', [
+                'supplier_id' => 'dropxl',
+                'sku' => 'SKU-1',
+                'quantity' => 1,
+            ]],
+            'place-order' => ['postJson', '/api/dropshipping/place-order', [
+                'supplier_id' => 'dropxl',
+                'order_data' => [
+                    'items' => [['sku' => 'SKU-1', 'quantity' => 1]],
+                    'shipping_address' => ['line1' => '1 Attacker St', 'city' => 'Nowhere'],
+                ],
+            ]],
+            'track-order' => ['postJson', '/api/dropshipping/track-order', [
+                'supplier_id' => 'dropxl',
+                'order_reference' => 'REF-1',
+            ]],
+        ];
+    }
+
+    #[DataProvider('endpoints')]
+    public function test_authenticated_non_staff_user_is_forbidden(string $method, string $uri, array $payload): void
+    {
+        Http::preventStrayRequests(); // a 403 must happen before any supplier call
+        Sanctum::actingAs(User::factory()->create());
+
+        $this->{$method}($uri, $payload)->assertStatus(403);
+    }
+
+    #[DataProvider('endpoints')]
+    public function test_super_admin_is_not_forbidden(string $method, string $uri, array $payload): void
+    {
+        Http::fake(); // no live supplier call; we only care that the guard lets staff through
+        Sanctum::actingAs($this->admin());
+
+        $this->assertNotSame(403, $this->{$method}($uri, $payload)->status());
+    }
+
+    public function test_unauthenticated_user_is_rejected(): void
+    {
+        $this->getJson('/api/dropshipping/suppliers')->assertStatus(401);
+    }
+}

--- a/tests/Feature/Api/DropshippingControllerTest.php
+++ b/tests/Feature/Api/DropshippingControllerTest.php
@@ -7,6 +7,7 @@ use App\Services\DropshippingService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class DropshippingControllerTest extends TestCase
@@ -18,7 +19,15 @@ class DropshippingControllerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+
+        // Staff, not a plain customer. These endpoints spend the merchant's supplier
+        // API key, so they are now admin-only; this file previously acted as a
+        // role-less user and asserted 200, which encoded the vulnerability rather
+        // than the intent. Authorization itself is covered by
+        // DropshippingAuthorizationTest — these tests cover validation and the
+        // supplier calls, which still need a caller who is allowed through.
+        Role::findOrCreate('super_admin', 'web');
+        $this->user = User::factory()->create()->assignRole('super_admin');
     }
 
     protected function actingAsUser(): void

--- a/tests/Feature/Api/WebhookEndpointApiTest.php
+++ b/tests/Feature/Api/WebhookEndpointApiTest.php
@@ -64,12 +64,44 @@ class WebhookEndpointApiTest extends TestCase
         $this->postJson('/api/webhook-endpoints', ['url' => 'https://x.test', 'events' => []])->assertStatus(422);
     }
 
+    public function test_create_rejects_non_https_and_private_network_urls(): void
+    {
+        Sanctum::actingAs($this->admin());
+
+        $unsafe = [
+            'http://partner.test/hook',                  // plaintext
+            'ftp://partner.test/hook',                   // wrong scheme
+            'https://127.0.0.1/hook',                    // loopback
+            'https://169.254.169.254/latest/meta-data/', // cloud metadata
+            'https://192.168.1.10/hook',                 // private LAN
+            'https://[::1]/hook',                        // IPv6 loopback
+        ];
+
+        foreach ($unsafe as $url) {
+            $response = $this->postJson('/api/webhook-endpoints', ['url' => $url, 'events' => ['order.paid']]);
+            $this->assertSame(422, $response->status(), "expected {$url} to be rejected as unsafe");
+        }
+
+        $this->assertDatabaseCount('webhook_endpoints', 0);
+    }
+
     public function test_admin_lists_endpoints(): void
     {
         $this->endpoint();
         Sanctum::actingAs($this->admin());
 
         $this->getJson('/api/webhook-endpoints')->assertStatus(200)->assertJsonPath('total', 1);
+    }
+
+    public function test_listing_endpoints_does_not_expose_the_signing_secret(): void
+    {
+        $this->endpoint();
+        Sanctum::actingAs($this->admin());
+
+        $response = $this->getJson('/api/webhook-endpoints')->assertStatus(200);
+
+        $this->assertNull($response->json('data.0.secret'));
+        $response->assertJsonMissing(['secret' => 'whsec_seed']);
     }
 
     public function test_admin_updates_an_endpoint(): void
@@ -83,6 +115,28 @@ class WebhookEndpointApiTest extends TestCase
         $endpoint->refresh();
         $this->assertFalse($endpoint->is_active);
         $this->assertSame(['order.cancelled'], $endpoint->events);
+    }
+
+    public function test_updating_an_endpoint_does_not_expose_the_signing_secret(): void
+    {
+        $endpoint = $this->endpoint();
+        Sanctum::actingAs($this->admin());
+
+        $response = $this->putJson("/api/webhook-endpoints/{$endpoint->id}", ['is_active' => false])->assertStatus(200);
+
+        $this->assertNull($response->json('secret'));
+        $this->assertSame('whsec_seed', $endpoint->fresh()->secret); // still stored, just not serialised
+    }
+
+    public function test_update_rejects_private_network_urls(): void
+    {
+        $endpoint = $this->endpoint();
+        Sanctum::actingAs($this->admin());
+
+        $this->putJson("/api/webhook-endpoints/{$endpoint->id}", ['url' => 'https://169.254.169.254/latest/meta-data/'])
+            ->assertStatus(422);
+
+        $this->assertSame('https://example.test/hook', $endpoint->fresh()->url);
     }
 
     public function test_admin_deletes_an_endpoint(): void

--- a/tests/Feature/Auth/CreateNewUserLoggingTest.php
+++ b/tests/Feature/Auth/CreateNewUserLoggingTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Actions\Fortify\CreateNewUser;
+use App\Models\User;
+use Exception;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+/**
+ * CreateNewUser logs its input on failure. Credentials must never reach the log.
+ */
+class CreateNewUserLoggingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const PASSWORD = 'S3cretPlaintext!2026';
+
+    /**
+     * The common failure path: a duplicate email. The password itself is valid,
+     * so 'password_confirmation' still holds the plaintext when we hit the catch.
+     */
+    public function test_validation_failure_does_not_log_the_plaintext_password(): void
+    {
+        User::factory()->create(['email' => 'taken@example.com']);
+
+        Log::spy();
+
+        try {
+            (new CreateNewUser)->create([
+                'name' => 'Test User',
+                'email' => 'taken@example.com',
+                'password' => self::PASSWORD,
+                'password_confirmation' => self::PASSWORD,
+            ]);
+            $this->fail('Expected a ValidationException for the duplicate email.');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('email', $e->errors());
+        }
+
+        $this->assertNothingLoggedContains(self::PASSWORD);
+    }
+
+    /**
+     * The QueryException path. A unique index on 'name' makes User::create fail at
+     * insert time while the email uniqueness check still passes, so the bcrypt hash
+     * is sitting in the exception's bindings when we reach the catch.
+     */
+    public function test_database_failure_does_not_log_the_password_hash(): void
+    {
+        Schema::table('users', fn (Blueprint $table) => $table->unique('name'));
+
+        User::factory()->create(['name' => 'Clashing Name', 'email' => 'other@example.com']);
+
+        Log::spy();
+
+        try {
+            (new CreateNewUser)->create([
+                'name' => 'Clashing Name',
+                'email' => 'fresh@example.com',
+                'password' => self::PASSWORD,
+                'password_confirmation' => self::PASSWORD,
+            ]);
+            $this->fail('Expected the insert to fail on the duplicate name.');
+        } catch (Exception $e) {
+            $this->assertStringContainsString('database error', strtolower($e->getMessage()));
+        }
+
+        // bcrypt hashes are generated in-flight, so match on the algorithm prefix.
+        $this->assertNothingLoggedContains('$2y$');
+        $this->assertNothingLoggedContains(self::PASSWORD);
+    }
+
+    /**
+     * Assert Log::error() was called, and that no argument of any such call
+     * contains $needle.
+     */
+    private function assertNothingLoggedContains(string $needle): void
+    {
+        Log::shouldHaveReceived('error')->withArgs(function (...$args) use ($needle) {
+            $this->assertStringNotContainsString(
+                $needle,
+                json_encode($args, JSON_PARTIAL_OUTPUT_ON_ERROR),
+                'A credential was written to the log.'
+            );
+
+            return true;
+        });
+    }
+}

--- a/tests/Feature/Auth/FailedLoginLoggingTest.php
+++ b/tests/Feature/Auth/FailedLoginLoggingTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Lockout;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * Fortify throttles login at 5/min, but nothing recorded the attempts — so
+ * credential stuffing was entirely invisible (OWASP A09). These tests pin both
+ * halves of the contract: the attempt IS recorded, and the submitted password
+ * is NOT, because Failed::$credentials carries it.
+ */
+class FailedLoginLoggingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function a_failed_login_is_logged_with_the_email_and_ip(): void
+    {
+        Log::spy();
+
+        event(new Failed('web', null, ['email' => 'victim@example.com', 'password' => 'wrong-password']));
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                return str_contains($message, 'Failed login')
+                    && $context['email'] === 'victim@example.com'
+                    && array_key_exists('ip', $context);
+            });
+    }
+
+    /** The whole point: Failed::$credentials contains the password. It must never reach the log. */
+    #[Test]
+    public function the_submitted_password_is_never_logged(): void
+    {
+        Log::spy();
+
+        event(new Failed('web', null, ['email' => 'victim@example.com', 'password' => 'Sup3rSecret!Password']));
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                $flat = json_encode([$message, $context]);
+
+                return ! str_contains($flat, 'Sup3rSecret!Password')
+                    && ! array_key_exists('password', $context);
+            });
+    }
+
+    /** Distinguishes "wrong password for a real account" from "probing a non-existent one". */
+    #[Test]
+    public function the_log_records_whether_the_account_exists(): void
+    {
+        $user = User::factory()->create(['email' => 'real@example.com']);
+        Log::spy();
+
+        event(new Failed('web', $user, ['email' => 'real@example.com', 'password' => 'wrong']));
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn (string $m, array $c) => $c['account_exists'] === true);
+    }
+
+    #[Test]
+    public function a_lockout_is_logged(): void
+    {
+        Log::spy();
+
+        event(new Lockout(Request::create('/login', 'POST', ['email' => 'victim@example.com'])));
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn (string $m, array $c) => str_contains($m, 'Login throttled'));
+    }
+}

--- a/tests/Feature/Auth/FailedLoginLoggingTest.php
+++ b/tests/Feature/Auth/FailedLoginLoggingTest.php
@@ -66,7 +66,9 @@ class FailedLoginLoggingTest extends TestCase
 
         Log::shouldHaveReceived('warning')
             ->once()
-            ->withArgs(fn (string $m, array $c) => $c['account_exists'] === true);
+            ->withArgs(function (string $message, array $context) {
+                return str_contains($message, 'Failed login') && $context['account_exists'] === true;
+            });
     }
 
     #[Test]
@@ -78,6 +80,9 @@ class FailedLoginLoggingTest extends TestCase
 
         Log::shouldHaveReceived('warning')
             ->once()
-            ->withArgs(fn (string $m, array $c) => str_contains($m, 'Login throttled'));
+            ->withArgs(function (string $message, array $context) {
+                return str_contains($message, 'Login throttled')
+                    && $context['email'] === 'victim@example.com';
+            });
     }
 }

--- a/tests/Feature/RateLimitAbuseTest.php
+++ b/tests/Feature/RateLimitAbuseTest.php
@@ -44,4 +44,45 @@ class RateLimitAbuseTest extends TestCase
 
         $this->post(route('chat.start'), ['customer_name' => 'A', 'customer_email' => 'a@example.com'])->assertStatus(429);
     }
+
+    /**
+     * Guest checkout reaches capturePayment() with a card token, so an unthrottled
+     * route is a free card-testing / BIN-enumeration oracle against our Stripe account.
+     */
+    public function test_checkout_process_is_rate_limited(): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->post(route('checkout.process'), ['email' => "a{$i}@example.com", 'stripeToken' => 'tok_test']);
+        }
+
+        $this->post(route('checkout.process'), ['email' => 'flood@example.com', 'stripeToken' => 'tok_test'])->assertStatus(429);
+    }
+
+    public function test_product_search_is_rate_limited(): void
+    {
+        for ($i = 0; $i < 30; $i++) {
+            $this->get(route('products.search', ['query' => "kw{$i}"]));
+        }
+
+        $this->get(route('products.search', ['query' => 'flood']))->assertStatus(429);
+    }
+
+    /**
+     * The app is only ever reached through a proxy, so an untrusted X-Forwarded-For
+     * makes every guest share the proxy's IP — one bucket, so one attacker throttles
+     * everyone. Per-IP limits must key off the forwarded client IP.
+     */
+    public function test_throttle_buckets_per_forwarded_client_ip_not_the_proxy(): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->post(route('cart.apply-coupon'), ['coupon_code' => 'GUESS'], ['X-Forwarded-For' => '1.1.1.1']);
+        }
+
+        $this->post(route('cart.apply-coupon'), ['coupon_code' => 'GUESS'], ['X-Forwarded-For' => '1.1.1.1'])
+            ->assertStatus(429);
+
+        // A different client behind the same proxy must not be collateral damage.
+        $this->post(route('cart.apply-coupon'), ['coupon_code' => 'GUESS'], ['X-Forwarded-For' => '2.2.2.2'])
+            ->assertStatus(302);
+    }
 }

--- a/tests/Feature/SecurityHeadersTest.php
+++ b/tests/Feature/SecurityHeadersTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SecurityHeadersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_storefront_response_carries_security_headers(): void
+    {
+        $response = $this->get('/');
+
+        // Assert the page actually rendered: without this the header assertions
+        // below would pass just as happily against a 500 error page.
+        $response->assertOk();
+        $response->assertHeader('X-Frame-Options', 'SAMEORIGIN');
+        $response->assertHeader('X-Content-Type-Options', 'nosniff');
+        $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $this->assertNotEmpty(
+            $response->headers->get('Content-Security-Policy-Report-Only'),
+            'Expected a Content-Security-Policy-Report-Only header.'
+        );
+    }
+
+    public function test_hsts_is_not_sent_over_plain_http(): void
+    {
+        $this->get('/')->assertHeaderMissing('Strict-Transport-Security');
+    }
+
+    public function test_hsts_is_sent_over_https(): void
+    {
+        $response = $this->get('https://localhost/');
+
+        $this->assertStringContainsString(
+            'max-age=',
+            (string) $response->headers->get('Strict-Transport-Security')
+        );
+    }
+}


### PR DESCRIPTION
Fixes the findings from the OWASP audit. **1227 tests pass** (baseline 1202 + 25 new). Six commits, one per finding, each independently reviewable and revertable.

Every fix is TDD — RED confirmed for the right reason first — and the guards were mutation-tested rather than trusted on a first green.

---

## 🔴 CRITICAL — `67dcfdf` any customer could ship goods on the merchant's account

The dropshipping API group had `auth:sanctum` and **no role check** — the only API controller without one. `DropshippingService::placeOrder` does a live `Http::post` to the supplier with the **merchant's API key** injected server-side and a **caller-supplied payload**. Registration is open.

> Register → mint a Sanctum token → `POST /api/dropshipping/place-order` with any items and address → real goods ship, billed to the merchant. No Order row, no payment, no limit. `track-order` was additionally an unscoped IDOR over any supplier reference.

Guarded in the controller, matching the five sibling controllers — there is no `role:` middleware alias registered in this app.

**Note for review:** `DropshippingControllerTest` previously authenticated as a role-less user and asserted `200` — it encoded the vulnerability. Its actor is now staff; those 12 tests still cover validation and supplier calls, and `DropshippingAuthorizationTest` now pins authorization itself (non-staff → 403 on all four, staff → not 403, with `Http::preventStrayRequests()`).

## 🟠 HIGH

**`eff7b7f` — plaintext passwords in the log.** `array_diff_key($input, ['password'])` didn't strip `password_confirmation`, which holds the same plaintext. **Reproduced**: a duplicate-email signup — where the password is *valid* — wrote the real credential to `storage/logs`. The `QueryException` path was worse than first diagnosed: `formatMessage()` interpolates bindings into the message, so the bcrypt hash leaked **twice**. Now an allowlist, not a denylist.

**`34fdc2f` — webhook signing secrets returned on every response.** No `$hidden`, so `index()` returned **every** endpoint's `whsec_` secret and `update()` leaked it too — while the controller's own comment claimed "returned once". `$hidden` + `makeVisible` on `store()` only, so the existing contract test stays green. Also fixes SSRF: `'url' => 'required|url'` allowed `http://169.254.169.254/`, readable back through `deliveries()` as an oracle.

**`c6ddf73` — no security headers at all.** Added X-Frame-Options, nosniff, Referrer-Policy, HSTS (gated on `secure()`), CSP as **Report-Only** so it can't break Filament/Livewire/Alpine. Registered in `app/Http/Kernel.php` — proven by A/B against the live server to be the path in effect, since this app runs the L10 skeleton despite framework v13.

**`c62d00a` — `/checkout/process` unthrottled.** Public, reaching `capturePayment` with a caller-supplied Stripe token: unlimited card testing. Now `throttle:10,1`.

## 🟡 MEDIUM

**`c62d00a` — TrustProxies trusted nothing**, so `$request->ip()` returned the *proxy's* address and all guest API traffic shared **one** 60/min bucket — a single attacker could throttle every guest. The test asserts the property, not the mechanism: one client hitting the limit must not throttle another behind the same proxy.

**`635a1cb`** — installer key now **fails closed** (see below); CORS `['*']` → env-driven, empty by default; `session.secure` now defaults true outside local/testing (verified per-environment: `local`/`testing` false, `production`/`staging` true); failed logins and lockouts are now logged, allowlisting the email out of `Failed::$credentials` — that array holds the submitted password.

---

## Judgement calls worth your review

**I did not delete `public/installer.php`.** Its `check_key()` returned `true` when no key was set, so `INSTALLER_ENABLED=true` alone exposed shell execution, `.env` rewrite and arbitrary-role user creation to anyone who found the URL. That's now fail-closed, which removes the vulnerability. But the file is undocumented and redundant with `setup.sh`, so **deleting it is the better answer** — that's a maintainer's call, not mine. The key also travels in the query string (access logs, Referer); documented in the file rather than changed, since fixing it alters the UX.

**CORS now defaults to no origins.** Correct for a same-origin storefront and unaffected for server-to-server clients (CORS is a browser mechanism), but it *is* a behaviour change — set `CORS_ALLOWED_ORIGINS` if a separate frontend consumes this API.

**SSRF validation is a speed bump, not a boundary.** Unresolvable hosts pass by design (existing tests rely on it) and DNS rebinding defeats resolve-then-fetch. Egress filtering on the queue worker is the real control; flagged in-code rather than built.

## Not fixed here — needs a decision

- **Public registration is broken**, and that's what's masking an access-control hole. `CreateNewUser` calls `assignRole("staff")` and **no seeder creates that role**, so the transaction rolls back. Behind it: `assignOrCreateTeam` attaches every registrant to `Team::first()` (the store's tenant), `canAccessPanel` returns `true` for `/app` with a `// TODO`, and Article/ProductCollection have no policies — Filament **allows by default** when none exists. Fixing the registration bug *without* fixing the team/panel gating opens the store's tenant to every signup. **They must be fixed together.**
- **SVG stored XSS — latent.** `->image()` accepts `image/svg+xml` onto a public disk. Currently unreachable (no `public/storage` symlink, `/storage/*` 404s) but goes live the moment anyone runs `storage:link`, which the config intends.
- `Password::default()` is min 8 with no complexity or breach check.
- The `Dependency Security Audit` workflow is red and has been for days — it runs `composer audit` with no `composer install` and no `--locked`. One flag fixes it.

**Dependencies are clean:** `composer audit --locked` and `npm audit --omit=dev` both report zero.