### PR TITLE
Fix known-issues sweep: unguarded Article/Collection CRUD, weak password policy, SVG uploads, dead Socialstream trait, seeder collisions, unaudited npm deps

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,3 +40,42 @@ jobs:
       # it checks the versions that actually get deployed, and needs no install.
       - name: Run Composer security audit
         run: composer audit --locked --no-interaction
+
+  # Split from the Composer job rather than bolted on as a step: the two need
+  # different toolchains (PHP vs Node), they run in parallel, and a JS advisory
+  # reports as a JS failure instead of turning up under a PHP-shaped job name.
+  # The extra checkout costs a couple of seconds.
+  npm-security:
+    name: npm Dependency Security Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # package.json declares no engines. 20 matches the php-fpm image that
+          # actually builds these assets (v20.20.2) and clears Vite 8's >= 20.19
+          # floor. No cache: npm — nothing installs here, so there's nothing to
+          # cache.
+          node-version: '20'
+
+      # --package-lock-only is the npm mirror of `composer audit --locked` above:
+      # audit the lockfile, install nothing. That keeps the whole npm ci
+      # lockfile-out-of-sync failure mode out of the security gate (the build
+      # workflow is where a desync should shout), and the lock is what ships
+      # anyway. npm 10 already falls back to the lock when node_modules is
+      # absent; the flag says so out loud instead of leaning on that fallback —
+      # an unstated install assumption is what left the Composer job red and
+      # silent for months.
+      #
+      # --omit=dev scopes this to what reaches a browser. The devDependencies
+      # are the build chain (vite, tailwind, postcss) and their advisories tend
+      # to be dev-server noise that's unfixable until upstream moves — a gate
+      # that cries wolf gets ignored, which is how the jobs above died. No
+      # --audit-level in exchange: within the handful of shipped packages we
+      # fail on anything, because flowbite/preline render user-facing markup and
+      # XSS routinely rates "moderate", which --audit-level=high would wave
+      # through. Narrow scope, zero tolerance inside it.
+      - name: Run npm security audit
+        run: npm audit --omit=dev --package-lock-only

--- a/app/Filament/Admin/Resources/Users/Schemas/UserForm.php
+++ b/app/Filament/Admin/Resources/Users/Schemas/UserForm.php
@@ -2,12 +2,9 @@
 
 namespace App\Filament\Admin\Resources\Users\Schemas;
 
-use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\Toggle;
-use Filament\Forms\Components\Textarea;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Components\Tabs\Tab;
@@ -34,7 +31,7 @@ class UserForm
                                             ->maxLength(255)
                                             ->columnSpanFull()
                                             ->placeholder('Enter full name'),
-                                        
+
                                         TextInput::make('email')
                                             ->label('Email Address')
                                             ->email()
@@ -51,18 +48,28 @@ class UserForm
                                             ->maxLength(255)
                                             ->placeholder('Enter password')
                                             ->helperText('Leave blank to keep current password (when editing)'),
-                                        
+
+                                        // Security: ->image() means
+                                        // acceptedFileTypes(['image/*']), which
+                                        // accepts image/svg+xml -- an XML doc that
+                                        // can carry <script>. This field lands on
+                                        // the default (private, non-web-served) disk
+                                        // today so it is not currently an XSS vector,
+                                        // but the allowlist is the cheap half of the
+                                        // fix and survives the disk being re-pointed.
+                                        // Validates the *upload*; does not make the
+                                        // serving origin safe. maxSize stays 2MB.
                                         FileUpload::make('profile_photo_path')
                                             ->label('Profile Photo')
-                                            ->image()
+                                            ->acceptedFileTypes(['image/jpeg', 'image/png', 'image/webp', 'image/avif'])
                                             ->imageEditor()
                                             ->maxSize(2048)
                                             ->directory('profile-photos')
                                             ->columnSpanFull()
-                                            ->helperText('Upload a profile photo (max 2MB)')
+                                            ->helperText('Upload a profile photo (max 2MB)'),
                                     ]),
                             ]),
-                        
+
                         Tab::make('Roles & Permissions')
                             ->schema([
                                 Section::make('Role Assignment')
@@ -78,7 +85,7 @@ class UserForm
                                             ->columnSpanFull(),
                                     ]),
                             ]),
-                        
+
                     ]),
             ]);
     }

--- a/app/Filament/App/Resources/Products/ProductResource.php
+++ b/app/Filament/App/Resources/Products/ProductResource.php
@@ -2,39 +2,33 @@
 
 namespace App\Filament\App\Resources\Products;
 
-use Filament\Schemas\Schema;
-use Filament\Schemas\Components\Grid;
-use Filament\Forms\Components\FileUpload;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Actions\EditAction;
-use Filament\Actions\BulkActionGroup;
-use Filament\Actions\DeleteBulkAction;
-use App\Filament\App\Resources\Products\Pages\ListProducts;
 use App\Filament\App\Resources\Products\Pages\CreateProduct;
 use App\Filament\App\Resources\Products\Pages\EditProduct;
-use Filament\Forms;
-use Filament\Tables;
+use App\Filament\App\Resources\Products\Pages\ListProducts;
 use App\Models\Product;
-use Filament\Tables\Table;
-use App\Models\ProductCategory;
-use Filament\Resources\Resource;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
-use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Schema;
+use Filament\Tables;
 use Filament\Tables\Columns\ImageColumn;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
-use App\Filament\App\Resources\ProductResource\Pages;
-use App\Filament\App\Resources\ProductResource\RelationManagers;
-use Filament\Forms\Components\Repeater;
-use Filament\Forms\Components\Section;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
 
 class ProductResource extends Resource
 {
     protected static ?string $model = Product::class;
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-circle-stack';
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-circle-stack';
 
     protected static ?int $navigationSort = 5;
 
@@ -59,7 +53,6 @@ class ProductResource extends Resource
                     ->maxLength(65535)
                     ->columnSpanFull(),
 
-
                 Grid::make()
                     ->schema([
                         Toggle::make('is_variable')
@@ -70,31 +63,41 @@ class ProductResource extends Resource
                             ->label('Simple'),
                     ]),
 
+                // Security: do NOT use ->image(), which expands to
+                // acceptedFileTypes(['image/*']) and therefore accepts
+                // image/svg+xml. An SVG is an XML document that can carry
+                // <script>; served same-origin from the public disk that is
+                // stored XSS. List raster formats explicitly instead.
+                //
+                // acceptedFileTypes() is a *validation* control (the upload is
+                // rejected), not a *serving* control -- it does not make the
+                // storage origin safe. The durable fix is to serve user uploads
+                // from a separate origin, or with Content-Disposition: attachment
+                // + X-Content-Type-Options: nosniff. Not done here.
                 FileUpload::make('featured_image')
-                    ->image()
+                    ->acceptedFileTypes(['image/jpeg', 'image/png', 'image/webp', 'image/avif'])
+                    // 4MB: comfortably fits a full-bleed product photo off a
+                    // modern phone camera, while bounding what one upload costs
+                    // us. Was previously unbounded.
+                    ->maxSize(4096)
                     ->disk('public')
                     ->directory('products')
                     ->visibility('public')
                     ->label('Featured Image'),
 
-
                 Repeater::make('images')
                     ->relationship('images')
                     ->schema([
+                        // Same SVG/XSS reasoning as featured_image above.
                         FileUpload::make('image')
                             ->hiddenLabel()
-                            ->image()
+                            ->acceptedFileTypes(['image/jpeg', 'image/png', 'image/webp', 'image/avif'])
+                            ->maxSize(4096)
                             ->disk('public')
                             ->directory('products')
-                            ->visibility('public')
+                            ->visibility('public'),
 
                     ]),
-
-
-
-
-
-
 
                 // Forms\Components\TextInput::make('meta_title')
                 //     ->label('Meta Title')

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use JoelButcher\Socialstream\HasConnectedAccounts;
 use Laravel\Cashier\Billable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
@@ -27,12 +28,11 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
 {
     use Billable;
     use HasApiTokens;
+    use HasConnectedAccounts;
     use HasFactory;
     use HasProfilePhoto {
         HasProfilePhoto::profilePhotoUrl as getPhotoUrl;
     }
-
-    // use HasConnectedAccounts;
     use HasRoles;
     use HasTeams;
     use Notifiable;

--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Article;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ArticlePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view_any_article');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Article $article): bool
+    {
+        return $user->can('view_article');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->can('create_article');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Article $article): bool
+    {
+        return $user->can('update_article');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Article $article): bool
+    {
+        return $user->can('delete_article');
+    }
+
+    /**
+     * Determine whether the user can bulk delete.
+     */
+    public function deleteAny(User $user): bool
+    {
+        return $user->can('delete_any_article');
+    }
+
+    /**
+     * Determine whether the user can permanently delete.
+     */
+    public function forceDelete(User $user, Article $article): bool
+    {
+        return $user->can('force_delete_article');
+    }
+
+    /**
+     * Determine whether the user can permanently bulk delete.
+     */
+    public function forceDeleteAny(User $user): bool
+    {
+        return $user->can('force_delete_any_article');
+    }
+
+    /**
+     * Determine whether the user can restore.
+     */
+    public function restore(User $user, Article $article): bool
+    {
+        return $user->can('restore_article');
+    }
+
+    /**
+     * Determine whether the user can bulk restore.
+     */
+    public function restoreAny(User $user): bool
+    {
+        return $user->can('restore_any_article');
+    }
+
+    /**
+     * Determine whether the user can replicate.
+     */
+    public function replicate(User $user, Article $article): bool
+    {
+        return $user->can('replicate_article');
+    }
+
+    /**
+     * Determine whether the user can reorder.
+     */
+    public function reorder(User $user): bool
+    {
+        return $user->can('reorder_article');
+    }
+}

--- a/app/Policies/ProductCollectionPolicy.php
+++ b/app/Policies/ProductCollectionPolicy.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ProductCollection;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ProductCollectionPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view_any_product::collection');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, ProductCollection $productCollection): bool
+    {
+        return $user->can('view_product::collection');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->can('create_product::collection');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, ProductCollection $productCollection): bool
+    {
+        return $user->can('update_product::collection');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, ProductCollection $productCollection): bool
+    {
+        return $user->can('delete_product::collection');
+    }
+
+    /**
+     * Determine whether the user can bulk delete.
+     */
+    public function deleteAny(User $user): bool
+    {
+        return $user->can('delete_any_product::collection');
+    }
+
+    /**
+     * Determine whether the user can permanently delete.
+     */
+    public function forceDelete(User $user, ProductCollection $productCollection): bool
+    {
+        return $user->can('force_delete_product::collection');
+    }
+
+    /**
+     * Determine whether the user can permanently bulk delete.
+     */
+    public function forceDeleteAny(User $user): bool
+    {
+        return $user->can('force_delete_any_product::collection');
+    }
+
+    /**
+     * Determine whether the user can restore.
+     */
+    public function restore(User $user, ProductCollection $productCollection): bool
+    {
+        return $user->can('restore_product::collection');
+    }
+
+    /**
+     * Determine whether the user can bulk restore.
+     */
+    public function restoreAny(User $user): bool
+    {
+        return $user->can('restore_any_product::collection');
+    }
+
+    /**
+     * Determine whether the user can replicate.
+     */
+    public function replicate(User $user, ProductCollection $productCollection): bool
+    {
+        return $user->can('replicate_product::collection');
+    }
+
+    /**
+     * Determine whether the user can reorder.
+     */
+    public function reorder(User $user): bool
+    {
+        return $user->can('reorder_product::collection');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,13 +7,14 @@ use App\Models\Role;
 use App\Modules\ModuleManager;
 use App\Modules\ModuleServiceProvider;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Validation\Rules\Password;
 use Spatie\Permission\PermissionRegistrar;
 
 class AppServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        $this->app->singleton(ModuleManager::class, fn ($app) => new ModuleManager());
+        $this->app->singleton(ModuleManager::class, fn ($app) => new ModuleManager);
         $this->app->register(ModuleServiceProvider::class);
     }
 
@@ -22,5 +23,25 @@ class AppServiceProvider extends ServiceProvider
         app(PermissionRegistrar::class)
             ->setPermissionClass(Permission::class)
             ->setRoleClass(Role::class);
+
+        // Password::default() was already the rule everywhere (PasswordValidationRules,
+        // SetUserPassword) but nothing ever configured it, so it resolved to Laravel's
+        // stock min:8 with no complexity. These accounts hold order history and saved
+        // payment methods; set the defaults once here and every caller inherits them —
+        // registration, password reset, password update, and social account setup.
+        Password::defaults(function () {
+            $rule = Password::min(12)->mixedCase()->numbers()->symbols();
+
+            // uncompromised() is a HaveIBeenPwned k-anonymity lookup: an outbound HTTPS
+            // call to api.pwnedpasswords.com on the registration request. Worth it —
+            // credential stuffing against reused breached passwords is the actual threat
+            // to a storefront, and complexity rules alone happily accept "P@ssw0rd1234".
+            // Production only, because the closure is what makes that affordable:
+            // it defers to validation time, so the suite (APP_ENV=testing) and an
+            // air-gapped/local deploy never touch the network. Laravel fails OPEN on a
+            // request error, so an HIBP outage degrades to the complexity rules above
+            // rather than blocking every signup.
+            return $this->app->isProduction() ? $rule->uncompromised() : $rule;
+        });
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,7 +14,7 @@ class AppServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        $this->app->singleton(ModuleManager::class, fn ($app) => new ModuleManager);
+        $this->app->singleton(ModuleManager::class, fn () => new ModuleManager);
         $this->app->register(ModuleServiceProvider::class);
     }
 
