### PR TITLE
docs: conformance ADRs, module development guide and context glossary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ rr
 /storage/rector
 
 /.idea
+
+# Agent worktree checkouts. The committed agent configuration is AGENTS.md,
+# CLAUDE.md and docs/agents/ — this directory is scratch.
+/.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+Guidance for coding agents working in `liberusoftware/ecommerce-laravel`.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues on `liberusoftware/ecommerce-laravel`, driven by the `gh` CLI.
+See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical roles, each label string equal to its name (`needs-triage`, `needs-info`,
+`ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one root `CONTEXT.md` and one `docs/adr/`. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+See [AGENTS.md](./AGENTS.md) — it is the source of truth for agent configuration in this repo.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,60 @@
+# Ecommerce
+
+A multi-merchant commerce platform: one shared deployment serving many independent merchants, each on its own domain.
+
+This file is deliberately narrow. It defines **only** the terms this repository uses that [`MODULES.md` §2](https://github.com/liberusoftware/documentation/blob/main/architecture/MODULES.md) does not — its architectural vocabulary (repository, package, capability, module, product, application, theme) is authoritative and not restated here.
+
+## Tenancy
+
+The five terms below are routinely used as if interchangeable. They are not, and confusing them has produced real defects — see [`docs/CONFORMANCE.md`](./docs/CONFORMANCE.md)'s security chapter.
+
+**Merchant**:
+A business selling on this platform. The commercial party, not a database row — every other term here is some technical aspect of one.
+_Avoid_: client, vendor, seller, shop
+
+**Team**:
+The tenant boundary. Data belonging to one `Team` must never be visible to another. Implemented by Jetstream's `Team`, which this repo did not choose so much as inherit.
+_Avoid_: organisation, account, tenant (as a noun for the row itself)
+
+**Tenant**:
+The property of being scoped to a `Team` — "tenant-scoped", "the tenant boundary". A role, not a thing.
+_Avoid_: using it to mean a `Team` record
+
+**Store**:
+A catalogue and its commercial configuration, owned by a `Team`. One `Team` may own several. Commerce tables scope on `store_id`; everything else scopes on `team_id`.
+_Avoid_: shop, site, brand
+
+> **Warning — the word is currently overloaded in the UI.** `app/Filament/Admin/Resources/Stores/StoreResource.php` sets `$model = Team::class` with `$modelLabel = 'Store'`, so the admin panel labels a `Team` a "Store" today. That is the *old* meaning and is being retired. No `Store` model or `stores` table exists yet.
+
+**Channel**:
+A way customers reach a `Store` — a web storefront, a mobile app, a marketplace. Hostnames are a channel property, which is how a request finds its merchant.
+_Avoid_: storefront (that is one kind of channel), site, domain
+
+## Reviews and ratings
+
+Two parallel stacks exist for what sounds like one concept. Both survive; neither is redundant.
+
+**Review**:
+Written feedback on a product, subject to moderation before it is publicly visible.
+_Avoid_: comment, feedback, testimonial
+
+**Rating**:
+A numeric score on a product. Independent of whether a `Review` accompanies it.
+_Avoid_: score, stars, review
+
+**Customer**:
+A person's commercial relationship with one `Team`. One `User` may hold several — a shopper who has bought from three merchants has three `Customer` records.
+_Avoid_: buyer, shopper, account, client
+
+**User**:
+An authenticated identity. Platform-wide and not tenant-scoped, which is why a `User` arriving on one merchant's domain while holding a `Customer` record at another is legitimate traffic rather than an attack.
+_Avoid_: customer, member, account
+
+## Where the rest lives
+
+| Vocabulary | Source |
+| --- | --- |
+| Architectural terms — repository, package, capability, module, product, application, distribution, adapter, theme | [`MODULES.md` §2](https://github.com/liberusoftware/documentation/blob/main/architecture/MODULES.md) |
+| Module names and boundaries | [`ECOMMERCE.md`](https://github.com/liberusoftware/documentation/blob/main/projects/ecommerce/ECOMMERCE.md) — authoritative; a module not in it requires a documented addition |
+| Package, repository and namespace naming | [`docs/MODULE_DEVELOPMENT.md`](./docs/MODULE_DEVELOPMENT.md) |
+| Theme vocabulary | [`THEMES.md`](https://github.com/liberusoftware/documentation/blob/main/standards/THEMES.md) |

--- a/docs/MODULE_DEVELOPMENT.md
+++ b/docs/MODULE_DEVELOPMENT.md
@@ -1,0 +1,266 @@
+# Module development
+
+How to build, test, promote and release an Ecommerce module.
+
+This is the document that outlives the migration. [`CONFORMANCE.md`](./CONFORMANCE.md) describes a codebase that starts changing the day wave 0 lands; [`MIGRATION_PLAN.md`](./MIGRATION_PLAN.md) is finished when the last module ships. This one stays useful.
+
+Everything here derives from the Liberu standards. Where commerce deviates, the deviation has an ADR and is marked **⚠ deviation** at the point it applies.
+
+---
+
+## 1. Package anatomy
+
+### 1.1 The four names
+
+A module carries four names in two forms. Only the repository keeps the `module-` prefix, and every other name derives from it mechanically — there is nothing to look up.
+
+| | Example | Rule |
+| --- | --- | --- |
+| Repository | `module-ecommerce-cart-filament` | `module-{product}-{capability}[-flavor]` |
+| Composer package | `liberusoftware/ecommerce-cart-filament` | repository minus `module-` |
+| `extra.liberu.name` | `ecommerce-cart-filament` | package minus vendor |
+| Namespace | `Liberu\Ecommerce\Cart\Filament\` | package, `StudlyCase` per segment |
+
+**⚠ deviation** — [ADR 0004](./adr/0004-no-module-prefix-in-package-names.md). `MODULES.md` §9's five presentation-adapter rows put `module-` in the *package* name and give namespaces two segments. Domain packages (`liberusoftware/ecommerce-cart`, `liberusoftware/ecommerce-core`) are fully conformant.
+
+The product word is **`ecommerce`**, always. Where earlier planning said `commerce-core`, read `ecommerce-core`.
+
+### 1.2 Module names come from the catalogue
+
+[`ECOMMERCE.md`](https://github.com/liberusoftware/documentation/blob/main/projects/ecommerce/ECOMMERCE.md) is authoritative for module boundaries and names. A module that is not in it requires a **documented catalogue addition plus a new repository**, not a local override — 414 provisioned repositories and 105 execution epics are keyed to those names, and the catalogue is what other products' plans are read against.
+
+### 1.3 Layout
+
+```
+module-ecommerce-cart/
+├── composer.json          type: liberu-module, extra.liberu.name
+├── module.json            the manifest module-manager reads
+├── src/
+│   ├── CartServiceProvider.php
+│   └── …
+├── routes/
+│   └── web.php            this module's routes — see §2, R11
+├── resources/
+│   ├── views/             default views a theme may override
+│   └── lang/{locale}/     this module's catalogue
+├── database/migrations/
+├── tests/                 Pest 5, standalone
+└── .github/workflows/     install.yml, tests.yml, compatibility.yml
+```
+
+A module ships **no `extra.laravel.providers`**. Composer install boots nothing; `ModuleManagerServiceProvider` is the sole registrar, gated on `module.json`. Filament panels are *declared* in the manifest, not registered directly.
+
+The module's own service provider registers its resources:
+
+```php
+public function boot(): void
+{
+    $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+    $this->loadViewsFrom(__DIR__.'/../resources/views', 'ecommerce-cart');
+    $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'ecommerce-cart');
+}
+```
+
+### 1.4 Views, routes and strings belong to the module
+
+Three rules that all follow from the same principle — a module must be installable and renderable without the host having been edited.
+
+- **Routes.** The module declares its own. The host includes module route files and owns only cross-module pages — home, checkout, sitemap. A module view calling `route('products.show')` against a host-owned name is a module depending on its consumer.
+- **Views.** The module ships default views. `THEMES.md` §5's resolution chain is *configured theme → parent chain → **module default view** → application fallback*, so the module's view is precisely the thing a theme overrides.
+- **Strings.** The module owns its message keys, in the form `ecommerce-cart::cart.line.removed`. Overrides are `vendor:publish` into `lang/vendor/{namespace}/{locale}/`.
+
+Note the whole fleet is ahead of nobody here: **no published package has ever shipped a translation catalogue, and only the `-livewire` flavour packages ship views.** The first commerce module to do either is exercising the mechanism for the first time.
+
+### 1.5 Tables
+
+New tables carry the module prefix — `ecommerce_cart_*`. Existing tables keep their bare names when they move.
+
+The schema stays permanently mixed as a result, which is recorded as a finding rather than pretended away. Renaming ~122 tables during extraction would put a schema-wide rename in the same waves as a live data-isolation fix, which is the one place a mistake stops being a bug.
+
+---
+
+## 2. The dependency rules
+
+Ten rules, applicable mechanically. R1 and R8 are **extensions** of the documentation rather than readings of it — [ADR 0006](./adr/0006-late-bound-host-model-resolution.md) and [ADR 0007](./adr/0007-events-and-identifiers-across-product-boundaries.md).
+
+### Reaching the host
+
+**R1 — Resolve host models late, never import them.** Reach the host user through `config('auth.providers.users.model')` and the host team through a resolver exposed by `liberusoftware/organizations-teams`. No commerce package ever names `App\Models\User` or `App\Models\Team`. *(MODULES.md §4 r5. The team resolver does not exist yet — it is a deliverable.)*
+
+**R2 — Tenant relations are inverse-only.** Each commerce model keeps `team()`. The forward direction — `Team::orders()`, `Team::products()` — does not survive; a foundation package cannot declare relations into commerce. Traversal from tenant to commerce goes through the owning module's query API. *(§4 r6.)*
+
+**R3 — Foreign keys stay inside a package's own tables**, with one late-bound exception: a reference to `users` or `teams` uses `foreignIdFor(Teams::teamModel())`, never a hardcoded table name. *(§4 r10.)*
+
+### Inside Ecommerce
+
+**R4 — Direct Composer dependency is the default.** Contract packages only where a provider is genuinely swappable — payment, tax, shipping, search. *(§5.2. A contract with one implementation is an interface with one implementation.)*
+
+**R5 — Commerce is strictly tiered, and a test enforces it.**
+
+```
+ecommerce-core
+  └─ catalog · pricing · inventory
+       └─ cart
+            └─ checkout
+                 └─ orders
+                      └─ fulfillment · returns
+```
+
+An architecture test asserts the graph is acyclic and that no package requires one above it. *(§4 r11. The tiers double as the migration ordering.)*
+
+**R6 — Orchestration sits at the top and depends downward.** A flow spanning several capabilities lives in the higher-tier module. `CheckoutService` becomes `ecommerce-checkout`, depending on promotions, reservations, payments, digital fulfillment and dropshipping.
+
+**R7 — Shared value types live in `ecommerce-core`.** Money, quantity, address, tax class. They move to a contracts package only when a non-commerce product needs them without the implementation — a tax class fails §5.1's domain-neutral test, so the foundation is not its home.
+
+### Across products
+
+**R8 — Events and stable identifiers only.** A commerce module never requires `billing-*`, `crm-*`, `cms-*` or `accounting-*`. It publishes domain events and holds identifiers — an invoice id, not an `Invoice`. A commerce installation must work with those products absent.
+
+**R9 — Presentation depends on domain; domain never depends on presentation.** A domain package never references Filament, Livewire, themes or HTTP. *(§4 r9, §5.6.)*
+
+**R10 — A module never assumes its host.** Product-specific behaviour is declared, not hard-required. *(§4 r17.)*
+
+---
+
+## 3. The testing bar
+
+### 3.1 What every module needs
+
+- **Unit and feature tests** for its own behaviour.
+- **Architecture tests** for the boundary rules in §2.
+- **Contract tests** only where a contract exists.
+
+`TESTING.md` §8's full evidence set is **not** the bar. Migration/upgrade, failure and schema-compatibility suites are deferred to a module's second release — the reference fleet meets almost none of it (only `settings` has tests at all; `identity-core`, `organizations-teams` and `webhooks` have zero), and holding commerce to a bar nothing upstream meets would stop extraction rather than improve it.
+
+### 3.2 Characterisation tests are triggered by behaviour
+
+A conditional, a calculation, a state transition, a side effect. **Not** by a coverage number. Pure data models are exempt.
+
+### 3.3 Standalone, and reparented
+
+A module's suite runs **without a host** — `composer install && composer test` from its own repository, on the `liberusoftware/package-testbench` bootstrap. Tests are reparented off the host's `Tests\TestCase` at the moment their subject moves; extending it is what `MODULES.md` §4 r19 forbids and what this gate exists to detect.
+
+New packages use **Pest 5**. The host's existing PHPUnit suite is never rewritten.
+
+### 3.4 Coverage
+
+| | Floor |
+| --- | --- |
+| Greenfield module | **100%** — `--min=100`, per `MODULES.md` §24 |
+| Module extracted from this host | **80%**, ratcheting upward |
+
+**⚠ deviation** — [ADR 0001](./adr/0001-coverage-floor-for-extracted-modules.md). The floor never moves down.
+
+### 3.5 Preservation evidence is three-part
+
+Nothing counts as preserved on two of the three:
+
+1. The host suite is green.
+2. The module suite is green **in its own repository**.
+3. A **host composition test** asserts registration, migrations, one end-to-end path, and that presentation surfaces resolve in their declared panels.
+
+The boundary rules themselves go upstream into `package-testbench` so every module gets them; only the whole-graph acyclicity check lives in the host.
+
+### 3.6 Deliberate loss needs an ADR *and* an upstream issue
+
+Both, every time. An ADR records the decision; the upstream issue is what stops the loss being permanent.
+
+---
+
+## 4. CI
+
+### 4.1 Three workflows, thin callers
+
+| Workflow | Evidence |
+| --- | --- |
+| `install.yml` | Clean dependency resolution, package bootstrap, manifest validation, minimal-host install |
+| `tests.yml` | Pest 5 suites, architecture and security checks, static analysis, coverage report |
+| `compatibility.yml` | Declared minimum/current PHP, Laravel, database, Filament/Livewire, representative hosts |
+
+Each is a 12–22 line caller into a reusable workflow in `liberusoftware/.github`:
+
+```yaml
+jobs:
+  tests:
+    uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
+    with:
+      phpstan-level: 8
+      coverage-threshold: 80
+```
+
+No `docker.yml` (`REPOSITORIES.md` §6.3 permits the substitution) and no per-module `release.yml`. **`MODULES.md` §24.1 fixes this at exactly three** — rule 20's *"each repo owns its workflows"* is satisfied by the thin caller, since a callable Actions workflow is not a Composer package.
+
+**Themes ship four.** `THEMES.md` §18.1 adds `visual.yml` for accessibility and visual regression. Two standards, two artifacts, no conflict — and no theme in the fleet has one yet.
+
+### 4.2 Settings
+
+- `phpstan-level: 8` everywhere. Baselines are floors, not measurements.
+- `coverage-threshold` per §3.4.
+- Third-party actions pinned to **full-length commit SHAs**; the reusable workflow pinned to a tag, not `@main`.
+
+### 4.3 Releases
+
+Tags are **bare** — `1.4.0`, not `v1.4.0`. **⚠ deviation** — [ADR 0005](./adr/0005-bare-version-tags.md). This is not cosmetic: `install.yml` and `compatibility.yml` trigger on bare tags only, so a `v`-prefixed tag publishes having silently skipped both gates. `module-analytics-core`'s `v1.0.4` did exactly that.
+
+A module releases only when its three workflows **and the host composition test against the candidate ref** are green.
+
+Until a module tags `1.0.0` the host consumes it as `dev-main`, via `minimum-stability: dev` + `prefer-stable: true` + `^1.0`. Tagging `0.1.0` at promotion would publish a version number for something the release gate has explicitly not cleared.
+
+---
+
+## 5. The README standard
+
+`REPOSITORIES.md` §6.1–6.3 and §7. Two rules cause every violation found so far:
+
+- **Only display a workflow badge when that workflow exists.** All ~1,930 provisioned stub READMEs carry a `tests.yml` badge with no `.github/` directory and a release badge with no releases.
+- **No unqualified claims.** *"Fully compatible with Laravel 13, PHP 8.5, and Pest 5"* is a claim the compatibility matrix must support, or it does not go in the README.
+
+A README documents purpose, installation, the compatibility matrix, and links to evidence. Installation and operations prose belongs in [`INSTALLATION.md`](./INSTALLATION.md) and [`OPERATIONS.md`](./OPERATIONS.md), not in a README that a reader is scanning to decide whether the package is what they want.
+
+---
+
+## 6. Promotion and release
+
+`MODULES.md` §30's "definition of done" is **circular** as a promotion gate: one of its thirteen bullets requires *"the independent GitHub repository, README, CI workflow, generated coverage report, release tag, and tested-host compatibility evidence"*. Repository creation cannot be gated on having a repository.
+
+So it splits at the point the repository exists.
+
+### 6.1 Promotion gate — all provable inside the monorepo
+
+- [ ] No `App\` dependency; no dependency on an unrelated product, provider implementation or presentation framework
+- [ ] Architecture tests green (§2's rules)
+- [ ] Its Pest suite runs **without a host**
+- [ ] Persistence and provider data stay inside the package
+- [ ] Public contracts and events versioned, documented, consumer- and implementation-tested
+- [ ] Coverage at its floor (§3.4)
+- [ ] Capability, category, owner, exclusions, dependencies and manifest approved
+- [ ] **No cross-boundary edit in its last N commits**, computed from `git log` at promotion time
+
+That last one is retrospective on purpose. Architecture tests prove the declared rules hold; they do not prove the boundary has stopped moving, and promoting a module whose edges are still shifting means paying the split cost twice. A prospective soak — thirty days, one wave — measures the same thing but waits on a calendar, and calendars get waived under schedule pressure in a way a `git log` query does not.
+
+### 6.2 What promotion does
+
+Eight steps, scripted as `fleet promote <module>`, because a hundred repetitions of an eight-step manual procedure is where steps get skipped — and the one most likely skipped is the composition test at the end.
+
+1. `git subtree split` — **not** an rsync. For extracted code the history is the record of *why*; the commit that introduced a tax rule is often its only explanation. Greenfield modules start fresh.
+2. Create the repository **if absent** — most already exist as stubs. 103 of the catalogue's 105 are provisioned; Checkout and Checkout Extensibility are not.
+3. Force-push the split history over the stub. The generated README records nothing worth keeping, and merging on top of it would leave a wrong `composer require` line permanently in the history.
+4. Scaffold the three workflows and Composer script aliases.
+5. Flip `.gitignore` for that module — its files leave the host tree. **⚠ deviation** — [ADR 0010](./adr/0010-modules-and-themes-are-gitignored.md).
+6. Swap the host's path entry for a VCS `repositories` entry.
+7. Update `.liberu-meta.json`.
+8. Run the host composition test.
+
+Promotion is **per-package, the moment each qualifies**. Batching by wave adds a synchronisation barrier where the slowest module holds the rest; a hundred small reviewable host commits beat four large ones.
+
+### 6.3 Release gate — §30 in full
+
+Everything §30 lists, now answerable: the independent repository, README to `REPOSITORIES.md`, the three CI workflows, generated coverage report and badge, release tag, tested-host compatibility evidence, runbooks, changelog and upgrade notes.
+
+The VCS `repositories` entry is **removed** once the module's first tag is live on Packagist. Its presence then carries information — *promoted but not yet published* — instead of accumulating ~100 redundant entries the way the fleet's 47 do today.
+
+### 6.4 Demotion
+
+Free only **before the first tag**, where it amounts to deleting an unreleased repository. After a tag it breaks every consumer and the honest move is deprecation.
+
+In practice a wrong boundary is almost always *"these classes belong to the neighbouring module"*, which is a forward move between two repositories rather than a demotion at all.

--- a/docs/adr/0001-coverage-floor-for-extracted-modules.md
+++ b/docs/adr/0001-coverage-floor-for-extracted-modules.md
@@ -1,0 +1,15 @@
+# 80% coverage floor for modules extracted from this host
+
+**Status**: accepted
+
+`MODULES.md` §24 requires `composer test:coverage` to enforce `--min=100` for every module. Greenfield commerce modules meet that; modules **extracted from this host** cannot, because the host has no meaningful test suite to extract coverage from — the fleet itself spans 7% to 100%. So an extracted module ships with a **floor of 80%**, ratcheting upward, while greenfield modules hold at 100 with no exemption.
+
+## Considered options
+
+Holding every module at 100 was rejected as the choice that actually produces less testing: a module that cannot pass its gate does not get extracted, so the boundary evidence extraction exists to produce is never generated, and the untested code stays in the host indefinitely.
+
+Setting the floor from each module's measured coverage at extraction time was rejected because it makes the gate a measurement rather than a bar — a module with 12% coverage would "pass" at 12%.
+
+## Consequences
+
+A module can be released while below the standard's bar, so the coverage badge on an extracted module means less than the same badge on a greenfield one. The floor is a floor: it never moves down, and an upstream issue against §24 records the divergence rather than hiding it.

--- a/docs/adr/0002-dropping-the-content-security-policy.md
+++ b/docs/adr/0002-dropping-the-content-security-policy.md
@@ -1,0 +1,11 @@
+# Adopting the foundation drops this repo's Content-Security-Policy
+
+**Status**: accepted
+
+`app/Http/Middleware/SecurityHeaders.php` sets a Content-Security-Policy that no boilerplate foundation module provides. Adopting the foundation's security middleware replaces it, so the CSP is **lost unless deliberately carried forward** — this ADR records that the loss is known, not accidental.
+
+## Consequences
+
+Between foundation adoption and the CSP's restoration upstream, the application ships without one. An upstream issue against the owning foundation module tracks adding it; until that lands, the middleware is kept in the host as a deliberate local override rather than deleted.
+
+This is one of two behaviours the foundation silently drops — see [ADR 0003](./0003-dropping-the-password-policy.md).

--- a/docs/adr/0003-dropping-the-password-policy.md
+++ b/docs/adr/0003-dropping-the-password-policy.md
@@ -1,0 +1,11 @@
+# Adopting the foundation drops this repo's password policy
+
+**Status**: accepted
+
+`app/Providers/AppServiceProvider.php:32` installs a `Password::defaults()` rule whose production branch calls `uncompromised()` — a HaveIBeenPwned k-anonymity lookup that rejects passwords found in known breaches. No boilerplate foundation module provides an equivalent, so adopting `identity-core` **drops the breach check**.
+
+## Consequences
+
+Users could register passwords known to be compromised. This is a real reduction in account security, not a formality, and it is why the loss is recorded here rather than absorbed silently.
+
+The rule stays in the host as a deliberate local override until an upstream issue against `identity-core` restores it. Same shape as [ADR 0002](./0002-dropping-the-content-security-policy.md).

--- a/docs/adr/0004-no-module-prefix-in-package-names.md
+++ b/docs/adr/0004-no-module-prefix-in-package-names.md
@@ -1,0 +1,31 @@
+# Package names and namespaces drop the `module-` prefix
+
+**Status**: accepted (scope narrowed after the naming audit)
+
+`MODULES.md` §9 opens *"Composer names communicate domain, capability, and role"* and gives five presentation-adapter rows in the form `liberusoftware/module-{name}-filament`. **No published package follows them** — all 40 boilerplate packages drop the prefix, so `module-blog-filament` the repository publishes `liberusoftware/blog-filament` the package. Commerce follows the fleet.
+
+The prefix survives as a **repository-name** convention only.
+
+## Scope
+
+This deviates from §9's five presentation-adapter rows and nothing else. Domain packages are conformant:
+
+| §9 row | Convention | This fleet |
+| --- | --- | --- |
+| Product capability | `liberusoftware/{product}-{capability}` | `liberusoftware/ecommerce-cart` — conformant |
+| Shared core | `liberusoftware/{capability}-core` | `liberusoftware/ecommerce-core` — conformant |
+| Filament / Livewire / API / React Native / Flutter adapters | `liberusoftware/module-…` | `liberusoftware/ecommerce-cart-filament` — **deviates** |
+
+The namespace deviation belongs here too rather than to an ADR of its own, being the same rows of the same table: namespaces derive mechanically from the package name, so `ecommerce-cart-filament` becomes `Liberu\Ecommerce\Cart\Filament\` — three segments against §9's two-segment `Liberu\{Domain}\{Capability}`.
+
+## Considered options
+
+Following §9 literally was rejected because the cost lands in every consumer's `require` block, to match a table 40 published packages already contradict.
+
+Renaming the 40 published packages to match §9 was rejected because it breaks every existing consumer to satisfy a document an upstream issue is already filed against.
+
+Adopting the `composer require liberusoftware/module-ecommerce-tax` line printed in the 414 provisioned stub READMEs was rejected because those repositories contain one generated README each — no `composer.json`, no tag, nothing on Packagist. The line is the repository slug pasted by a template, provably so: `module-crm-crm-core`'s README is titled `# Crm: Crm Core Core Module`.
+
+## Consequences
+
+A module carries four names — repository, Composer package, `extra.liberu.name`, namespace — in two forms, with only the repository keeping `module-`. `docs/MODULE_DEVELOPMENT.md` documents the mapping so it is derivable rather than looked up.

