### PR TITLE
ci: audit the lock file so the security job can actually run

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,5 +33,10 @@ jobs:
         with:
           php-version: '8.5'
 
+      # --locked audits composer.lock directly. Without it, `composer audit` looks
+      # for an installed vendor/ tree, which no step here creates, so the job died
+      # with "No installed packages found" on every run — red since at least
+      # 2026-07-14 and reporting nothing. Auditing the lock is also what we want:
+      # it checks the versions that actually get deployed, and needs no install.
       - name: Run Composer security audit
-        run: composer audit --no-interaction
+        run: composer audit --locked --no-interaction


### PR DESCRIPTION
The `Dependency Security Audit` job has failed on **every run since at least 2026-07-14** and has never reported on a single dependency.

## Why

`composer audit` looks for an installed `vendor/` tree. The job checks out, sets up PHP, and audits — no `composer install` anywhere. So it exits 1 with Composer's own advice:

```
No installed packages found. Please run "composer install" before running "audit"
or pass "--locked" to audit the lock file.
```

## The fix

```diff
- run: composer audit --no-interaction
+ run: composer audit --locked --no-interaction
```

`--locked` audits `composer.lock` directly. It's the option the error message names, and it's the better one here: the lock pins the versions that actually get deployed, and it needs no install step (the job stays ~10s instead of adding a minute of `composer install`).

## Verified, not assumed

Both forms run against this project's real lock file:

| Command | Result |
|---|---|
| `composer audit --no-interaction` (current, no vendor/) | `No installed packages found.` — **reproduces the CI failure exactly** |
| `composer audit --locked --no-interaction` (this PR) | `No security vulnerability advisories found.` |

So: **no advisories today.** The job just couldn't tell us that.

## Why it matters beyond the red tick

A permanently-red security gate is worse than no gate — it trains everyone to scroll past the one check whose entire job is to shout. It also means that if a real advisory landed in `composer.lock` tomorrow, nothing here would have caught it: the job would have failed for the same boring reason it always does.

## Not included, deliberately

This job only audits Composer. The project also ships npm dependencies, so a job called "Dependency Security Audit" is currently covering half of them. `npm audit --omit=dev` reports **0 vulnerabilities** today, so nothing is hiding — but adding it is a separate, deliberate change rather than something to smuggle into a one-line fix. Happy to do it if wanted.