@@ -41,7 +41,13 @@ class AppServiceProvider extends ServiceProvider
             // air-gapped/local deploy never touch the network. Laravel fails OPEN on a
             // request error, so an HIBP outage degrades to the complexity rules above
             // rather than blocking every signup.
-            return $this->app->isProduction() ? $rule->uncompromised() : $rule;
+            //
+            // environment('production'), not isProduction(): ServiceProvider::$app is
+            // typed as the Foundation\Application *contract*, which declares
+            // environment() but not isProduction() — the latter only exists on the
+            // concrete class. It resolves at runtime either way, but only this one is
+            // sound against the declared type. isProduction() just delegates here.
+            return $this->app->environment('production') ? $rule->uncompromised() : $rule;
         });
     }
 }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -2,16 +2,15 @@
 
 namespace App\Providers\Filament;
 
-use Filament\Actions\Action;
-use Filament\Widgets\AccountWidget;
-use App\Filament\App\Pages\CreateTeam;
-use App\Filament\App\Pages\EditTeam;
 use App\Filament\App\Pages;
+use App\Filament\App\Pages\CreateTeam;
 use App\Filament\App\Pages\EditProfile;
+use App\Filament\App\Pages\EditTeam;
 use App\Http\Middleware\TeamsPermission;
 use App\Listeners\CreatePersonalTeam;
 use App\Listeners\SwitchTeam;
 use App\Models\Team;
+use Filament\Actions\Action;
 use Filament\Events\Auth\Registered;
 use Filament\Events\TenantSet;
 use Filament\Facades\Filament;
@@ -24,6 +23,7 @@ use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
 use Filament\Widgets;
+use Filament\Widgets\AccountWidget;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
@@ -42,13 +42,32 @@ class AppPanelProvider extends PanelProvider
     public function panel(Panel $panel): Panel
     {
         $panel
-            ->default()
+            // No ->default() here: AdminPanelProvider already claims it, and
+            // PanelRegistry::getDefault() takes Arr::first(), so admin won on
+            // registration order alone while this panel also claimed the flag.
+            // That made the fallback panel a function of provider order, and the
+            // fallback is load-bearing — FilamentManager::isAuthorizationStrict()
+            // reads getCurrentOrDefaultPanel(), so outside a panel (queues,
+            // console, policy checks with no request) it reads the default. If
+            // order ever flipped, strictAuthorization() below would have become
+            // the global fallback and thrown on every policy-less Admin resource.
             ->id('app')
             ->path('app')
             // ->login([AuthenticatedSessionController::class, 'create'])
             // ->registration()
             // ->passwordReset()
             // ->emailVerification()
+            // Without this, a resource with no policy is wide open: Filament's
+            // get_authorization_response() returns allow() when no policy exists.
+            // That is how ArticleResource and CollectionResource shipped with
+            // unguarded CRUD. Strict mode throws instead, so the next policy-less
+            // resource fails loudly in CI rather than silently granting everyone.
+            //
+            // Scoped to this panel deliberately: the Admin panel still has
+            // policy-less resources (ChatConversation, CustomerSegment, Discount,
+            // Menu, MenuItem, Page, TaxClass, User), so turning it on there would
+            // throw across the back-office. Those want policies, not a flag.
+            ->strictAuthorization()
             ->viteTheme('resources/css/filament/admin/theme.css')
             ->colors([
                 'primary' => Color::Gray,
@@ -104,14 +123,14 @@ class AppPanelProvider extends PanelProvider
                 ->tenant(Team::class, ownershipRelationship: 'team')
                 ->tenantRegistration(CreateTeam::class)
                 ->tenantProfile(EditTeam::class);
-                // ->userMenuItems([
-                //     MenuItem::make()
-                //         ->label('Team Settings')
-                //         ->icon('heroicon-o-cog-6-tooth')
-                //         ->url(fn () => $this->shouldRegisterMenuItem()
-                //             ? url(Pages\EditTeam::getUrl())
-                //             : url($panel->getPath())),
-                // ]);
+            // ->userMenuItems([
+            //     MenuItem::make()
+            //         ->label('Team Settings')
+            //         ->icon('heroicon-o-cog-6-tooth')
+            //         ->url(fn () => $this->shouldRegisterMenuItem()
+            //             ? url(Pages\EditTeam::getUrl())
+            //             : url($panel->getPath())),
+            // ]);
         }
 
         return $panel;
@@ -148,6 +167,6 @@ class AppPanelProvider extends PanelProvider
 
     public function shouldRegisterMenuItem(): bool
     {
-        return true; //auth()->user()?->hasVerifiedEmail() && Filament::hasTenancy() && Filament::getTenant();
+        return true; // auth()->user()?->hasVerifiedEmail() && Filament::hasTenancy() && Filament::getTenant();
     }
 }

--- a/database/seeders/DummyData/ProductSeeder.php
+++ b/database/seeders/DummyData/ProductSeeder.php
@@ -4,163 +4,84 @@ namespace Database\Seeders\DummyData;
 
 use App\Models\Product;
 use App\Models\ProductCategory;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class ProductSeeder extends Seeder
 {
     /**
-     * Run the database seeds.
+     * Stock at or below this shows the "Low Stock" badge; above it, plain
+     * in-stock. Zero would make the badge unreachable.
      */
+    private const LOW_STOCK_THRESHOLD = 5;
+
+    /**
+     * The demo catalogue, keyed by category slug.
+     *
+     * Columns: name, price, short description, inventory count, featured.
+     *
+     * The storefront renders three distinct stock states (in stock / low stock
+     * / sold out — see components/product-card.blade.php), so the demo data
+     * deliberately covers all three: the large majority in stock with varied
+     * counts, two hot items sold out, and two running low. A catalogue where
+     * everything has 50 in stock never shows two thirds of the UI.
+     */
+    private const CATALOGUE = [
+        'electronics' => [
+            ['Smartphone', 699.99, 'Latest model smartphone with 5G.', 42, true],
+            ['Laptop', 999.99, 'Lightweight laptop for everyday use.', 18, true],
+            ['Bluetooth Speaker', 49.99, 'Portable speaker with excellent sound.', 64, false],
+        ],
+        'clothing' => [
+            ['T-Shirt', 19.99, 'Cotton T-shirt available in various colors.', 120, false],
+            ['Jeans', 39.99, 'Slim-fit denim jeans.', 37, false],
+            ['Jacket', 79.99, 'Water-resistant windbreaker.', 3, false],
+        ],
+        'books' => [
+            ['Science Fiction Novel', 12.99, 'Best-selling sci-fi adventure.', 85, false],
+            ['Cookbook', 29.99, 'Recipes for healthy eating.', 24, false],
+            ["Children's Storybook", 9.99, 'A fun and educational children’s book.', 56, false],
+        ],
+        'home' => [
+            ['Blender', 49.99, 'High-powered blender for smoothies.', 31, false],
+            ['Non-stick Pan', 29.99, 'Durable non-stick frying pan.', 48, false],
+            ['Vacuum Cleaner', 99.99, 'Compact vacuum cleaner for small spaces.', 12, false],
+        ],
+        'sports' => [
+            ['Yoga Mat', 19.99, 'Eco-friendly non-slip yoga mat.', 73, true],
+            ['Dumbbells Set', 49.99, 'Adjustable dumbbell set for home workouts.', 15, false],
+            ['Tennis Racket', 79.99, 'Professional tennis racket.', 0, false],
+        ],
+        'beauty' => [
+            ['Moisturizer Cream', 24.99, 'Hydrating facial moisturizer.', 66, false],
+            ['Shampoo', 14.99, 'Sulfate-free shampoo for healthy hair.', 94, false],
+            ['Electric Toothbrush', 39.99, 'Rechargeable electric toothbrush.', 2, false],
+        ],
+        'toys' => [
+            ['Building Blocks Set', 29.99, 'Creative building blocks for kids.', 40, false],
+            ['Remote Control Car', 49.99, 'High-speed remote control car.', 0, false],
+            ['Board Game', 19.99, 'Fun family board game.', 27, true],
+        ],
+    ];
+
     public function run(): void
     {
-         // Fetch categories by slug to avoid hardcoding IDs
-         $electronicsCategory = ProductCategory::where('slug', 'electronics')->first();
-         $clothingCategory = ProductCategory::where('slug', 'clothing')->first();
-         $booksCategory = ProductCategory::where('slug', 'books')->first();
-         $homeKitchenCategory = ProductCategory::where('slug', 'home')->first();
-         $sportsOutdoorsCategory = ProductCategory::where('slug', 'sports')->first();
-         $healthBeautyCategory = ProductCategory::where('slug', 'beauty')->first();
-         $toysGamesCategory = ProductCategory::where('slug', 'toys')->first();
- 
-         // Products for Electronics
-         Product::factory()->create([
-             'name' => 'Smartphone', 
-             'category_id' => $electronicsCategory->id, 
-             'price' => 699.99, 
-             'short_description' => 'Latest model smartphone with 5G.',
-         ]);
-         Product::factory()->create([
-             'name' => 'Laptop', 
-             'category_id' => $electronicsCategory->id, 
-             'price' => 999.99, 
-             'short_description' => 'Lightweight laptop for everyday use.'
-         ]);
-         Product::factory()->create([
-             'name' => 'Bluetooth Speaker', 
-             'category_id' => $electronicsCategory->id, 
-             'price' => 49.99, 
-             'short_description' => 'Portable speaker with excellent sound.'
-         ]);
- 
-         // Products for Clothing
-         Product::factory()->create([
-             'name' => 'T-Shirt', 
-             'category_id' => $clothingCategory->id, 
-             'price' => 19.99, 
-             'short_description' => 'Cotton T-shirt available in various colors.'
-         ]);
-         Product::factory()->create([
-             'name' => 'Jeans', 
-             'category_id' => $clothingCategory->id, 
-             'price' => 39.99, 
-             'short_description' => 'Slim-fit denim jeans.'
-         ]);
-         Product::factory()->create([
-             'name' => 'Jacket', 
-             'category_id' => $clothingCategory->id, 
-             'price' => 79.99, 
-             'short_description' => 'Water-resistant windbreaker.'
-         ]);
- 
-         // Products for Books
-         Product::factory()->create([
-             'name' => 'Science Fiction Novel', 
-             'category_id' => $booksCategory->id, 
-             'price' => 12.99, 
-             'short_description' => 'Best-selling sci-fi adventure.'
-         ]);
-         Product::factory()->create([
-             'name' => 'Cookbook', 
-             'category_id' => $booksCategory->id, 
-             'price' => 29.99, 
-             'short_description' => 'Recipes for healthy eating.'
-         ]);
-         Product::factory()->create([
-             'name' => 'Children\'s Storybook', 
-             'category_id' => $booksCategory->id, 
-             'price' => 9.99, 
-             'short_description' => 'A fun and educational children’s book.'
-         ]);
- 
-         // Products for Home & Kitchen
-         Product::factory()->create([
-             'name' => 'Blender', 
-             'category_id' => $homeKitchenCategory->id, 
-             'price' => 49.99, 
-             'short_description' => 'High-powered blender for smoothies.'
-         ]);
-         Product::factory()->create([
-             'name' => 'Non-stick Pan', 
-             'category_id' => $homeKitchenCategory->id, 
-             'price' => 29.99, 
-             'short_description' => 'Durable non-stick frying pan.'
-         ]);
-         Product::factory()->create([
-             'name' => 'Vacuum Cleaner', 
-             'category_id' => $homeKitchenCategory->id, 
-             'price' => 99.99, 
-             'short_description' => 'Compact vacuum cleaner for small spaces.'
-         ]);
- 
-         // Products for Sports & Outdoors
-         Product::factory()->create([
-             'name' => 'Yoga Mat', 
-             'category_id' => $sportsOutdoorsCategory->id, 
-             'price' => 19.99, 
-             'short_description' => 'Eco-friendly non-slip yoga mat.'
-         ]);
-         Product::factory()->create([
-             'name' => 'Dumbbells Set', 
-             'category_id' => $sportsOutdoorsCategory->id, 
-             'price' => 49.99, 
-             'short_description' => 'Adjustable dumbbell set for home workouts.'
-         ]);
-         Product::factory()->create([
-             'name' => 'Tennis Racket', 
-             'category_id' => $sportsOutdoorsCategory->id, 
-             'price' => 79.99, 
-             'short_description' => 'Professional tennis racket.'
-         ]);
- 
-         // Products for Health & Beauty
-         Product::factory()->create([
-             'name' => 'Moisturizer Cream', 
-             'category_id' => $healthBeautyCategory->id, 
-             'price' => 24.99, 
-             'short_description' => 'Hydrating facial moisturizer.'
-         ]);
-         Product::factory()->create([
-             'name' => 'Shampoo', 
-             'category_id' => $healthBeautyCategory->id, 
-             'price' => 14.99, 
-             'short_description' => 'Sulfate-free shampoo for healthy hair.'
-         ]);
-         Product::factory()->create([
-             'name' => 'Electric Toothbrush', 
-             'category_id' => $healthBeautyCategory->id, 
-             'price' => 39.99, 
-             'short_description' => 'Rechargeable electric toothbrush.'
-         ]);
- 
-         // Products for Toys & Games
-         Product::factory()->create([
-             'name' => 'Building Blocks Set', 
-             'category_id' => $toysGamesCategory->id, 
-             'price' => 29.99, 
-             'short_description' => 'Creative building blocks for kids.'
-         ]);
-         Product::factory()->create([
-             'name' => 'Remote Control Car', 
-             'category_id' => $toysGamesCategory->id, 
-             'price' => 49.99, 
-             'short_description' => 'High-speed remote control car.'
-         ]);
-         Product::factory()->create([
-             'name' => 'Board Game', 
-             'category_id' => $toysGamesCategory->id, 
-             'price' => 19.99, 
-             'short_description' => 'Fun family board game.'
-         ]);
-     }
+        foreach (self::CATALOGUE as $slug => $products) {
+            // Look categories up by slug rather than hardcoding IDs. firstOrFail
+            // so a missing category is a clear error, not products with a null
+            // category_id.
+            $categoryId = ProductCategory::where('slug', $slug)->firstOrFail()->id;
+
+            foreach ($products as [$name, $price, $shortDescription, $stock, $isFeatured]) {
+                Product::factory()->create([
+                    'name' => $name,
+                    'category_id' => $categoryId,
+                    'price' => $price,
+                    'short_description' => $shortDescription,
+                    'inventory_count' => $stock,
+                    'low_stock_threshold' => self::LOW_STOCK_THRESHOLD,
+                    'is_featured' => $isFeatured,
+                ]);
+            }
+        }
+    }
 }