--- a/docs/adr/0005-bare-version-tags.md
+++ b/docs/adr/0005-bare-version-tags.md
@@ -1,0 +1,19 @@
+# Release tags are bare, not `v`-prefixed
+
+**Status**: accepted
+
+`CI.md` §Release policy illustrates a protected version tag as `v1.2.3`. The fleet's own release workflows trigger on `tags: ['[0-9]+.[0-9]+.[0-9]+']`, which **excludes that example**. Commerce tags bare — `1.4.0` — matching the triggers rather than the prose.
+
+## Why this is not cosmetic
+
+`module-analytics-core` carries `1.4.0`, `1.4.1` **and `v1.0.4`**. Because `install.yml` and `compatibility.yml` only fire on bare tags, **`v1.0.4` was published having silently skipped both release gates.** A release that looks gated and was not is worse than one that is openly ungated.
+
+## Considered options
+
+Widening the triggers to accept both forms was rejected for exactly that reason: it makes the two formats interchangeable in the tag list while leaving every historical `v`-tag looking as though it passed gates it never ran.
+
+Following `CI.md` and switching to `v`-prefixed tags fleet-wide was rejected as the larger change, made to satisfy an example rather than a rule — §Release policy says *"a protected version tag such as `v1.2.3`"*, which is illustrative phrasing.
+
+## Consequences
+
+One format, enforced by the triggers themselves. An upstream issue against `CI.md`'s example, and the stray `v`-tags in the fleet cleaned up so nothing published claims a gate it skipped.

