### PR TITLE
chore: gate formatting with Pint on changed files only

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,74 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# This gate is a ratchet, not a sweep. It checks only the PHP files a pull
+# request actually touches, and deliberately leaves the rest of the tree alone.
+#
+# Running `pint` across the repository would rewrite most of ~400 files in one
+# commit: it would bury every real change under formatting noise, conflict with
+# every branch already in flight, and make `git blame` useless on a codebase
+# whose history is the main tool for working out why something is the way it is.
+# The cost of that is paid once and the benefit arrives gradually either way, so
+# the trade lands on gradual — files get formatted as they get edited.
+#
+# The consequence to know about: a red Lint job here is about the diff, never
+# about the file. Editing a long-unformatted file means adopting its formatting
+# in the same commit, which is the point.
+jobs:
+  pint:
+    name: Pint (changed files)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      # fetch-depth: 0 — the diff below needs the base branch's history, and the
+      # default shallow checkout does not have it.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      # --no-scripts: this job only needs vendor/bin/pint on disk. Skipping
+      # package:discover keeps it independent of whether the application boots,
+      # so a formatting failure reads as a formatting failure.
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-scripts
+
+      # ACMR — added, copied, modified, renamed. Deleted files are excluded
+      # because Pint cannot check a path that no longer exists.
+      - name: Collect changed PHP files
+        id: changed
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          git diff --name-only --diff-filter=ACMR \
+            "FETCH_HEAD...HEAD" -- '*.php' > changed.txt
+          echo "count=$(wc -l < changed.txt)" >> "$GITHUB_OUTPUT"
+          cat changed.txt
+
+      # -d '\n' so a path containing a space stays one argument. The `--` guards
+      # against a filename that starts with a dash being read as an option.
+      - name: Run Pint
+        if: steps.changed.outputs.count != '0'
+        run: xargs -a changed.txt -d '\n' ./vendor/bin/pint --test --

--- a/app/PintProbe.php
+++ b/app/PintProbe.php
@@ -1,8 +1,0 @@
-<?php
-namespace App;
-class PintProbe {
-    public function probe( $x ) {
-        if($x){ return 1;}
-        return 0 ;
-    }
-}

--- a/app/PintProbe.php
+++ b/app/PintProbe.php
@@ -1,0 +1,8 @@
+<?php
+namespace App;
+class PintProbe {
+    public function probe( $x ) {
+        if($x){ return 1;}
+        return 0 ;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,12 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
+        ],
+        "lint": [
+            "@php vendor/bin/pint --test"
+        ],
+        "lint:fix": [
+            "@php vendor/bin/pint"
         ]
     },
     "extra": {

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,3 @@
+{
+    "preset": "laravel"
+}


### PR DESCRIPTION
Wave 0 asks for an enforcement layer. This is the part of it that can land here: `laravel/pint` is already in `require-dev` and completely unused — no `pint.json`, no CI job, nothing calling it.

## The gate is a ratchet, not a sweep

It checks **only the PHP files a pull request touches** and leaves the rest of the tree alone.

Running `pint` across the repository would rewrite most of ~400 files in one commit. That would bury every real change under formatting noise, conflict with every branch already in flight, and make `git blame` useless on a codebase whose history is the main tool for working out why something is the way it is. The benefit arrives gradually either way, so the trade lands on gradual — files get formatted as they get edited.

**The consequence worth knowing:** a red Lint job is about the diff, never about the file. Editing a long-unformatted file means adopting its formatting in the same commit. That is the mechanism, not a side effect.

## Details

- `pint.json` pins the `laravel` preset. That is Pint's current default, so it changes nothing today and stops a future default from silently reformatting the codebase.
- `composer lint` / `composer lint:fix` are the local equivalents. **This does not touch `composer.lock`** — the lock's content-hash is computed from `require`, `require-dev`, `extra` and a handful of other keys; [`scripts` is not one of them](https://github.com/composer/composer/blob/main/src/Composer/Package/Locker.php#L93).
- The job installs with `--no-scripts`, so it needs only `vendor/bin/pint` on disk and does not depend on the application booting. A formatting failure reads as a formatting failure.
- `--diff-filter=ACMR` excludes deletions, since Pint cannot check a path that no longer exists. `xargs -d '\n'` keeps paths with spaces intact.

## PHPStan is not in this change

It is not installed, and adding a `require-dev` entry means regenerating `composer.lock`, which needs a Composer network route this environment does not have. Same blocker as #963 had.

## Verification

The two commits after the first one exercise the gate in both directions on this PR — a deliberately misformatted file to prove Lint goes red, then its removal to prove it goes green. Check the run history rather than taking the mechanism on trust.