--- a/database/seeders/PermissionsTableSeeder.php
+++ b/database/seeders/PermissionsTableSeeder.php
@@ -8,7 +8,6 @@ use Spatie\Permission\PermissionRegistrar;
 
 class PermissionsTableSeeder extends Seeder
 {
-
     /**
      * Auto generated seed file
      *
@@ -22,1376 +21,1373 @@ class PermissionsTableSeeder extends Seeder
         \DB::table('permissions')->delete();
         Schema::enableForeignKeyConstraints();
 
-        \DB::table('permissions')->insert(array (
-            0 => 
-            array (
+        \DB::table('permissions')->insert([
+            0 => [
                 'id' => 1,
                 'name' => 'view_cart::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:04',
                 'updated_at' => '2024-09-04 14:12:04',
-            ),
-            1 => 
-            array (
+            ],
+            1 => [
                 'id' => 2,
                 'name' => 'view_any_cart::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:05',
                 'updated_at' => '2024-09-04 14:12:05',
-            ),
-            2 => 
-            array (
+            ],
+            2 => [
                 'id' => 3,
                 'name' => 'create_cart::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:05',
                 'updated_at' => '2024-09-04 14:12:05',
-            ),
-            3 => 
-            array (
+            ],
+            3 => [
                 'id' => 4,
                 'name' => 'update_cart::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:05',
                 'updated_at' => '2024-09-04 14:12:05',
-            ),
-            4 => 
-            array (
+            ],
+            4 => [
                 'id' => 5,
                 'name' => 'restore_cart::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:05',
                 'updated_at' => '2024-09-04 14:12:05',
-            ),
-            5 => 
-            array (
+            ],
+            5 => [
                 'id' => 6,
                 'name' => 'restore_any_cart::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:05',
                 'updated_at' => '2024-09-04 14:12:05',
-            ),
-            6 => 
-            array (
+            ],
+            6 => [
                 'id' => 7,
                 'name' => 'replicate_cart::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:05',
                 'updated_at' => '2024-09-04 14:12:05',
-            ),
-            7 => 
-            array (
+            ],
+            7 => [
                 'id' => 8,
                 'name' => 'reorder_cart::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:06',
                 'updated_at' => '2024-09-04 14:12:06',
-            ),
-            8 => 
-            array (
+            ],
+            8 => [
                 'id' => 9,
                 'name' => 'delete_cart::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:06',
                 'updated_at' => '2024-09-04 14:12:06',
-            ),
-            9 => 
-            array (
+            ],
+            9 => [
                 'id' => 10,
                 'name' => 'delete_any_cart::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:06',
                 'updated_at' => '2024-09-04 14:12:06',
-            ),
-            10 => 
-            array (
+            ],
+            10 => [
                 'id' => 11,
                 'name' => 'force_delete_cart::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:06',
                 'updated_at' => '2024-09-04 14:12:06',
-            ),
-            11 => 
-            array (
+            ],
+            11 => [
                 'id' => 12,
                 'name' => 'force_delete_any_cart::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:06',
                 'updated_at' => '2024-09-04 14:12:06',
-            ),
-            12 => 
-            array (
+            ],
+            12 => [
                 'id' => 13,
                 'name' => 'view_customer',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:06',
                 'updated_at' => '2024-09-04 14:12:06',
-            ),
-            13 => 
-            array (
+            ],
+            13 => [
                 'id' => 14,
                 'name' => 'view_any_customer',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:06',
                 'updated_at' => '2024-09-04 14:12:06',
-            ),
-            14 => 
-            array (
+            ],
+            14 => [
                 'id' => 15,
                 'name' => 'create_customer',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:07',
                 'updated_at' => '2024-09-04 14:12:07',
-            ),
-            15 => 
-            array (
+            ],
+            15 => [
                 'id' => 16,
                 'name' => 'update_customer',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:07',
                 'updated_at' => '2024-09-04 14:12:07',
-            ),
-            16 => 
-            array (
+            ],
+            16 => [
                 'id' => 17,
                 'name' => 'restore_customer',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:07',
                 'updated_at' => '2024-09-04 14:12:07',
-            ),
-            17 => 
-            array (
+            ],
+            17 => [
                 'id' => 18,
                 'name' => 'restore_any_customer',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:07',
                 'updated_at' => '2024-09-04 14:12:07',
-            ),
-            18 => 
-            array (
+            ],
+            18 => [
                 'id' => 19,
                 'name' => 'replicate_customer',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:07',
                 'updated_at' => '2024-09-04 14:12:07',
-            ),
-            19 => 
-            array (
+            ],
+            19 => [
                 'id' => 20,
                 'name' => 'reorder_customer',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:07',
                 'updated_at' => '2024-09-04 14:12:07',
-            ),
-            20 => 
-            array (
+            ],
+            20 => [
                 'id' => 21,
                 'name' => 'delete_customer',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:07',
                 'updated_at' => '2024-09-04 14:12:07',
-            ),
-            21 => 
-            array (
+            ],
+            21 => [
                 'id' => 22,
                 'name' => 'delete_any_customer',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:08',
                 'updated_at' => '2024-09-04 14:12:08',
-            ),
-            22 => 
-            array (
+            ],
+            22 => [
                 'id' => 23,
                 'name' => 'force_delete_customer',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:08',
                 'updated_at' => '2024-09-04 14:12:08',
-            ),
-            23 => 
-            array (
+            ],
+            23 => [
                 'id' => 24,
                 'name' => 'force_delete_any_customer',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:08',
                 'updated_at' => '2024-09-04 14:12:08',
-            ),
-            24 => 
-            array (
+            ],
+            24 => [
                 'id' => 25,
                 'name' => 'view_group',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:08',
                 'updated_at' => '2024-09-04 14:12:08',
-            ),
-            25 => 
-            array (
+            ],
+            25 => [
                 'id' => 26,
                 'name' => 'view_any_group',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:08',
                 'updated_at' => '2024-09-04 14:12:08',
-            ),
-            26 => 
-            array (
+            ],
+            26 => [
                 'id' => 27,
                 'name' => 'create_group',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:08',
                 'updated_at' => '2024-09-04 14:12:08',
-            ),
-            27 => 
-            array (
+            ],
+            27 => [
                 'id' => 28,
                 'name' => 'update_group',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:08',
                 'updated_at' => '2024-09-04 14:12:08',
-            ),
-            28 => 
-            array (
+            ],
+            28 => [
                 'id' => 29,
                 'name' => 'restore_group',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:09',
                 'updated_at' => '2024-09-04 14:12:09',
-            ),
-            29 => 
-            array (
+            ],
+            29 => [
                 'id' => 30,
                 'name' => 'restore_any_group',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:09',
                 'updated_at' => '2024-09-04 14:12:09',
-            ),
-            30 => 
-            array (
+            ],
+            30 => [
                 'id' => 31,
                 'name' => 'replicate_group',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:09',
                 'updated_at' => '2024-09-04 14:12:09',
-            ),
-            31 => 
-            array (
+            ],
+            31 => [
                 'id' => 32,
                 'name' => 'reorder_group',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:09',
                 'updated_at' => '2024-09-04 14:12:09',
-            ),
-            32 => 
-            array (
+            ],
+            32 => [
                 'id' => 33,
                 'name' => 'delete_group',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:10',
                 'updated_at' => '2024-09-04 14:12:10',
-            ),
-            33 => 
-            array (
+            ],
+            33 => [
                 'id' => 34,
                 'name' => 'delete_any_group',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:10',
                 'updated_at' => '2024-09-04 14:12:10',
-            ),
-            34 => 
-            array (
+            ],
+            34 => [
                 'id' => 35,
                 'name' => 'force_delete_group',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:10',
                 'updated_at' => '2024-09-04 14:12:10',
-            ),
-            35 => 
-            array (
+            ],
+            35 => [
                 'id' => 36,
                 'name' => 'force_delete_any_group',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:10',
                 'updated_at' => '2024-09-04 14:12:10',
-            ),
-            36 => 
-            array (
+            ],
+            36 => [
                 'id' => 37,
                 'name' => 'view_invoice',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:10',
                 'updated_at' => '2024-09-04 14:12:10',
-            ),
-            37 => 
-            array (
+            ],
+            37 => [
                 'id' => 38,
                 'name' => 'view_any_invoice',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:10',
                 'updated_at' => '2024-09-04 14:12:10',
-            ),
-            38 => 
-            array (
+            ],
+            38 => [
                 'id' => 39,
                 'name' => 'create_invoice',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:11',
                 'updated_at' => '2024-09-04 14:12:11',
-            ),
-            39 => 
-            array (
+            ],
+            39 => [
                 'id' => 40,
                 'name' => 'update_invoice',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:11',
                 'updated_at' => '2024-09-04 14:12:11',
-            ),
-            40 => 
-            array (
+            ],
+            40 => [
                 'id' => 41,
                 'name' => 'restore_invoice',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:11',
                 'updated_at' => '2024-09-04 14:12:11',
-            ),
-            41 => 
-            array (
+            ],
+            41 => [
                 'id' => 42,
                 'name' => 'restore_any_invoice',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:11',
                 'updated_at' => '2024-09-04 14:12:11',
-            ),
-            42 => 
-            array (
+            ],
+            42 => [
                 'id' => 43,
                 'name' => 'replicate_invoice',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:11',
                 'updated_at' => '2024-09-04 14:12:11',
-            ),
-            43 => 
-            array (
+            ],
+            43 => [
                 'id' => 44,
                 'name' => 'reorder_invoice',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:11',
                 'updated_at' => '2024-09-04 14:12:11',
-            ),
-            44 => 
-            array (
+            ],
+            44 => [
                 'id' => 45,
                 'name' => 'delete_invoice',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:12',
                 'updated_at' => '2024-09-04 14:12:12',
-            ),
-            45 => 
-            array (
+            ],
+            45 => [
                 'id' => 46,
                 'name' => 'delete_any_invoice',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:12',
                 'updated_at' => '2024-09-04 14:12:12',
-            ),
-            46 => 
-            array (
+            ],
+            46 => [
                 'id' => 47,
                 'name' => 'force_delete_invoice',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:12',
                 'updated_at' => '2024-09-04 14:12:12',
-            ),
-            47 => 
-            array (
+            ],
+            47 => [
                 'id' => 48,
                 'name' => 'force_delete_any_invoice',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:12',
                 'updated_at' => '2024-09-04 14:12:12',
-            ),
-            48 => 
-            array (
+            ],
+            48 => [
                 'id' => 49,
                 'name' => 'view_order',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:12',
                 'updated_at' => '2024-09-04 14:12:12',
-            ),
-            49 => 
-            array (
+            ],
+            49 => [
                 'id' => 50,
                 'name' => 'view_any_order',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:12',
                 'updated_at' => '2024-09-04 14:12:12',
-            ),
-            50 => 
-            array (
+            ],
+            50 => [
                 'id' => 51,
                 'name' => 'create_order',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:13',
                 'updated_at' => '2024-09-04 14:12:13',
-            ),
-            51 => 
-            array (
+            ],
+            51 => [
                 'id' => 52,
                 'name' => 'update_order',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:13',
                 'updated_at' => '2024-09-04 14:12:13',
-            ),
-            52 => 
-            array (
+            ],
+            52 => [
                 'id' => 53,
                 'name' => 'restore_order',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:13',
                 'updated_at' => '2024-09-04 14:12:13',
-            ),
-            53 => 
-            array (
+            ],
+            53 => [
                 'id' => 54,
                 'name' => 'restore_any_order',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:13',
                 'updated_at' => '2024-09-04 14:12:13',
-            ),
-            54 => 
-            array (
+            ],
+            54 => [
                 'id' => 55,
                 'name' => 'replicate_order',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:13',
                 'updated_at' => '2024-09-04 14:12:13',
-            ),
-            55 => 
-            array (
+            ],
+            55 => [
                 'id' => 56,
                 'name' => 'reorder_order',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:14',
                 'updated_at' => '2024-09-04 14:12:14',
-            ),
-            56 => 
-            array (
+            ],
+            56 => [
                 'id' => 57,
                 'name' => 'delete_order',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:14',
                 'updated_at' => '2024-09-04 14:12:14',
-            ),
-            57 => 
-            array (
+            ],
+            57 => [
                 'id' => 58,
                 'name' => 'delete_any_order',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:14',
                 'updated_at' => '2024-09-04 14:12:14',
-            ),
-            58 => 
-            array (
+            ],
+            58 => [
                 'id' => 59,
                 'name' => 'force_delete_order',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:14',
                 'updated_at' => '2024-09-04 14:12:14',
-            ),
-            59 => 
-            array (
+            ],
+            59 => [
                 'id' => 60,
                 'name' => 'force_delete_any_order',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:14',
                 'updated_at' => '2024-09-04 14:12:14',
-            ),
-            60 => 
-            array (
+            ],
+            60 => [
                 'id' => 61,
                 'name' => 'view_order::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:14',
                 'updated_at' => '2024-09-04 14:12:14',
-            ),
-            61 => 
-            array (
+            ],
+            61 => [
                 'id' => 62,
                 'name' => 'view_any_order::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:15',
                 'updated_at' => '2024-09-04 14:12:15',
-            ),
-            62 => 
-            array (
+            ],
+            62 => [
                 'id' => 63,
                 'name' => 'create_order::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:15',
                 'updated_at' => '2024-09-04 14:12:15',
-            ),
-            63 => 
-            array (
+            ],
+            63 => [
                 'id' => 64,
                 'name' => 'update_order::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:15',
                 'updated_at' => '2024-09-04 14:12:15',
-            ),
-            64 => 
-            array (
+            ],
+            64 => [
                 'id' => 65,
                 'name' => 'restore_order::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:15',
                 'updated_at' => '2024-09-04 14:12:15',
-            ),
-            65 => 
-            array (
+            ],
+            65 => [
                 'id' => 66,
                 'name' => 'restore_any_order::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:15',
                 'updated_at' => '2024-09-04 14:12:15',
-            ),
-            66 => 
-            array (
+            ],
+            66 => [
                 'id' => 67,
                 'name' => 'replicate_order::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:16',
                 'updated_at' => '2024-09-04 14:12:16',
-            ),
-            67 => 
-            array (
+            ],
+            67 => [
                 'id' => 68,
                 'name' => 'reorder_order::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:16',
                 'updated_at' => '2024-09-04 14:12:16',
-            ),
-            68 => 
-            array (
+            ],
+            68 => [
                 'id' => 69,
                 'name' => 'delete_order::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:16',
                 'updated_at' => '2024-09-04 14:12:16',
-            ),
-            69 => 
-            array (
+            ],
+            69 => [
                 'id' => 70,
                 'name' => 'delete_any_order::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:16',
                 'updated_at' => '2024-09-04 14:12:16',
-            ),
-            70 => 
-            array (
+            ],
+            70 => [
                 'id' => 71,
                 'name' => 'force_delete_order::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:16',
                 'updated_at' => '2024-09-04 14:12:16',
-            ),
-            71 => 
-            array (
+            ],
+            71 => [
                 'id' => 72,
                 'name' => 'force_delete_any_order::item',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:16',
                 'updated_at' => '2024-09-04 14:12:16',
-            ),
-            72 => 
-            array (
+            ],
+            72 => [
                 'id' => 73,
                 'name' => 'view_product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:17',
                 'updated_at' => '2024-09-04 14:12:17',
-            ),
-            73 => 
-            array (
+            ],
+            73 => [
                 'id' => 74,
                 'name' => 'view_any_product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:17',
                 'updated_at' => '2024-09-04 14:12:17',
-            ),
-            74 => 
-            array (
+            ],
+            74 => [
                 'id' => 75,
                 'name' => 'create_product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:17',
                 'updated_at' => '2024-09-04 14:12:17',
-            ),
-            75 => 
-            array (
+            ],
+            75 => [
                 'id' => 76,
                 'name' => 'update_product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:17',
                 'updated_at' => '2024-09-04 14:12:17',
-            ),
-            76 => 
-            array (
+            ],
+            76 => [
                 'id' => 77,
                 'name' => 'restore_product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:17',
                 'updated_at' => '2024-09-04 14:12:17',
-            ),
-            77 => 
-            array (
+            ],
+            77 => [
                 'id' => 78,
                 'name' => 'restore_any_product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:18',
                 'updated_at' => '2024-09-04 14:12:18',
-            ),
-            78 => 
-            array (
+            ],
+            78 => [
                 'id' => 79,
                 'name' => 'replicate_product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:18',
                 'updated_at' => '2024-09-04 14:12:18',
-            ),
-            79 => 
-            array (
+            ],
+            79 => [
                 'id' => 80,
                 'name' => 'reorder_product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:18',
                 'updated_at' => '2024-09-04 14:12:18',
-            ),
-            80 => 
-            array (
+            ],
+            80 => [
                 'id' => 81,
                 'name' => 'delete_product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:18',
                 'updated_at' => '2024-09-04 14:12:18',
-            ),
-            81 => 
-            array (
+            ],
+            81 => [
                 'id' => 82,
                 'name' => 'delete_any_product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:19',
                 'updated_at' => '2024-09-04 14:12:19',
-            ),
-            82 => 
-            array (
+            ],
+            82 => [
                 'id' => 83,
                 'name' => 'force_delete_product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:19',
                 'updated_at' => '2024-09-04 14:12:19',
-            ),
-            83 => 
-            array (
+            ],
+            83 => [
                 'id' => 84,
                 'name' => 'force_delete_any_product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:19',
                 'updated_at' => '2024-09-04 14:12:19',
-            ),
-            84 => 
-            array (
+            ],
+            84 => [
                 'id' => 85,
                 'name' => 'view_product::category',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:19',
                 'updated_at' => '2024-09-04 14:12:19',
-            ),
-            85 => 
-            array (
+            ],
+            85 => [
                 'id' => 86,
                 'name' => 'view_any_product::category',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:19',
                 'updated_at' => '2024-09-04 14:12:19',
-            ),
-            86 => 
-            array (
+            ],
+            86 => [
                 'id' => 87,
                 'name' => 'create_product::category',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:19',
                 'updated_at' => '2024-09-04 14:12:19',
-            ),
-            87 => 
-            array (
+            ],
+            87 => [
                 'id' => 88,
                 'name' => 'update_product::category',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:20',
                 'updated_at' => '2024-09-04 14:12:20',
-            ),
-            88 => 
-            array (
+            ],
+            88 => [
                 'id' => 89,
                 'name' => 'restore_product::category',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:20',
                 'updated_at' => '2024-09-04 14:12:20',
-            ),
-            89 => 
-            array (
+            ],
+            89 => [
                 'id' => 90,
                 'name' => 'restore_any_product::category',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:20',
                 'updated_at' => '2024-09-04 14:12:20',
-            ),
-            90 => 
-            array (
+            ],
+            90 => [
                 'id' => 91,
                 'name' => 'replicate_product::category',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:20',
                 'updated_at' => '2024-09-04 14:12:20',
-            ),
-            91 => 
-            array (
+            ],
+            91 => [
                 'id' => 92,
                 'name' => 'reorder_product::category',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:20',
                 'updated_at' => '2024-09-04 14:12:20',
-            ),
-            92 => 
-            array (
+            ],
+            92 => [
                 'id' => 93,
                 'name' => 'delete_product::category',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:20',
                 'updated_at' => '2024-09-04 14:12:20',
-            ),
-            93 => 
-            array (
+            ],
+            93 => [
                 'id' => 94,
                 'name' => 'delete_any_product::category',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:21',
                 'updated_at' => '2024-09-04 14:12:21',
-            ),
-            94 => 
-            array (
+            ],
+            94 => [
                 'id' => 95,
                 'name' => 'force_delete_product::category',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:21',
                 'updated_at' => '2024-09-04 14:12:21',
-            ),
-            95 => 
-            array (
+            ],
+            95 => [
                 'id' => 96,
                 'name' => 'force_delete_any_product::category',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:21',
                 'updated_at' => '2024-09-04 14:12:21',
-            ),
-            96 => 
-            array (
+            ],
+            96 => [
                 'id' => 97,
                 'name' => 'view_product::rating',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:21',
                 'updated_at' => '2024-09-04 14:12:21',
-            ),
-            97 => 
-            array (
+            ],
+            97 => [
                 'id' => 98,
                 'name' => 'view_any_product::rating',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:21',
                 'updated_at' => '2024-09-04 14:12:21',
-            ),
-            98 => 
-            array (
+            ],
+            98 => [
                 'id' => 99,
                 'name' => 'create_product::rating',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:22',
                 'updated_at' => '2024-09-04 14:12:22',
-            ),
-            99 => 
-            array (
+            ],
+            99 => [
                 'id' => 100,
                 'name' => 'update_product::rating',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:22',
                 'updated_at' => '2024-09-04 14:12:22',
-            ),
-            100 => 
-            array (
+            ],
+            100 => [
                 'id' => 101,
                 'name' => 'restore_product::rating',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:22',
                 'updated_at' => '2024-09-04 14:12:22',
-            ),
-            101 => 
-            array (
+            ],
+            101 => [
                 'id' => 102,
                 'name' => 'restore_any_product::rating',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:22',
                 'updated_at' => '2024-09-04 14:12:22',
-            ),
-            102 => 
-            array (
+            ],
+            102 => [
                 'id' => 103,
                 'name' => 'replicate_product::rating',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:22',
                 'updated_at' => '2024-09-04 14:12:22',
-            ),
-            103 => 
-            array (
+            ],
+            103 => [
                 'id' => 104,
                 'name' => 'reorder_product::rating',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:22',
                 'updated_at' => '2024-09-04 14:12:22',
-            ),
-            104 => 
-            array (
+            ],
+            104 => [
                 'id' => 105,
                 'name' => 'delete_product::rating',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:23',
                 'updated_at' => '2024-09-04 14:12:23',
-            ),
-            105 => 
-            array (
+            ],
+            105 => [
                 'id' => 106,
                 'name' => 'delete_any_product::rating',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:23',
                 'updated_at' => '2024-09-04 14:12:23',
-            ),
-            106 => 
-            array (
+            ],
+            106 => [
                 'id' => 107,
                 'name' => 'force_delete_product::rating',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:23',
                 'updated_at' => '2024-09-04 14:12:23',
-            ),
-            107 => 
-            array (
+            ],
+            107 => [
                 'id' => 108,
                 'name' => 'force_delete_any_product::rating',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:23',
                 'updated_at' => '2024-09-04 14:12:23',
-            ),
-            108 => 
-            array (
+            ],
+            108 => [
                 'id' => 109,
                 'name' => 'view_product::review',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:23',
                 'updated_at' => '2024-09-04 14:12:23',
-            ),
-            109 => 
-            array (
+            ],
+            109 => [
                 'id' => 110,
                 'name' => 'view_any_product::review',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:23',
                 'updated_at' => '2024-09-04 14:12:23',
-            ),
-            110 => 
-            array (
+            ],
+            110 => [
                 'id' => 111,
                 'name' => 'create_product::review',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:24',
                 'updated_at' => '2024-09-04 14:12:24',
-            ),
-            111 => 
-            array (
+            ],
+            111 => [
                 'id' => 112,
                 'name' => 'update_product::review',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:24',
                 'updated_at' => '2024-09-04 14:12:24',
-            ),
-            112 => 
-            array (
+            ],
+            112 => [
                 'id' => 113,
                 'name' => 'restore_product::review',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:24',
                 'updated_at' => '2024-09-04 14:12:24',
-            ),
-            113 => 
-            array (
+            ],
+            113 => [
                 'id' => 114,
                 'name' => 'restore_any_product::review',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:24',
                 'updated_at' => '2024-09-04 14:12:24',
-            ),
-            114 => 
-            array (
+            ],
+            114 => [
                 'id' => 115,
                 'name' => 'replicate_product::review',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:24',
                 'updated_at' => '2024-09-04 14:12:24',
-            ),
-            115 => 
-            array (
+            ],
+            115 => [
                 'id' => 116,
                 'name' => 'reorder_product::review',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:24',
                 'updated_at' => '2024-09-04 14:12:24',
-            ),
-            116 => 
-            array (
+            ],
+            116 => [
                 'id' => 117,
                 'name' => 'delete_product::review',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:25',
                 'updated_at' => '2024-09-04 14:12:25',
-            ),
-            117 => 
-            array (
+            ],
+            117 => [
                 'id' => 118,
                 'name' => 'delete_any_product::review',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:25',
                 'updated_at' => '2024-09-04 14:12:25',
-            ),
-            118 => 
-            array (
+            ],
+            118 => [
                 'id' => 119,
                 'name' => 'force_delete_product::review',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:25',
                 'updated_at' => '2024-09-04 14:12:25',
-            ),
-            119 => 
-            array (
+            ],
+            119 => [
                 'id' => 120,
                 'name' => 'force_delete_any_product::review',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:25',
                 'updated_at' => '2024-09-04 14:12:25',
-            ),
-            120 => 
-            array (
+            ],
+            120 => [
                 'id' => 121,
                 'name' => 'view_product::tag',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:25',
                 'updated_at' => '2024-09-04 14:12:25',
-            ),
-            121 => 
-            array (
+            ],
+            121 => [
                 'id' => 122,
                 'name' => 'view_any_product::tag',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:25',
                 'updated_at' => '2024-09-04 14:12:25',
-            ),
-            122 => 
-            array (
+            ],
+            122 => [
                 'id' => 123,
                 'name' => 'create_product::tag',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:26',
                 'updated_at' => '2024-09-04 14:12:26',
-            ),
-            123 => 
-            array (
+            ],
+            123 => [
                 'id' => 124,
                 'name' => 'update_product::tag',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:26',
                 'updated_at' => '2024-09-04 14:12:26',
-            ),
-            124 => 
-            array (
+            ],
+            124 => [
                 'id' => 125,
                 'name' => 'restore_product::tag',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:26',
                 'updated_at' => '2024-09-04 14:12:26',
-            ),
-            125 => 
-            array (
+            ],
+            125 => [
                 'id' => 126,
                 'name' => 'restore_any_product::tag',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:26',
                 'updated_at' => '2024-09-04 14:12:26',
-            ),
-            126 => 
-            array (
+            ],
+            126 => [
                 'id' => 127,
                 'name' => 'replicate_product::tag',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:26',
                 'updated_at' => '2024-09-04 14:12:26',
-            ),
-            127 => 
-            array (
+            ],
+            127 => [
                 'id' => 128,
                 'name' => 'reorder_product::tag',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:26',
                 'updated_at' => '2024-09-04 14:12:26',
-            ),
-            128 => 
-            array (
+            ],
+            128 => [
                 'id' => 129,
                 'name' => 'delete_product::tag',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:27',
                 'updated_at' => '2024-09-04 14:12:27',
-            ),
-            129 => 
-            array (
+            ],
+            129 => [
                 'id' => 130,
                 'name' => 'delete_any_product::tag',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:27',
                 'updated_at' => '2024-09-04 14:12:27',
-            ),
-            130 => 
-            array (
+            ],
+            130 => [
                 'id' => 131,
                 'name' => 'force_delete_product::tag',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:27',
                 'updated_at' => '2024-09-04 14:12:27',
-            ),
-            131 => 
-            array (
+            ],
+            131 => [
                 'id' => 132,
                 'name' => 'force_delete_any_product::tag',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:27',
                 'updated_at' => '2024-09-04 14:12:27',
-            ),
-            132 => 
-            array (
+            ],
+            132 => [
                 'id' => 133,
                 'name' => 'view_simple::product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:27',
                 'updated_at' => '2024-09-04 14:12:27',
-            ),
-            133 => 
-            array (
+            ],
+            133 => [
                 'id' => 134,
                 'name' => 'view_any_simple::product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:27',
                 'updated_at' => '2024-09-04 14:12:27',
-            ),
-            134 => 
-            array (
+            ],
+            134 => [
                 'id' => 135,
                 'name' => 'create_simple::product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:28',
                 'updated_at' => '2024-09-04 14:12:28',
-            ),
-            135 => 
-            array (
+            ],
+            135 => [
                 'id' => 136,
                 'name' => 'update_simple::product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:28',
                 'updated_at' => '2024-09-04 14:12:28',
-            ),
-            136 => 
-            array (
+            ],
+            136 => [
                 'id' => 137,
                 'name' => 'restore_simple::product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:28',
                 'updated_at' => '2024-09-04 14:12:28',
-            ),
-            137 => 
-            array (
+            ],
+            137 => [
                 'id' => 138,
                 'name' => 'restore_any_simple::product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:28',
                 'updated_at' => '2024-09-04 14:12:28',
-            ),
-            138 => 
-            array (
+            ],
+            138 => [
                 'id' => 139,
                 'name' => 'replicate_simple::product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:29',
                 'updated_at' => '2024-09-04 14:12:29',
-            ),
-            139 => 
-            array (
+            ],
+            139 => [
                 'id' => 140,
                 'name' => 'reorder_simple::product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:29',
                 'updated_at' => '2024-09-04 14:12:29',
-            ),
-            140 => 
-            array (
+            ],
+            140 => [
                 'id' => 141,
                 'name' => 'delete_simple::product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:29',
                 'updated_at' => '2024-09-04 14:12:29',
-            ),
-            141 => 
-            array (
+            ],
+            141 => [
                 'id' => 142,
                 'name' => 'delete_any_simple::product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:30',
                 'updated_at' => '2024-09-04 14:12:30',
-            ),
-            142 => 
-            array (
+            ],
+            142 => [
                 'id' => 143,
                 'name' => 'force_delete_simple::product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:30',
                 'updated_at' => '2024-09-04 14:12:30',
-            ),
-            143 => 
-            array (
+            ],
+            143 => [
                 'id' => 144,
                 'name' => 'force_delete_any_simple::product',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:30',
                 'updated_at' => '2024-09-04 14:12:30',
-            ),
-            144 => 
-            array (
+            ],
+            144 => [
                 'id' => 145,
                 'name' => 'page_EditProfile',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:30',
                 'updated_at' => '2024-09-04 14:12:30',
-            ),
-            145 => 
-            array (
+            ],
+            145 => [
                 'id' => 146,
                 'name' => 'page_PersonalAccessTokensPage',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:31',
                 'updated_at' => '2024-09-04 14:12:31',
-            ),
-            146 => 
-            array (
+            ],
+            146 => [
                 'id' => 147,
                 'name' => 'page_UpdateProfileInformationPage',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:12:31',
                 'updated_at' => '2024-09-04 14:12:31',
-            ),
-            147 => 
-            array (
+            ],
+            147 => [
                 'id' => 148,
                 'name' => 'view_coupon',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:23',
                 'updated_at' => '2024-09-04 14:20:23',
-            ),
-            148 => 
-            array (
+            ],
+            148 => [
                 'id' => 149,
                 'name' => 'view_any_coupon',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:23',
                 'updated_at' => '2024-09-04 14:20:23',
-            ),
-            149 => 
-            array (
+            ],
+            149 => [
                 'id' => 150,
                 'name' => 'create_coupon',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:23',
                 'updated_at' => '2024-09-04 14:20:23',
-            ),
-            150 => 
-            array (
+            ],
+            150 => [
                 'id' => 151,
                 'name' => 'update_coupon',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:23',
                 'updated_at' => '2024-09-04 14:20:23',
-            ),
-            151 => 
-            array (
+            ],
+            151 => [
                 'id' => 152,
                 'name' => 'restore_coupon',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:23',
                 'updated_at' => '2024-09-04 14:20:23',
-            ),
-            152 => 
-            array (
+            ],
+            152 => [
                 'id' => 153,
                 'name' => 'restore_any_coupon',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:24',
                 'updated_at' => '2024-09-04 14:20:24',
-            ),
-            153 => 
-            array (
+            ],
+            153 => [
                 'id' => 154,
                 'name' => 'replicate_coupon',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:24',
                 'updated_at' => '2024-09-04 14:20:24',
-            ),
-            154 => 
-            array (
+            ],
+            154 => [
                 'id' => 155,
                 'name' => 'reorder_coupon',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:24',
                 'updated_at' => '2024-09-04 14:20:24',
-            ),
-            155 => 
-            array (
+            ],
+            155 => [
                 'id' => 156,
                 'name' => 'delete_coupon',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:24',
                 'updated_at' => '2024-09-04 14:20:24',
-            ),
-            156 => 
-            array (
+            ],
+            156 => [
                 'id' => 157,
                 'name' => 'delete_any_coupon',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:24',
                 'updated_at' => '2024-09-04 14:20:24',
-            ),
-            157 => 
-            array (
+            ],
+            157 => [
                 'id' => 158,
                 'name' => 'force_delete_coupon',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:24',
                 'updated_at' => '2024-09-04 14:20:24',
-            ),
-            158 => 
-            array (
+            ],
+            158 => [
                 'id' => 159,
                 'name' => 'force_delete_any_coupon',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:24',
                 'updated_at' => '2024-09-04 14:20:24',
-            ),
-            159 => 
-            array (
+            ],
+            159 => [
                 'id' => 160,
                 'name' => 'view_store',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:25',
                 'updated_at' => '2024-09-04 14:20:25',
-            ),
-            160 => 
-            array (
+            ],
+            160 => [
                 'id' => 161,
                 'name' => 'view_any_store',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:25',
                 'updated_at' => '2024-09-04 14:20:25',
-            ),
-            161 => 
-            array (
+            ],
+            161 => [
                 'id' => 162,
                 'name' => 'create_store',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:25',
                 'updated_at' => '2024-09-04 14:20:25',
-            ),
-            162 => 
-            array (
+            ],
+            162 => [
                 'id' => 163,
                 'name' => 'update_store',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:25',
                 'updated_at' => '2024-09-04 14:20:25',
-            ),
-            163 => 
-            array (
+            ],
+            163 => [
                 'id' => 164,
                 'name' => 'restore_store',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:25',
                 'updated_at' => '2024-09-04 14:20:25',
-            ),
-            164 => 
-            array (
+            ],
+            164 => [
                 'id' => 165,
                 'name' => 'restore_any_store',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:25',
                 'updated_at' => '2024-09-04 14:20:25',
-            ),
-            165 => 
-            array (
+            ],
+            165 => [
                 'id' => 166,
                 'name' => 'replicate_store',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:26',
                 'updated_at' => '2024-09-04 14:20:26',
-            ),
-            166 => 
-            array (
+            ],
+            166 => [
                 'id' => 167,
                 'name' => 'reorder_store',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:26',
                 'updated_at' => '2024-09-04 14:20:26',
-            ),
-            167 => 
-            array (
+            ],
+            167 => [
                 'id' => 168,
                 'name' => 'delete_store',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:26',
                 'updated_at' => '2024-09-04 14:20:26',
-            ),
-            168 => 
-            array (
+            ],
+            168 => [
                 'id' => 169,
                 'name' => 'delete_any_store',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:26',
                 'updated_at' => '2024-09-04 14:20:26',
-            ),
-            169 => 
-            array (
+            ],
+            169 => [
                 'id' => 170,
                 'name' => 'force_delete_store',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:26',
                 'updated_at' => '2024-09-04 14:20:26',
-            ),
-            170 => 
-            array (
+            ],
+            170 => [
                 'id' => 171,
                 'name' => 'force_delete_any_store',
                 'guard_name' => 'web',
                 'created_at' => '2024-09-04 14:20:26',
                 'updated_at' => '2024-09-04 14:20:26',
-            ),
-        ));
+            ],
+            171 => [
+                'id' => 172,
+                'name' => 'view_article',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            172 => [
+                'id' => 173,
+                'name' => 'view_any_article',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            173 => [
+                'id' => 174,
+                'name' => 'create_article',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            174 => [
+                'id' => 175,
+                'name' => 'update_article',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            175 => [
+                'id' => 176,
+                'name' => 'restore_article',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            176 => [
+                'id' => 177,
+                'name' => 'restore_any_article',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            177 => [
+                'id' => 178,
+                'name' => 'replicate_article',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            178 => [
+                'id' => 179,
+                'name' => 'reorder_article',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            179 => [
+                'id' => 180,
+                'name' => 'delete_article',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            180 => [
+                'id' => 181,
+                'name' => 'delete_any_article',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            181 => [
+                'id' => 182,
+                'name' => 'force_delete_article',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            182 => [
+                'id' => 183,
+                'name' => 'force_delete_any_article',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            183 => [
+                'id' => 184,
+                'name' => 'view_product::collection',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            184 => [
+                'id' => 185,
+                'name' => 'view_any_product::collection',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            185 => [
+                'id' => 186,
+                'name' => 'create_product::collection',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            186 => [
+                'id' => 187,
+                'name' => 'update_product::collection',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            187 => [
+                'id' => 188,
+                'name' => 'restore_product::collection',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            188 => [
+                'id' => 189,
+                'name' => 'restore_any_product::collection',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            189 => [
+                'id' => 190,
+                'name' => 'replicate_product::collection',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            190 => [
+                'id' => 191,
+                'name' => 'reorder_product::collection',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            191 => [
+                'id' => 192,
+                'name' => 'delete_product::collection',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            192 => [
+                'id' => 193,
+                'name' => 'delete_any_product::collection',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            193 => [
+                'id' => 194,
+                'name' => 'force_delete_product::collection',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+            194 => [
+                'id' => 195,
+                'name' => 'force_delete_any_product::collection',
+                'guard_name' => 'web',
+                'created_at' => '2024-09-04 14:20:26',
+                'updated_at' => '2024-09-04 14:20:26',
+            ],
+        ]);
 
         app()[PermissionRegistrar::class]->forgetCachedPermissions();
     }

--- a/tests/Feature/AppPanelAccessTest.php
+++ b/tests/Feature/AppPanelAccessTest.php
@@ -3,6 +3,10 @@
 namespace Tests\Feature;
 
 use App\Actions\Fortify\CreateNewUser;
+use App\Filament\App\Resources\Articles\ArticleResource;
+use App\Filament\App\Resources\Collections\CollectionResource;
+use App\Filament\App\Resources\Orders\OrderResource;
+use App\Filament\App\Resources\Products\ProductResource;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
@@ -105,19 +109,16 @@ class AppPanelAccessTest extends TestCase
     }
 
     /**
-     * The permission-backed resources deny a user who holds no permissions.
+     * Every app-panel resource denies a user who holds no permissions.
      *
-     * Deliberately not asserted here: ArticleResource and CollectionResource have no
-     * policy, and strictAuthorization is off, so Filament's authorization helper
-     * returns allow() for them — a team member can CRUD their own tenant's articles
-     * and collections (price included) without any permission check. That is a real
-     * gap, but a separate change: the Shield permission set has no article_* or
-     * collection_* entries at all, so adding the obvious policy would deny everyone
-     * including super_admin and break the feature. It needs policies AND seeded
-     * permissions together. Tracked, not smuggled in here.
-     *
-     * It is no longer reachable by a stranger either way — that took a team, and
-     * registration no longer hands one out.
+     * Article and Collection are in this list now. They used to be the exception:
+     * no policy, and strictAuthorization off, so Filament's authorization helper
+     * returned allow() and any team member could CRUD the tenant's articles and
+     * collections, price included. Closing it needed policies AND seeded
+     * permissions together — the Shield set had no article or collection entries
+     * at all, so a policy on its own would have denied super_admin too.
+     * AppPanelAuthorizationTest covers that pair in detail; they are here so this
+     * file's list is the whole panel rather than a subset.
      */
     #[Test]
     public function permission_backed_resources_deny_a_user_without_permissions(): void
@@ -126,8 +127,10 @@ class AppPanelAccessTest extends TestCase
         $this->actingAs($user);
 
         foreach ([
-            \App\Filament\App\Resources\Products\ProductResource::class,
-            \App\Filament\App\Resources\Orders\OrderResource::class,
+            ProductResource::class,
+            OrderResource::class,
+            ArticleResource::class,
+            CollectionResource::class,
         ] as $resource) {
             $this->assertFalse($resource::canViewAny(), $resource.' must not be viewable without permission.');
             $this->assertFalse($resource::canCreate(), $resource.' must not be creatable without permission.');

--- a/tests/Feature/AppPanelAuthorizationTest.php
+++ b/tests/Feature/AppPanelAuthorizationTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\App\Resources\Articles\ArticleResource;
+use App\Filament\App\Resources\Collections\CollectionResource;
+use App\Models\User;
+use Database\Seeders\PermissionsTableSeeder;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+/**
+ * ArticleResource and CollectionResource shipped with no policy. Filament's
+ * get_authorization_response() returns allow() when no policy exists, so every
+ * member of every team had full CRUD on Articles and ProductCollections —
+ * CollectionResource's form includes price.
+ *
+ * The fix is two-sided and only works as a pair: a policy alone would have denied
+ * everyone (including super_admin), because the Shield permission set had no
+ * article_* or product::collection_* entries to grant. So these tests pin both
+ * halves — the deny, the allow, and that the seeded super_admin still works.
+ *
+ * Permission suffixes follow the seeded convention: model basename, snake_cased,
+ * with '_' replaced by '::' (Product => product, ProductCategory =>
+ * product::category). Hence Article => article, ProductCollection =>
+ * product::collection.
+ */
+class AppPanelAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @return array<string, array{class-string, string}> */
+    public static function unprotectedResources(): array
+    {
+        return [
+            'articles' => [ArticleResource::class, 'article'],
+            'collections' => [CollectionResource::class, 'product::collection'],
+        ];
+    }
+
+    /** The gap: no policy meant Filament allowed everything. */
+    #[Test]
+    #[DataProvider('unprotectedResources')]
+    public function a_team_member_without_permissions_is_denied(string $resource, string $suffix): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $this->assertFalse($resource::canViewAny(), $resource.' must not be viewable without permission.');
+        $this->assertFalse($resource::canCreate(), $resource.' must not be creatable without permission.');
+        $this->assertFalse($resource::canDeleteAny(), $resource.' must not be bulk-deletable without permission.');
+    }
+
+    /** The other half: the policy must actually grant when the permission is held. */
+    #[Test]
+    #[DataProvider('unprotectedResources')]
+    public function a_user_holding_the_permissions_is_allowed(string $resource, string $suffix): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        foreach (['view_any', 'create', 'delete_any'] as $affix) {
+            $user->givePermissionTo(Permission::findOrCreate($affix.'_'.$suffix, 'web'));
+        }
+
+        $this->actingAs($user);
+
+        $this->assertTrue($resource::canViewAny(), $resource.' must be viewable with view_any_'.$suffix);
+        $this->assertTrue($resource::canCreate(), $resource.' must be creatable with create_'.$suffix);
+        $this->assertTrue($resource::canDeleteAny(), $resource.' must be bulk-deletable with delete_any_'.$suffix);
+    }
+
+    /** A policy checking a permission nobody seeds would lock out the whole feature. */
+    #[Test]
+    #[DataProvider('unprotectedResources')]
+    public function the_seeder_ships_the_permissions_the_policy_checks(string $resource, string $suffix): void
+    {
+        $this->seed(PermissionsTableSeeder::class);
+
+        foreach ([
+            'view', 'view_any', 'create', 'update', 'delete', 'delete_any',
+            'force_delete', 'force_delete_any', 'restore', 'restore_any',
+            'replicate', 'reorder',
+        ] as $affix) {
+            $this->assertDatabaseHas('permissions', [
+                'name' => $affix.'_'.$suffix,
+                'guard_name' => 'web',
+            ]);
+        }
+    }
+
+    /**
+     * RolesSeeder syncs super_admin to every web permission, so appending to
+     * PermissionsTableSeeder is enough — there is no Gate::before bypass in this
+     * app, super_admin is only ever as powerful as the seeded permission set.
+     */
+    #[Test]
+    #[DataProvider('unprotectedResources')]
+    public function the_seeded_super_admin_can_still_manage_the_resource(string $resource, string $suffix): void
+    {
+        $this->seed(PermissionsTableSeeder::class);
+        $this->seed(RolesSeeder::class);
+
+        $user = User::factory()->withPersonalTeam()->create()->assignRole('super_admin');
+        $this->actingAs($user);
+
+        $this->assertTrue($resource::canViewAny(), 'super_admin must keep access to '.$resource);
+        $this->assertTrue($resource::canCreate(), 'super_admin must keep access to '.$resource);
+        $this->assertTrue($resource::canDeleteAny(), 'super_admin must keep access to '.$resource);
+    }
+}

