### PR TITLE
Unbreak registration and shut the /app panel (together)

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -44,18 +44,28 @@ class CreateNewUser implements CreatesNewUsers
             ])->validate();
 
            
-            $user = DB::transaction(function () use ($input) {
-                return tap(User::create([
-                    'name'     => $input['name'],
-                    'email'    => $input['email'],
-                    'password' => Hash::make($input['password']),
-                ]), function (User $user) use ($input) {
-                    $team = $this->assignOrCreateTeam($user);
-                    $user->switchTeam($team);
-                    setPermissionsTeamId($team->id);
-                    $user->assignRole("staff");
-                });
-            });
+            // A public registration produces a shopper: a user, and nothing else.
+            //
+            // This used to attach every registrant to Team::first() — the merchant's
+            // own team, seeded by DefaultTeamSeeder and owned by the admin — and then
+            // assign a `staff` role. Both were wrong:
+            //
+            //  - Team membership is what gates /app (see User::canAccessPanel), and
+            //    teams are created through TeamPolicy::create, which requires the
+            //    `create_store` permission. Handing one out at signup bypassed that
+            //    gate and dropped strangers inside the store's tenant.
+            //  - Nothing consumes `staff`. RolesSeeder stopped creating it in cf711cb
+            //    without touching this caller, so every registration has been throwing
+            //    RoleDoesNotExist since — and on an unseeded database Team::first()
+            //    returned null and fatally errored one line earlier.
+            //
+            // Shoppers have their own account area on the storefront (/orders,
+            // /wishlist, /invoices, /payment_methods). They do not need the panel.
+            $user = User::create([
+                'name' => $input['name'],
+                'email' => $input['email'],
+                'password' => Hash::make($input['password']),
+            ]);
             // $user = DB::transaction(function () use ($input) {
             //     return tap(,
             //     , function (User $user) use ($input) {
@@ -122,16 +132,4 @@ class CreateNewUser implements CreatesNewUsers
         }
     }
 
-    /**
-     * Assign the user to the first team or create a personal team.
-     *
-     * @throws Exception
-     */
-    protected function assignOrCreateTeam(User $user): Team
-    {
-        $team = Team::first();
-    
-        $team->users()->attach($user);
-        return $team;
-    }
 }

--- a/app/Http/Responses/LoginResponse.php
+++ b/app/Http/Responses/LoginResponse.php
@@ -2,45 +2,52 @@
 
 namespace App\Http\Responses;
 
-use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 
 class LoginResponse implements LoginResponseContract
 {
+    /**
+     * Panels, by role. Checked in order.
+     *
+     * `staff => /app` used to sit here, but no seeder has created that role since
+     * cf711cb, so the entry could never match — and it was a no-op anyway, because
+     * the fall-through below already sent everyone to /app.
+     */
     protected array $roleRedirects = [
+        'super_admin' => '/admin',
         'admin' => '/admin',
-        'staff' => '/app',
     ];
-
-    protected function shouldRedirect(Request $request, string $redirect): bool
-    {
-        // Check if the current request path matches the redirect path
-        return !$request->is($redirect) && !$request->is($redirect . '/*');
-    }
 
     public function toResponse($request)
     {
-        setPermissionsTeamId(Auth::user()->current_team_id);
         $user = Auth::user();
+
+        setPermissionsTeamId($user->current_team_id);
+
+        if ($request->wantsJson()) {
+            return new JsonResponse(['two_factor' => false], 200);
+        }
 
         foreach ($this->roleRedirects as $role => $redirect) {
             if ($user->hasRole($role)) {
-                return $request->wantsJson()
-                    ? new JsonResponse(['two_factor' => false], 200)
-                    : ($this->shouldRedirect($request, $redirect)
-                        ? redirect()->to($redirect)
-                        : redirect()->intended($redirect));
+                return redirect()->to($redirect);
             }
         }
 
-        // Default redirection
-        $redirect = '/app';
-        return $request->wantsJson()
-            ? new JsonResponse(['two_factor' => false], 200)
-            : ($this->shouldRedirect($request, $redirect)
-                        ? redirect()->to($redirect)
-                        : redirect()->intended($redirect));
+        // Team members get the back-office they can actually reach.
+        if ($user->allTeams()->isNotEmpty()) {
+            return redirect()->to('/app');
+        }
+
+        // Everyone else is a shopper. This used to default to /app, which sent every
+        // customer into the team back-office — and now that /app requires a team,
+        // that default would land them on a refusal.
+        //
+        // intended(), not to(): a shopper logging in was usually part-way through
+        // something (a checkout, a product they wanted to save), and that is where
+        // they should end up. '/' is only the fallback.
+        return redirect()->intended('/');
     }
 }