--- a/docs/adr/0006-late-bound-host-model-resolution.md
+++ b/docs/adr/0006-late-bound-host-model-resolution.md
@@ -1,0 +1,17 @@
+# Modules resolve host models late, and never import them
+
+**Status**: accepted
+
+A commerce module needs the application's user and team models but must not depend on the application. So a module resolves them **at call time through configuration** — `config('auth.providers.users.model')` for the user, and a team resolver contributed to `organizations-teams` for the team — and never has `App\User` or `App\Models\Team` in a `use` statement.
+
+Foreign keys stay inside a package's own tables. The single cross-boundary exception is the same late-bound form: `foreignIdFor(Teams::teamModel())`.
+
+## Why this is an ADR
+
+This is an **extension** of the documentation rather than a reading of it. `MODULES.md` forbids a module depending on `App\`, but does not say how a module is then supposed to reference the host's user — so a reader looking for the rule upstream will not find it, and a reader looking at the code will wonder why an obvious import is missing.
+
+## Consequences
+
+The team resolver does not exist yet; it is an upstream contribution to `organizations-teams`, and commerce modules cannot resolve a team until it lands.
+
+Static analysis cannot see through a config lookup, so a wrong model class is a runtime failure rather than a build failure. The host composition test is what catches it.

--- a/docs/adr/0007-events-and-identifiers-across-product-boundaries.md
+++ b/docs/adr/0007-events-and-identifiers-across-product-boundaries.md
@@ -1,0 +1,19 @@
+# Across product boundaries: events and stable identifiers only
+
+**Status**: accepted
+
+Inside Ecommerce, a module may take a direct Composer dependency on another — the modules are strictly tiered and an architecture test enforces acyclicity. **Across products it may not.** No commerce module ever requires `billing-*`, `crm-*`, `cms-*` or `accounting-*`; it emits an event, or holds a stable identifier it does not resolve.
+
+## Why this is an ADR
+
+Like [ADR 0006](./0006-late-bound-host-model-resolution.md), this is an **extension** — `MODULES.md` describes product ecosystems without saying what may cross between them. A reader will find a direct dependency inside Ecommerce and reasonably assume the same is allowed to Billing.
+
+## Considered options
+
+Contracts packages at every product boundary were rejected as premature: a shared contract only earns its keep where a provider is genuinely swappable, and a contract with one implementation is an interface with one implementation.
+
+## Consequences
+
+Cross-product reads become eventually consistent by construction. A commerce module that needs a fact from Billing either holds the identifier and asks the host, or reacts to an event — it cannot query.
+
+The rule is only as strong as its test. The architecture test that enforces acyclicity inside Ecommerce is the same one that must reject a cross-product `require`, and it lives upstream in `package-testbench`.

--- a/docs/adr/0008-reviews-and-ratings-merge.md
+++ b/docs/adr/0008-reviews-and-ratings-merge.md
@@ -1,0 +1,20 @@
+# The reviews/ratings merge keeps moderation and backfills customers
+
+**Status**: accepted
+
+Two parallel review stacks exist, both live, both in the GDPR export and erasure paths, both still under active development. `ProductReview` and `ProductRating` survive the merge. Two details are load-bearing and easy to lose:
+
+- **The `approved` moderation column is ported.** Without it the public review listing becomes unmoderated the moment the merge lands — a content-safety regression disguised as a schema cleanup.
+- **Reviews by a `User` with no `Customer` record get a `Customer` backfilled**, rather than being dropped as unmappable. Deleting a customer's published review to simplify a migration is not a migration decision.
+
+## Considered options
+
+Dropping the losing stack outright was rejected on both counts above.
+
+Deferring the merge until after extraction was rejected because the two stacks would then land in different modules, making the merge a cross-module change rather than an in-host one. **All four duplicate-stack merges happen before their module is extracted.**
+
+## Consequences
+
+The merge is the most expensive of the four and touches GDPR paths, so it is rehearsed against production-shaped data rather than run directly.
+
+Reviews and ratings remain genuinely separate concepts afterwards — see [`CONTEXT.md`](../../CONTEXT.md). A rating without a review is normal, not an incomplete record.

--- a/docs/adr/0009-vendor-rename-to-liberusoftware.md
+++ b/docs/adr/0009-vendor-rename-to-liberusoftware.md
@@ -1,0 +1,13 @@
+# Vendor rename: `liberu-eccommerce` → `liberusoftware`
+
+**Status**: accepted
+
+`composer.json` declares `"name": "liberu-eccommerce/ecommerce-laravel"` — a vendor nobody else uses, containing a typo (`eccommerce`). Everything commerce publishes goes under **`liberusoftware`**, matching the other 40 packages, and the typo dies with the rename.
+
+## Why the rename is free
+
+Packagist shows `liberu-eccommerce/ecommerce-laravel` with **0 downloads, 0 dependents and no tags**. There is nothing to break. A rename that costs nothing today costs a redirect and a deprecation notice once anything depends on it.
+
+## Consequences
+
+The host's own package name changes, which is invisible to an application nobody `require`s. Every commerce module is unaffected — none has been published yet.

--- a/docs/adr/0010-modules-and-themes-are-gitignored.md
+++ b/docs/adr/0010-modules-and-themes-are-gitignored.md
@@ -1,0 +1,23 @@
+# `/modules` and `/themes` are gitignored; a promoted package leaves the host tree
+
+**Status**: accepted
+
+`THEMES.md` §3.2 states *"the current decision, matching `/modules`, is **not** to add `/themes` to `.gitignore`"*, restated in §20's definition of done, and changeable *"only through an ADR and migration plan"* — the standard names the instrument, and this is it.
+
+Commerce goes the other way for **both** directories. During the path phase a module's code is committed to the host, because that is where it lives. **At promotion the `.gitignore` flips per package**, its files disappear from the host tree, and Composer becomes the only source.
+
+## Why both, in one ADR
+
+§3.2 cites `/modules` as its own precedent, so deciding the two separately would break the symmetry the clause rests on.
+
+## Considered options
+
+`boilerplate-laravel`'s shape — keep the installed tree committed, guard it with `git diff --exit-code --stat -- modules themes` in `release.yml` — was rejected. It maintains a second copy of code whose authoritative source is elsewhere, and the guard exists solely to police a duplication that need not exist. 726 files are tracked under its `modules/` today while the same code is also installed from VCS.
+
+## Consequences
+
+**Promotion becomes observable**: whether a module is promoted is answerable by `ls`, not by reading a lockfile.
+
+A fresh clone no longer contains module or theme source, so anyone reading the code must `composer install` first — the ordinary Laravel expectation, but a change from how this repository and boilerplate behave today.
+
+An upstream issue against §3.2 records the divergence, paired with one asking `boilerplate-laravel` to confirm its committed `modules/` tree is monorepo residue rather than intended vendoring.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,24 @@
+# Architecture Decision Records
+
+One rule decides what lands here: **a deviation from the Liberu documentation, or a deliberate loss of behaviour.** Not "significant decision" — every decision this repository's conformance effort made is significant, and an ADR per decision would turn this directory into meeting minutes.
+
+Gaps become findings, never silent exemptions. A deviation without an ADR is a bug.
+
+| # | Decision | Kind |
+| --- | --- | --- |
+| [0001](./0001-coverage-floor-for-extracted-modules.md) | 80% coverage floor for extracted modules | deviation — `MODULES.md` §24 |
+| [0002](./0002-dropping-the-content-security-policy.md) | Foundation adoption drops the CSP | behaviour loss |
+| [0003](./0003-dropping-the-password-policy.md) | Foundation adoption drops the breach-check password policy | behaviour loss |
+| [0004](./0004-no-module-prefix-in-package-names.md) | Package names and namespaces drop the `module-` prefix | deviation — `MODULES.md` §9 |
+| [0005](./0005-bare-version-tags.md) | Release tags are bare, not `v`-prefixed | deviation — `CI.md` §Release policy |
+| [0006](./0006-late-bound-host-model-resolution.md) | Modules resolve host models late and never import them | extension |
+| [0007](./0007-events-and-identifiers-across-product-boundaries.md) | Events and stable identifiers only across product boundaries | extension |
+| [0008](./0008-reviews-and-ratings-merge.md) | Reviews/ratings merge keeps moderation, backfills customers | behaviour loss avoided |
+| [0009](./0009-vendor-rename-to-liberusoftware.md) | Vendor rename `liberu-eccommerce` → `liberusoftware` | deviation — naming |
+| [0010](./0010-modules-and-themes-are-gitignored.md) | `/modules` and `/themes` are gitignored | deviation — `THEMES.md` §3.2 |
+
+Every deviation above also has an upstream issue filed against the document it deviates from. They are listed in [`../CONFORMANCE.md`](../CONFORMANCE.md)'s upstream chapter — a reader hitting one of these ADRs needs to know the disagreement is filed rather than forgotten.
+
+## Adding one
+
+Sequential numbering, `NNNN-slug.md`, next number after the highest here. Keep it short: what the context was, what was decided, why. Options and consequences only where a future reader would otherwise re-litigate the decision or be surprised by a downstream effect.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,37 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the glossary of domain terms.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This repo is **single-context**: one root glossary, one ADR directory, covering the whole
+Laravel application.
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-example-decision.md
+│   └── 0002-another-decision.md
+├── app/
+└── resources/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
First part of the conformance spec planned in [Wayfinder: conform ecommerce-laravel to the Liberu documentation standards](https://github.com/liberusoftware/ecommerce-laravel/issues/925), whose sixteen decision tickets are now all closed. The manifest is in [Assemble the conformance spec and migration plan](https://github.com/liberusoftware/ecommerce-laravel/issues/955).

Documentation only — no application code changes.

## What is here

**`CONTEXT.md`** — the tenancy and review vocabulary `MODULES.md` §2 does not cover: merchant / team / tenant / store / channel, and review / rating / customer / user. Narrow on purpose; a full glossary would restate an upstream document that will drift.

It carries one warning worth reading before the rest: `app/Filament/Admin/Resources/Stores/StoreResource.php` sets `$model = Team::class` with `$modelLabel = 'Store'`, so **the admin panel labels a `Team` a "Store" today** — while the merchant-resolution decision introduces a genuinely different `Store` beneath `Team`. That collision is live, not hypothetical.

**`docs/adr/`** — ten ADRs and an index. One rule admits them: **a deviation from the Liberu documentation, or a deliberate loss of behaviour.** Not "significant decision" — an ADR per closed ticket would have made sixteen and turned the directory into meeting minutes.

| # | Decision | Kind |
| --- | --- | --- |
| 0001 | 80% coverage floor for extracted modules | deviation — `MODULES.md` §24 |
| 0002 | Foundation adoption drops the CSP | behaviour loss |
| 0003 | Foundation adoption drops the breach-check password policy | behaviour loss |
| 0004 | Package names and namespaces drop the `module-` prefix | deviation — §9 |
| 0005 | Release tags are bare, not `v`-prefixed | deviation — `CI.md` |
| 0006 | Modules resolve host models late, never import them | extension |
| 0007 | Events and stable identifiers only across product boundaries | extension |
| 0008 | Reviews/ratings merge keeps moderation, backfills customers | behaviour loss avoided |
| 0009 | Vendor rename `liberu-eccommerce` → `liberusoftware` | deviation — naming |
| 0010 | `/modules` and `/themes` are gitignored | deviation — `THEMES.md` §3.2 |

Every deviation also has an upstream issue against the document it deviates from, so a reader hitting one knows the disagreement is filed rather than forgotten.

**`docs/MODULE_DEVELOPMENT.md`** — package anatomy, the ten dependency rules, the testing bar, CI, the README standard, and the promotion checklist. This is the document meant to outlive the migration.

Its central structural point: **`MODULES.md` §30's "definition of done" is circular as a promotion gate.** One of its thirteen bullets requires *"the independent GitHub repository, README, CI workflow, generated coverage report, release tag, and tested-host compatibility evidence"* — repository creation cannot be gated on having a repository. It splits into a promotion gate (everything provable inside the monorepo) and a release gate (§30 in full).

## Repository hygiene, same change

- **`/.claude/` is now ignored** — 4,557 files of agent worktree checkouts, including `composer.lock` copies, one `git add -A` from being committed.
- **`AGENTS.md`, `CLAUDE.md` and `docs/agents/` are committed for the first time.** A fresh clone carried none of the agent configuration, and `docs/agents/issue-tracker.md` is what tells the next agent how the map's operations work.

## Two findings worth a reviewer's attention

Neither is introduced by this PR; both were found while writing it.

- **Six of forty-seven tenancy pairings are coherent.** `IsTenantModel` is used by 37 models; only 6 sit on a table carrying `team_id`. Thirty-one models resolve `->team` to `where team_id = ?` against tables with no such column. Two of those reach a tenant-scoped Filament panel — filed as [#958](https://github.com/liberusoftware/ecommerce-laravel/issues/958), where whether it is a crash or a leak is stated as undetermined rather than guessed.
- **`module-analytics-core`'s `v1.0.4` was published having silently skipped both release gates**, because `install.yml` and `compatibility.yml` trigger on bare tags only. This is why ADR 0005 exists.

## Still to come

`CONFORMANCE.md`, `MIGRATION_PLAN.md`, `INSTALLATION.md`, `OPERATIONS.md`, the triage of the existing 13 `docs/` files, and four research-branch merges into `docs/research/`.