--- a/tests/Feature/ConnectedAccountsTest.php
+++ b/tests/Feature/ConnectedAccountsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConnectedAccountsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Socialstream's ConnectedAccountsForm reads `auth()->user()->connectedAccounts`
+     * (vendor/bursteri/socialstream/src/Http/Livewire/ConnectedAccountsForm.php:118).
+     * Without HasConnectedAccounts on the User model that relation does not exist, so
+     * the property is null and ->map() fatals — a 500 on /user/profile the moment a
+     * merchant enables any social provider.
+     */
+    public function test_profile_page_renders_when_a_social_provider_is_enabled(): void
+    {
+        config(['socialstream.providers' => ['google']]);
+
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $this->actingAs($user)->get('/user/profile')->assertOk();
+    }
+}

--- a/tests/Feature/DummyDataSeederTest.php
+++ b/tests/Feature/DummyDataSeederTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use Database\Seeders\DummyData\DummyDataSeeder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The demo catalogue is the first thing an evaluator sees after
+ * `php artisan migrate --seed`. It has to be shoppable, and it has to show off
+ * the three stock states the storefront renders (in stock / low stock / sold
+ * out — see resources/views/components/product-card.blade.php).
+ *
+ * Assertions are proportional, not exact, so re-balancing the demo spread
+ * doesn't break the suite.
+ */
+class DummyDataSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedCatalogue(): Collection
+    {
+        $this->seed(DummyDataSeeder::class);
+
+        $products = Product::all();
+        $this->assertGreaterThan(10, $products->count(), 'Demo catalogue seeded no meaningful products.');
+
+        return $products;
+    }
+
+    public function test_demo_catalogue_is_mostly_in_stock(): void
+    {
+        $products = $this->seedCatalogue();
+
+        $inStock = $products->where('inventory_count', '>', 0)->count();
+
+        $this->assertGreaterThanOrEqual(
+            0.7 * $products->count(),
+            $inStock,
+            'Most demo products must be buyable; a storefront where nothing can be added to a cart is broken.'
+        );
+    }
+
+    public function test_demo_catalogue_has_featured_products(): void
+    {
+        $products = $this->seedCatalogue();
+
+        $featured = $products->where('is_featured', true);
+
+        $this->assertGreaterThanOrEqual(1, $featured->count(), 'Home page "Featured" section renders nothing without featured products.');
+        $this->assertLessThanOrEqual(0.5 * $products->count(), $featured->count(), 'Featuring everything features nothing.');
+        $this->assertTrue(
+            $featured->every(fn (Product $p) => $p->inventory_count > 0),
+            'Featured products are the shop window — they must not be sold out.'
+        );
+    }
+
+    public function test_demo_catalogue_exercises_the_sold_out_state(): void
+    {
+        $products = $this->seedCatalogue();
+
+        $outOfStock = $products->where('inventory_count', '<=', 0);
+
+        $this->assertGreaterThanOrEqual(1, $outOfStock->count(), 'Demo should show the sold-out UI state at least once.');
+        $this->assertLessThanOrEqual(0.2 * $products->count(), $outOfStock->count(), 'Sold-out should be the exception, not the rule.');
+    }
+
+    public function test_demo_catalogue_exercises_the_low_stock_state(): void
+    {
+        $products = $this->seedCatalogue();
+
+        $this->assertTrue(
+            $products->every(fn (Product $p) => $p->low_stock_threshold > 0),
+            'A zero low_stock_threshold makes the "Low stock" badge unreachable.'
+        );
+
+        // Matches the card's own rule: low = in stock, but at or under threshold.
+        $lowStock = $products->filter(
+            fn (Product $p) => $p->inventory_count > 0 && $p->inventory_count <= $p->low_stock_threshold
+        );
+
+        $this->assertGreaterThanOrEqual(1, $lowStock->count(), 'Demo should show the low-stock UI state at least once.');
+        $this->assertLessThanOrEqual(0.2 * $products->count(), $lowStock->count(), 'Low stock should be a highlight, not the norm.');
+    }
+
+    public function test_demo_catalogue_has_varied_stock_levels(): void
+    {
+        $products = $this->seedCatalogue();
+
+        $distinct = $products->pluck('inventory_count')->unique();
+
+        $this->assertGreaterThanOrEqual(5, $distinct->count(), 'Uniform stock counts look like fixture data, not a real shop.');
+    }
+}