--- a/app/Http/Responses/RegisterResponse.php
+++ b/app/Http/Responses/RegisterResponse.php
@@ -1,25 +1,29 @@
-<?php 
+<?php
 
 namespace App\Http\Responses;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\JsonResponse;
-use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 
 class RegisterResponse implements RegisterResponseContract
 {
+    /**
+     * Kept in step with LoginResponse. `staff => /app` is gone: no seeder has
+     * created that role since cf711cb, and it was a no-op anyway because the
+     * fall-through already sent everyone to /app.
+     *
+     * A brand-new registrant can only be a shopper now — registration grants no
+     * team and no role — so in practice this map never matches here. It stays for
+     * the case where an existing admin somehow lands on this response, and so the
+     * two responses don't drift apart.
+     */
     protected array $roleRedirects = [
+        'super_admin' => '/admin',
         'admin' => '/admin',
-        'staff' => '/app',
     ];
-
-    protected function shouldRedirect(Request $request, string $redirect): bool
-    {
-        // Check if the current request path matches the redirect path
-        return !$request->is($redirect) && !$request->is($redirect . '/*');
-    }
 
     /**
      * @param  Request  $request
@@ -27,26 +31,26 @@ class RegisterResponse implements RegisterResponseContract
      */
     public function toResponse($request)
     {
-        setPermissionsTeamId(Auth::user()->current_team_id);
         $user = Auth::user();
 
-        // Check if the user has a role and redirect accordingly
+        setPermissionsTeamId($user->current_team_id);
+
+        if ($request->wantsJson()) {
+            return new JsonResponse(['two_factor' => false], 200);
+        }
+
         foreach ($this->roleRedirects as $role => $redirect) {
             if ($user->hasRole($role)) {
-                return $request->wantsJson()
-                    ? new JsonResponse(['two_factor' => false], 200)
-                    : ($this->shouldRedirect($request, $redirect)
-                        ? redirect()->to($redirect)
-                        : redirect()->intended($redirect));
+                return redirect()->to($redirect);
             }
         }
 
-        // Default redirection
-        $redirect = '/app';
-        return $request->wantsJson()
-            ? new JsonResponse(['two_factor' => false], 200)
-            : ($this->shouldRedirect($request, $redirect)
-                        ? redirect()->to($redirect)
-                        : redirect()->intended($redirect));
+        if ($user->allTeams()->isNotEmpty()) {
+            return redirect()->to('/app');
+        }
+
+        // Someone who just signed up to buy something. This defaulted to /app —
+        // the team back-office — which they now cannot enter at all.
+        return redirect()->intended('/');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -40,14 +40,36 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
     // use SetsProfilePhotoFromUrl;
     use TwoFactorAuthenticatable;
 
+    /**
+     * Panel access.
+     *
+     * `admin` is the back-office for the whole store: super_admin only.
+     *
+     * `app` is a team's back-office — Products, Orders, Invoices, Customers,
+     * Articles, Collections — scoped by Filament to the current tenant. So the
+     * question it answers is "do you belong to a team?", and teams are handed out
+     * through TeamPolicy::create, which requires the `create_store` permission.
+     * That keeps the decision in one place instead of duplicating a role check here.
+     *
+     * This previously ended `return true; // TODO: Check panel and role`, so any
+     * authenticated user — no roles, no teams — was waved into /app. Only a
+     * separate bug in registration kept strangers from arriving; fixing that
+     * without this would have opened the door.
+     *
+     * Shoppers are not refused anything by this: their account area lives on the
+     * storefront (/orders, /wishlist, /invoices, /payment_methods).
+     *
+     * Note $this, not auth()->user(): Filament passes the user to authorize, and
+     * reading the session instead silently authorized the wrong person under
+     * impersonation or in queued contexts.
+     */
     public function canAccessPanel(Panel $panel): bool
     {
-        $user = auth()->user();
-        if ($panel->getId() === 'admin' && ! $user->hasRole('super_admin')) {
-            return false;
-        }
-
-        return true; // TODO: Check panel and role
+        return match ($panel->getId()) {
+            'admin' => $this->hasRole('super_admin'),
+            'app' => $this->allTeams()->isNotEmpty(),
+            default => false,
+        };
     }
 
     public function wishlist()

--- a/tests/Feature/AppPanelAccessTest.php
+++ b/tests/Feature/AppPanelAccessTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\Fortify\CreateNewUser;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Registration and /app access are one problem, not two.
+ *
+ * Registration was broken — CreateNewUser assigned a `staff` role that no seeder
+ * creates (RolesSeeder dropped it in cf711cb without touching the caller), and on
+ * an unseeded database Team::first() returned null and fatally errored first. That
+ * bug was the only thing keeping strangers out of /app, because canAccessPanel
+ * ended `return true; // TODO` and assignOrCreateTeam attached every registrant to
+ * Team::first() — the merchant's own team.
+ *
+ * So fixing registration alone would have opened the door. These tests pin both
+ * halves together: a registrant gets no team and no role, and /app requires a team.
+ */
+class AppPanelAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @return array<string, mixed> */
+    private function payload(array $overrides = []): array
+    {
+        return array_merge([
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.test',
+            'password' => 'Sup3rSecret!Password',
+            'password_confirmation' => 'Sup3rSecret!Password',
+        ], $overrides);
+    }
+
+    #[Test]
+    public function registration_succeeds(): void
+    {
+        $user = (new CreateNewUser)->create($this->payload());
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertSame('ada@example.test', $user->email);
+    }
+
+    /**
+     * The heart of it. A shopper signing up must not become a member of the
+     * merchant's team — assignOrCreateTeam used to attach them to Team::first().
+     */
+    #[Test]
+    public function registration_does_not_put_a_shopper_in_the_stores_team(): void
+    {
+        $storeTeam = Team::factory()->create(['name' => 'The Store', 'personal_team' => false]);
+
+        $user = (new CreateNewUser)->create($this->payload());
+
+        $this->assertSame(0, $user->allTeams()->count(), 'A registrant must not be attached to any team.');
+        $this->assertFalse($user->belongsToTeam($storeTeam), 'A registrant must never land inside the store team.');
+    }
+
+    #[Test]
+    public function registration_grants_no_roles(): void
+    {
+        $user = (new CreateNewUser)->create($this->payload());
+
+        $this->assertCount(0, $user->getRoleNames(), 'A shopper is not staff.');
+    }
+
+    /** The gate that the registration bug was standing in for. */
+    #[Test]
+    public function a_user_with_no_team_cannot_reach_the_app_panel(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $this->assertFalse($user->canAccessPanel(Filament::getPanel('app')));
+    }
+
+    #[Test]
+    public function a_team_member_can_reach_the_app_panel(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $this->assertTrue($user->canAccessPanel(Filament::getPanel('app')));
+    }
+
+    #[Test]
+    public function only_a_super_admin_can_reach_the_admin_panel(): void
+    {
+        Role::findOrCreate('super_admin', 'web');
+
+        $plain = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($plain);
+        $this->assertFalse($plain->canAccessPanel(Filament::getPanel('admin')));
+
+        $admin = User::factory()->withPersonalTeam()->create()->assignRole('super_admin');
+        $this->actingAs($admin);
+        $this->assertTrue($admin->canAccessPanel(Filament::getPanel('admin')));
+    }
+
+    /**
+     * The permission-backed resources deny a user who holds no permissions.
+     *
+     * Deliberately not asserted here: ArticleResource and CollectionResource have no
+     * policy, and strictAuthorization is off, so Filament's authorization helper
+     * returns allow() for them — a team member can CRUD their own tenant's articles
+     * and collections (price included) without any permission check. That is a real
+     * gap, but a separate change: the Shield permission set has no article_* or
+     * collection_* entries at all, so adding the obvious policy would deny everyone
+     * including super_admin and break the feature. It needs policies AND seeded
+     * permissions together. Tracked, not smuggled in here.
+     *
+     * It is no longer reachable by a stranger either way — that took a team, and
+     * registration no longer hands one out.
+     */
+    #[Test]
+    public function permission_backed_resources_deny_a_user_without_permissions(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        foreach ([
+            \App\Filament\App\Resources\Products\ProductResource::class,
+            \App\Filament\App\Resources\Orders\OrderResource::class,
+        ] as $resource) {
+            $this->assertFalse($resource::canViewAny(), $resource.' must not be viewable without permission.');
+            $this->assertFalse($resource::canCreate(), $resource.' must not be creatable without permission.');
+            $this->assertFalse($resource::canDeleteAny(), $resource.' must not be deletable without permission.');
+        }
+    }
+}

--- a/tests/Unit/FortifyActionsTest.php
+++ b/tests/Unit/FortifyActionsTest.php
@@ -6,38 +6,30 @@ use App\Actions\Fortify\CreateNewUser;
 use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
-use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
-use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class FortifyActionsTest extends TestCase
 {
     use RefreshDatabase;
 
-    private function makeTeam(): Team
-    {
-        $tempUser = User::factory()->create();
-        $team = new Team();
-        $team->name = 'Test Team';
-        $team->user_id = $tempUser->id;
-        $team->personal_team = false;
-        $team->save();
-
-        // Spatie permissions need team context and the staff role
-        setPermissionsTeamId($team->id);
-        Role::findOrCreate('staff');
-
-        return $team;
-    }
+    /**
+     * Deliberately removed: makeTeam().
+     *
+     * It created a team and a `staff` role, which is precisely why this suite was
+     * green while registration threw on every real request. CreateNewUser attached
+     * every registrant to Team::first() and assigned `staff`; the fixture supplied
+     * both, so neither the missing role nor the null team could ever surface here.
+     *
+     * Registration now creates a user and nothing else, so there is nothing to
+     * arrange. AppPanelAccessTest asserts that directly — no team, no roles.
+     */
 
     public function test_create_new_user_creates_user(): void
     {
-        $this->makeTeam();
-
         $action = new CreateNewUser();
         $user = $action->create([
             'name' => 'John Doe',
@@ -53,8 +45,6 @@ class FortifyActionsTest extends TestCase
 
     public function test_create_new_user_hashes_password(): void
     {
-        $this->makeTeam();
-
         $action = new CreateNewUser();
         $user = $action->create([
             'name' => 'Jane Doe',
@@ -77,8 +67,6 @@ class FortifyActionsTest extends TestCase
 
     public function test_create_new_user_validates_email_uniqueness(): void
     {
-        $this->makeTeam();
-
         $action = new CreateNewUser();
         $action->create([
             'name' => 'First User',


### PR DESCRIPTION
These are **one change**. Registration was broken — and that bug was the only thing keeping strangers out of the team back-office. Fixing it alone would have opened the door.

**1245 tests pass** (1238 + 7 new). Both halves mutation-checked. Verified live end-to-end.

---

## The coupling

`CreateNewUser` attached every registrant to **`Team::first()`** — the merchant's own team, seeded by `DefaultTeamSeeder`, owned by the admin — then assigned a `staff` role. The method is called `assignOrCreateTeam` and its docblock promises *"or create a personal team"*; **neither branch ever existed**.

Meanwhile `canAccessPanel` ended `return true; // TODO: Check panel and role`, so a user with **zero roles and zero teams** was waved into `/app` — Products, Orders, Invoices, Customers. I verified that directly.

It only ever failed to bite because **registration threw first**:
- `RolesSeeder` stopped creating `staff` in `cf711cb` (Mar 2026) without touching the caller → `RoleDoesNotExist`.
- On an unseeded DB, `Team::first()` returns `null` and `$team->users()` raises an **`Error`**, which escapes all five catch blocks as an uncaught 500 — one line *earlier*.

## What changed

**Registration produces a shopper: a user, and nothing else.** No team — team membership is what gates `/app`, and teams are granted via `TeamPolicy::create`, which requires the `create_store` permission; handing one out at signup bypassed that gate. No `staff` role — nothing consumes it: `canAccessPanel` never checked it, and the `staff => /app` entries were no-ops sitting above a fall-through that already sent everyone to `/app`.

**`canAccessPanel` asks the question that matches the panel** — `admin` wants `super_admin`, `app` wants team membership. It now reads `$this` instead of `auth()->user()`, which authorized the *session* user rather than the one Filament passed in (wrong under impersonation and in queued contexts).

**Login/register default to the storefront**, using `intended()` so a shopper who logged in mid-checkout ends up back there. Shoppers lose nothing — their account area is `/orders`, `/wishlist`, `/invoices`, `/payment_methods`.

## The test that hid it

`FortifyActionsTest::makeTeam()` created a team **and** the `staff` role — with a comment saying so. That fixture is precisely why the suite stayed green while every real registration threw. It's gone, and those tests still pass.

## Verified live

```
POST /register            -> 302 http://localhost:8000/     (was: throw)
  teams: 0   roles: []    in the store team? false
GET /app                  -> 403
GET /admin                -> 403
GET /orders               -> 200   (shoppers keep their account area)
```

Mutation-checked, both halves independently:
- `canAccessPanel` back to `'app' => true` → **1 failed**
- registration re-attaching to `Team::first()` → **1 failed**

## Known gap, deliberately not fixed here

`ArticleResource` and `CollectionResource` have **no policy**, and `strictAuthorization` is off, so Filament's authorization helper returns `allow()` — a team member can CRUD their own tenant's articles and collections (**price included**) with no permission check. Verified: `viewAny=true create=true deleteAny=true`.

It is **no longer reachable by a stranger** — that takes a team, and registration no longer hands one out. It needs policies **and** seeded permissions *together*: the Shield permission set has no `article_*` or `collection_*` entries at all, so the obvious policy would deny `super_admin` and break the feature outright. Separate change, happy to do it.

## Also found, not touched

- `RoleBasedRedirect` is **dead** — never registered, and all six of its targets (`/staff`, `/buyer`, `/seller`, `/tenant`, `/landlord`, `/contractor`) 404. It's inherited from a property-management app.
- `config('permission.teams')` is **`false`**, so `setPermissionsTeamId()` is a no-op and roles are global — despite code throughout reading as if they were team-scoped.
- `CreateUserWithTeamsFromProvider` (Socialstream) contains the exact personal-team implementation `assignOrCreateTeam` was supposed to grow into, and is never bound.