### PR TITLE
test: enforce the two static rules the codebase keeps breaking

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -73,10 +73,17 @@ A worker is required for normal operation, not just for throughput. Dropshipping
 php artisan queue:work --tries=3
 ```
 
-Two things worth knowing about the current queue configuration:
+One thing worth knowing about the current queue configuration:
 
-- **`after_commit` is `false` on all four connections** (`config/queue.php:42,51,62,71`), and `dispatchAfterCommit` is never used — while two checkout paths dispatch webhooks from inside open transactions. A job can therefore run against a transaction that has not committed yet.
-- **`SendWebhookDelivery` hand-rolls its own retry** (`:14`) and re-dispatches itself rather than failing. Its failures never reach `failed_jobs`, so they are invisible to Horizon and to `queue:failed`.
+**`SendWebhookDelivery` hand-rolls its own retry** (`:14`) and re-dispatches itself rather than throwing, so a failed delivery never reaches `failed_jobs` and `queue:failed` will not show it. That is deliberate — a failing receiver must not bubble an exception into the order transition that triggered it — and it does not make failures invisible, only differently placed: every attempt is written to `webhook_deliveries` with its status code and `success`, and `webhooks:retry-failed` re-queues any `(endpoint, order, event)` tuple that never succeeded inside a 24-hour window. **Watch that table, not `failed_jobs`.**
+
+### `after_commit` — corrected
+
+An earlier revision of this document claimed that `after_commit` being `false` on all four connections was a fault, because "two checkout paths dispatch webhooks from inside open transactions". **That is wrong**, and the correction matters because the claim would send someone hunting a race that does not exist.
+
+`false` is Laravel's shipped default, not a local choice. And no dispatch happens inside a transaction: both checkouts close their `DB::transaction` — which covers only order creation and stock reservation — before charging, and every `transitionTo` call in the codebase, which is what fires the outbound webhook, runs after that closure has returned. `queueDropship` is likewise called from outside it.
+
+The [`CONFORMANCE.md`](./CONFORMANCE.md) snapshot still carries the original claim, by design: it is dated and superseded rather than revised.
 
 ---
 

--- a/tests/Unit/ArchitectureTest.php
+++ b/tests/Unit/ArchitectureTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Static rules about the shipped code, checked by reading it rather than
+ * running it.
+ *
+ * These use token_get_all rather than grep. A regex over the raw text cannot
+ * tell `env('X')` from the same characters inside a string literal, a comment,
+ * or a docblock example — and the codebase has all three. Tokenising asks PHP
+ * itself what is code, so the rules have no false positives to explain away and
+ * nobody learns to ignore them.
+ */
+class ArchitectureTest extends TestCase
+{
+    /** Directories whose contents ship and run in production. */
+    private const SCANNED = ['app', 'routes', 'database', 'bootstrap'];
+
+    public function test_env_is_only_called_from_config(): void
+    {
+        $found = $this->callSites(['env']);
+
+        $this->assertSame([], $found, implode("\n", [
+            'env() must only be called from config/.',
+            '',
+            'Under `config:cache` — which is how this deploys — env() returns null',
+            'everywhere except while config files are being loaded. A call outside',
+            'config/ therefore works locally and silently resolves to nothing in',
+            'production. DropxlService and SubscriptionController both shipped that',
+            'way. Read the value through config() and add the config/ entry.',
+            '',
+            ...$found,
+        ]));
+    }
+
+    public function test_no_debug_helpers_are_left_in_shipped_code(): void
+    {
+        $found = $this->callSites(['dd', 'dump', 'var_dump', 'ray', 'print_r']);
+
+        $this->assertSame([], $found, "Debug helpers left in shipped code:\n".implode("\n", $found));
+    }
+
+    /**
+     * Every call to one of $names, as file:line. Method calls and definitions of
+     * the same name are not call sites of the global function and are skipped.
+     *
+     * @param  list<string>  $names
+     * @return list<string>
+     */
+    private function callSites(array $names): array
+    {
+        $found = [];
+
+        foreach ($this->phpFiles() as $file) {
+            $tokens = token_get_all(file_get_contents($file->getPathname()));
+
+            foreach ($tokens as $i => $token) {
+                if (! is_array($token) || $token[0] !== T_STRING || ! in_array($token[1], $names, true)) {
+                    continue;
+                }
+
+                // `$this->env(...)`, `Foo::env(...)`, `function env(...)` — the
+                // name matches but none of them calls the global function.
+                $before = $this->significantToken($tokens, $i, -1);
+                if (is_array($before) && in_array($before[0], [T_OBJECT_OPERATOR, T_NULLSAFE_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION], true)) {
+                    continue;
+                }
+
+                if ($this->significantToken($tokens, $i, 1) !== '(') {
+                    continue;
+                }
+
+                $found[] = $this->relativePath($file).':'.$token[2];
+            }
+        }
+
+        return $found;
+    }
+
+    /** The next non-whitespace, non-comment token in $direction from $i. */
+    private function significantToken(array $tokens, int $i, int $direction): array|string|null
+    {
+        for ($j = $i + $direction; isset($tokens[$j]); $j += $direction) {
+            if (is_array($tokens[$j]) && in_array($tokens[$j][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return $tokens[$j];
+        }
+
+        return null;
+    }
+
+    /** @return iterable<SplFileInfo> */
+    private function phpFiles(): iterable
+    {
+        foreach (self::SCANNED as $directory) {
+            $path = $this->basePath().DIRECTORY_SEPARATOR.$directory;
+
+            if (! is_dir($path)) {
+                continue;
+            }
+
+            /** @var SplFileInfo $file */
+            foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS)) as $file) {
+                if ($file->isFile() && $file->getExtension() === 'php') {
+                    yield $file;
+                }
+            }
+        }
+    }
+
+    private function relativePath(SplFileInfo $file): string
+    {
+        return ltrim(str_replace($this->basePath(), '', $file->getPathname()), DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * The repository root. Resolved from __DIR__ rather than base_path() so this
+     * test needs no booted application — it reads files, nothing else.
+     */
+    private function basePath(): string
+    {
+        return dirname(__DIR__, 2);
+    }
+}


### PR DESCRIPTION
The other half of the wave 0 enforcement layer — the half that needs no new dependency. Two rules read out of the source rather than run.

## `env()` outside `config/`

The rule that has already cost something. Under `config:cache` — which is how this deploys — `env()` returns `null` everywhere except while config files are loading, so a call outside `config/` **works locally and silently resolves to nothing in production**. `DropxlService` and `SubscriptionController` both shipped that way and were fixed in `e677de8`.

The mistake is easy to reintroduce and produces no error when it is. That is exactly the shape of thing a test should hold, rather than a note in a document nobody reads at the moment they need it.

## Debug helpers in shipped code

`dd`, `dump`, `var_dump`, `ray`, `print_r`. Cheap companion rule.

## Why `token_get_all` and not grep

A regex over raw text cannot tell `env('X')` from the same characters inside a string literal, a comment, or a docblock example — and this codebase has all three. **A rule with false positives is a rule people learn to ignore.**

Tokenising asks PHP itself what is code. Checked against a probe covering every near-miss:

```php
private $env = 'x';
public function env($k) { ... }   // definition   — skipped
$this->env('X');                  // method call  — skipped
Config::env('Y');                 // static call  — skipped
"env('LITERAL')";                 // string       — skipped
// env('COMMENT')                 // comment      — skipped
return env('REAL');               //              <- the only hit
```

One violation reported, on the right line.

Both rules pass on the current tree, so this is a ratchet like #967 rather than a backlog.

## Correction to `OPERATIONS.md`

The queue section claimed `after_commit` being `false` was a fault, because "two checkout paths dispatch webhooks from inside open transactions".

**That is wrong**, and it matters because the claim would send someone hunting a race that does not exist. `false` is Laravel's shipped default, not a local choice. And no dispatch happens inside a transaction: both checkouts close the `DB::transaction` — which covers only order creation and stock reservation — before charging, and every `transitionTo` call, which is what fires the outbound webhook, runs after that closure returns. `queueDropship` is called from outside it too.

The `SendWebhookDelivery` entry is reworded rather than removed. Its failures genuinely never reach `failed_jobs`, but calling them "invisible" was overstated — every attempt lands in `webhook_deliveries` with its status code, and `webhooks:retry-failed` re-queues any tuple that never succeeded inside 24 hours. **Watch that table, not `failed_jobs`.**

`CONFORMANCE.md` keeps the original claim, by design — it is a dated snapshot, superseded rather than revised.