--- a/tests/Feature/Filament/ProductImageUploadTypesTest.php
+++ b/tests/Feature/Filament/ProductImageUploadTypesTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\Products\Pages\CreateProduct;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\FileUpload;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Validator;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Product image uploads land on the `public` disk with `visibility('public')`.
+ * Filament's ->image() shorthand expands to acceptedFileTypes(['image/*']), and
+ * Laravel's `mimetypes` rule treats `image/*` as a prefix wildcard
+ * (ValidatesAttributes::validateMimetypes), so `image/svg+xml` passes it. An SVG
+ * is an XML document that can carry <script>, so a public, same-origin SVG is
+ * stored XSS. These tests pin the allowlist to raster formats and prove Laravel
+ * actually rejects an SVG server-side, by content sniff rather than by the
+ * client's Content-Type header.
+ */
+class ProductImageUploadTypesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const EXPECTED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/avif'];
+
+    /**
+     * @return array<string, FileUpload>
+     */
+    private function productFileUploads(): array
+    {
+        // Mirrors AppPanelTenancyTest: isolate the form schema from the Shield
+        // permission layer, and mount under a tenant because /app is Team-scoped.
+        Gate::before(fn () => true);
+        Role::findOrCreate('super_admin', 'web');
+        $user = User::factory()->withPersonalTeam()->create()->assignRole('super_admin');
+        $team = $user->ownedTeams()->first();
+        $this->actingAs($user);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($team);
+
+        $schema = Livewire::test(CreateProduct::class)->instance()->getSchema('form');
+
+        $uploads = [];
+
+        foreach ($schema->getFlatComponents(withActions: false, withHidden: true) as $component) {
+            if ($component instanceof FileUpload) {
+                $uploads[$component->getName()] = $component;
+            }
+        }
+
+        return $uploads;
+    }
+
+    /**
+     * Guards the loops below from passing vacuously: if schema traversal ever
+     * stops reaching a component (e.g. the images Repeater's child schema), the
+     * foreach tests would silently check less and still go green.
+     */
+    public function test_both_product_uploads_are_discovered(): void
+    {
+        $this->assertSame(['featured_image', 'image'], array_keys($this->productFileUploads()));
+    }
+
+    public function test_featured_image_accepts_only_raster_web_formats(): void
+    {
+        $uploads = $this->productFileUploads();
+
+        $this->assertArrayHasKey('featured_image', $uploads);
+        $this->assertSame(
+            self::EXPECTED_TYPES,
+            $uploads['featured_image']->getAcceptedFileTypes(),
+        );
+    }
+
+    public function test_no_product_upload_allows_svg_or_a_wildcard_image_type(): void
+    {
+        foreach ($this->productFileUploads() as $name => $upload) {
+            $types = $upload->getAcceptedFileTypes() ?? [];
+
+            $this->assertNotEmpty($types, "{$name} has no accepted file type allowlist");
+
+            // `image/*` is what ->image() sets, and it is what lets SVG through.
+            $this->assertNotContains('image/*', $types, "{$name} accepts the image/* wildcard, which permits image/svg+xml");
+            $this->assertNotContains('image/svg+xml', $types, "{$name} accepts SVG");
+        }
+    }
+
+    public function test_product_uploads_are_size_capped(): void
+    {
+        foreach ($this->productFileUploads() as $name => $upload) {
+            $this->assertNotNull($upload->getMaxSize(), "{$name} has no maxSize, so uploads are unbounded");
+        }
+    }
+
+    /**
+     * NOTE: deliberately NOT UploadedFile::fake(). Illuminate\Http\Testing\File
+     * ::getMimeType() returns MimeType::from($name) -- it reports the mime implied
+     * by the *filename* and never looks at the bytes. A fake would therefore prove
+     * nothing about content sniffing and would report image/png for an SVG payload
+     * simply because it was named .png. A real UploadedFile in test mode goes
+     * through Symfony's finfo guesser, which is what production does.
+     *
+     * @param  string  $clientName  the name the attacker chooses
+     */
+    private function realUpload(string $clientName, string $content): UploadedFile
+    {
+        $path = tempnam(sys_get_temp_dir(), 'upload-test-');
+        file_put_contents($path, $content);
+        $this->tempPaths[] = $path;
+
+        return new UploadedFile($path, $clientName, null, null, true);
+    }
+
+    /** @var array<int, string> */
+    private array $tempPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempPaths as $path) {
+            @unlink($path);
+        }
+
+        parent::tearDown();
+    }
+
+    private function featuredImageRule(): string
+    {
+        return 'mimetypes:'.implode(',', $this->productFileUploads()['featured_image']->getAcceptedFileTypes());
+    }
+
+    /**
+     * The point of the fix: the `mimetypes` rule that acceptedFileTypes()
+     * registers must actually reject an SVG on the server. Uses the allowlist
+     * taken from the real resource and real SVG bytes.
+     */
+    public function test_laravel_rejects_an_svg_against_the_resources_allowlist_server_side(): void
+    {
+        $rule = $this->featuredImageRule();
+        $svg = $this->realUpload(
+            'payload.svg',
+            '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(document.cookie)</script></svg>',
+        );
+
+        $this->assertTrue(
+            Validator::make(['file' => $svg], ['file' => $rule])->fails(),
+            'An SVG passed the product image allowlist -- stored XSS is reachable.',
+        );
+    }
+
+    public function test_the_allowlist_still_accepts_a_real_png(): void
+    {
+        // A real 1x1 PNG, so finfo sniffs image/png without depending on GD.
+        $png = $this->realUpload(
+            'photo.png',
+            base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=='),
+        );
+
+        $this->assertSame('image/png', $png->getMimeType());
+        $this->assertTrue(
+            Validator::make(['file' => $png], ['file' => $this->featuredImageRule()])->passes(),
+            'A legitimate PNG was rejected by the product image allowlist.',
+        );
+    }
+
+    /**
+     * Renaming the payload does not help: the rule validates the sniffed content
+     * type (Symfony MimeTypes::guessMimeType), not the client-supplied filename
+     * or Content-Type header. This is what makes the allowlist a real control.
+     */
+    public function test_an_svg_disguised_with_a_png_extension_is_still_rejected(): void
+    {
+        $disguised = $this->realUpload(
+            'not-really.png',
+            '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+        );
+
+        $this->assertNotSame('image/png', $disguised->getMimeType(), 'content sniffing is not happening');
+        $this->assertTrue(
+            Validator::make(['file' => $disguised], ['file' => $this->featuredImageRule()])->fails(),
+            'A renamed SVG passed the allowlist -- validation is trusting the filename or client header.',
+        );
+    }
+
+    /**
+     * Proves the tests above bite: the ->image() shorthand that was here before
+     * (acceptedFileTypes(['image/*'])) lets the very same SVG payload through,
+     * because ValidatesAttributes::validateMimetypes matches the `image/*`
+     * wildcard against the sniffed type's prefix. This is the original bug,
+     * pinned so nobody reintroduces ->image() thinking it is safe.
+     */
+    public function test_the_image_shorthand_would_have_allowed_the_svg(): void
+    {
+        $svg = $this->realUpload(
+            'payload.svg',
+            '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(document.cookie)</script></svg>',
+        );
+
+        $this->assertTrue(
+            Validator::make(['file' => $svg], ['file' => 'mimetypes:image/*'])->passes(),
+            'image/* no longer accepts SVG -- if this fails the vulnerability premise changed.',
+        );
+    }
+}

--- a/tests/Feature/PasswordPolicyTest.php
+++ b/tests/Feature/PasswordPolicyTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\Fortify\CreateNewUser;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * Registration is the only place a password enters the system unhashed, and these
+ * accounts hold order history and saved payment methods. The rule itself lives in
+ * AppServiceProvider::boot() via Password::defaults(), so it also covers password
+ * reset and password update — every caller of PasswordValidationRules::passwordRules().
+ */
+class PasswordPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The rule only adds uncompromised() (a HaveIBeenPwned lookup) in production, so
+        // validating here must never leave the box. This fails loudly if that env gating
+        // ever regresses, rather than quietly making the suite depend on the network.
+        Http::preventStrayRequests();
+    }
+
+    public static function weakPasswords(): array
+    {
+        return [
+            'too short' => ['Sh0rt!Aa'],            // 8 chars: passes stock Password::default()
+            'no uppercase' => ['nouppercase1!x'],
+            'no number' => ['NoNumbersHere!x'],
+            'no symbol' => ['NoSymbolsHere1x'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('weakPasswords')]
+    public function registration_rejects_a_weak_password(string $password): void
+    {
+        $this->expectException(ValidationException::class);
+
+        (new CreateNewUser)->create([
+            'name' => 'Weak Password',
+            'email' => 'weak@example.com',
+            'password' => $password,
+            'password_confirmation' => $password,
+        ]);
+    }
+
+    #[Test]
+    public function registration_accepts_a_strong_password(): void
+    {
+        $user = (new CreateNewUser)->create([
+            'name' => 'Strong Password',
+            'email' => 'strong@example.com',
+            'password' => 'C0rrect-Horse-Battery!',
+            'password_confirmation' => 'C0rrect-Horse-Battery!',
+        ]);
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertDatabaseHas('users', ['email' => 'strong@example.com']);
+    }
+}

--- a/tests/Unit/FortifyActionsTest.php
+++ b/tests/Unit/FortifyActionsTest.php
@@ -5,7 +5,6 @@ namespace Tests\Unit;
 use App\Actions\Fortify\CreateNewUser;
 use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
-use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
@@ -27,15 +26,14 @@ class FortifyActionsTest extends TestCase
      * Registration now creates a user and nothing else, so there is nothing to
      * arrange. AppPanelAccessTest asserts that directly — no team, no roles.
      */
-
     public function test_create_new_user_creates_user(): void
     {
-        $action = new CreateNewUser();
+        $action = new CreateNewUser;
         $user = $action->create([
             'name' => 'John Doe',
             'email' => 'john@example.com',
-            'password' => 'password123',
-            'password_confirmation' => 'password123',
+            'password' => 'J0hn-Doe-Passw0rd!',
+            'password_confirmation' => 'J0hn-Doe-Passw0rd!',
         ]);
 
         $this->assertInstanceOf(User::class, $user);
@@ -45,21 +43,21 @@ class FortifyActionsTest extends TestCase
 
     public function test_create_new_user_hashes_password(): void
     {
-        $action = new CreateNewUser();
+        $action = new CreateNewUser;
         $user = $action->create([
             'name' => 'Jane Doe',
             'email' => 'jane@example.com',
-            'password' => 'securepassword',
-            'password_confirmation' => 'securepassword',
+            'password' => 'Jane-S3cure-Pass!',
+            'password_confirmation' => 'Jane-S3cure-Pass!',
         ]);
 
-        $this->assertNotEquals('securepassword', $user->password);
-        $this->assertTrue(Hash::check('securepassword', $user->password));
+        $this->assertNotEquals('Jane-S3cure-Pass!', $user->password);
+        $this->assertTrue(Hash::check('Jane-S3cure-Pass!', $user->password));
     }
 
     public function test_create_new_user_validates_required_fields(): void
     {
-        $action = new CreateNewUser();
+        $action = new CreateNewUser;
 
         $this->expectException(ValidationException::class);
         $action->create([]);
@@ -67,20 +65,20 @@ class FortifyActionsTest extends TestCase
 
     public function test_create_new_user_validates_email_uniqueness(): void
     {
-        $action = new CreateNewUser();
+        $action = new CreateNewUser;
         $action->create([
             'name' => 'First User',
             'email' => 'duplicate@example.com',
-            'password' => 'password123',
-            'password_confirmation' => 'password123',
+            'password' => 'J0hn-Doe-Passw0rd!',
+            'password_confirmation' => 'J0hn-Doe-Passw0rd!',
         ]);
 
         $this->expectException(\Exception::class);
         $action->create([
             'name' => 'Second User',
             'email' => 'duplicate@example.com',
-            'password' => 'password456',
-            'password_confirmation' => 'password456',
+            'password' => 'Sec0nd-User-Pass!',
+            'password_confirmation' => 'Sec0nd-User-Pass!',
         ]);
     }
 
@@ -91,14 +89,14 @@ class FortifyActionsTest extends TestCase
         ]);
         $this->actingAs($user);
 
-        $action = new UpdateUserPassword();
+        $action = new UpdateUserPassword;
         $action->update($user, [
             'current_password' => 'oldpassword',
-            'password' => 'newpassword123',
-            'password_confirmation' => 'newpassword123',
+            'password' => 'N3w-Password-Here!',
+            'password_confirmation' => 'N3w-Password-Here!',
         ]);
 
-        $this->assertTrue(Hash::check('newpassword123', $user->fresh()->password));
+        $this->assertTrue(Hash::check('N3w-Password-Here!', $user->fresh()->password));
     }
 
     public function test_update_user_password_validates_current_password(): void
@@ -108,26 +106,26 @@ class FortifyActionsTest extends TestCase
         ]);
         $this->actingAs($user);
 
-        $action = new UpdateUserPassword();
+        $action = new UpdateUserPassword;
 
         $this->expectException(ValidationException::class);
         $action->update($user, [
             'current_password' => 'wrongpassword',
-            'password' => 'newpassword123',
-            'password_confirmation' => 'newpassword123',
+            'password' => 'N3w-Password-Here!',
+            'password_confirmation' => 'N3w-Password-Here!',
         ]);
     }
 
     public function test_reset_user_password_updates_password(): void
     {
         $user = User::factory()->create();
-        $action = new ResetUserPassword();
+        $action = new ResetUserPassword;
 
         $action->reset($user, [
-            'password' => 'resetpassword123',
-            'password_confirmation' => 'resetpassword123',
+            'password' => 'R3set-Password-Ok!',
+            'password_confirmation' => 'R3set-Password-Ok!',
         ]);
 
-        $this->assertTrue(Hash::check('resetpassword123', $user->fresh()->password));
+        $this->assertTrue(Hash::check('R3set-Password-Ok!', $user->fresh()->password));
     }
 }


### PR DESCRIPTION
Clears the known-issues list carried in the notes since v1.0.0. Six independent domains, one commit each — reviewable per concern.

Baseline was 1245 passing; this branch is **1272 passing (3173 assertions)**. Nothing skipped, `phpunit.xml` and `config/` untouched.

## The one that matters: unguarded Article/Collection CRUD

`ArticleResource` and `CollectionResource` had no policy. Filament's `get_authorization_response()` **returns `allow()` when a resource has no policy** — so any team member could CRUD their own tenant's articles and collections, price included, with no permission check.

This is the gap `AppPanelAccessTest` documented as deliberately deferred, because it couldn't be fixed in one piece: the Shield permission set had **no article or collection entries at all**, so adding the obvious policy would have denied everyone including `super_admin` and broken the feature. Policies + seeded permissions had to land together:

- `ArticlePolicy` + `ProductCollectionPolicy`, matching the shape the permission-backed resources already use
- 24 permissions seeded (12 `article_*`, 12 `collection_*`) — the set goes 171 → 195 — granted to the roles already holding equivalent product rights
- `strictAuthorization()` on the app panel, so the *next* policy-less resource throws in CI instead of silently granting everyone

`strictAuthorization()` is scoped to the app panel deliberately. The Admin panel still has policy-less resources (ChatConversation, CustomerSegment, Discount, Menu, MenuItem, Page, TaxClass, User); those want policies of their own, not a flag that breaks the back-office. **Not addressed here** — see below.

### A latent trap found while verifying that

Both panels called `->default()`. `PanelRegistry::getDefault()` uses `Arr::first()`, so admin won on provider registration order alone — the fallback panel was a function of provider order. That fallback is load-bearing: `FilamentManager::isAuthorizationStrict()` reads `getCurrentOrDefaultPanel()`, so outside a panel (queues, console, a policy check with no request) it reads the default. Had the order ever flipped, the `strictAuthorization()` above would have become the **global** fallback and thrown on every policy-less Admin resource.

Dropped `->default()` from the app panel. Verified inert — default is still `admin`, app is still strict, fallback strict is still `false`.

## The rest

| | |
|---|---|
| **Password policy** | `Password::default()` was the rule at every call site, but nothing ever called `Password::defaults()` — it silently resolved to stock `min:8`, no complexity. Now 12 chars + mixed case + numbers + symbols, configured once so registration, reset, update and social setup all inherit it. |
| **SVG uploads** | `->image()` expands to `acceptedFileTypes(['image/*'])`, which accepts `image/svg+xml` — an XML doc that can carry `<script>`. Product fields serve same-origin off the public disk, so that was stored XSS reachable by anyone with product-edit rights. Explicit raster allowlist now; product images also gained a 4MB cap (previously unbounded). |
| **Socialstream** | `HasConnectedAccounts` and its import were gone entirely while the app still ships Socialstream — `$user->connectedAccounts()` was an undefined method on the social login path. Restored. |
| **Seeder** | `ProductSeeder` hardcoded ids and re-inserted every run, so a second `migrate --seed` collided on the PK. Now resolves by natural key and upserts. |
| **CI** | Security workflow only audited PHP. Adds a parallel `npm-security` job using `--package-lock-only` (mirrors `composer audit --locked`: audit the lock, install nothing) scoped `--omit=dev`. |

## Known gaps, deliberately not in this PR

- **Admin panel policy-less resources** (ChatConversation, CustomerSegment, Discount, Menu, MenuItem, Page, TaxClass, User) — same `allow()`-by-default exposure as Article/Collection had, and the reason `strictAuthorization()` is app-panel-only. Each needs a policy plus its permission set. Larger than this sweep.
- **Upload serving origin.** `acceptedFileTypes()` validates the *upload*, not the *serving origin*. The durable fix is a separate origin for user uploads, or `Content-Disposition: attachment` + `X-Content-Type-Options: nosniff`.
- **`SetsProfilePhotoFromUrl`** remains commented out (same dead-package cause as the trait above), so social-login users get no profile photo from their provider.