### PR TITLE
test: assert every IsTenantModel model has a team_id column

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,77 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# This gate is a ratchet, not a sweep. It checks only the PHP files a pull
+# request actually touches, and deliberately leaves the rest of the tree alone.
+#
+# Running `pint` across the repository would rewrite most of ~400 files in one
+# commit: it would bury every real change under formatting noise, conflict with
+# every branch already in flight, and make `git blame` useless on a codebase
+# whose history is the main tool for working out why something is the way it is.
+# The cost of that is paid once and the benefit arrives gradually either way, so
+# the trade lands on gradual — files get formatted as they get edited.
+#
+# The consequence to know about: a red Lint job here is about the diff, never
+# about the file. Editing a long-unformatted file means adopting its formatting
+# in the same commit, which is the point.
+jobs:
+  pint:
+    name: Pint (changed files)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      # fetch-depth: 0 — the diff below needs the base branch's history, and the
+      # default shallow checkout does not have it.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      # --no-scripts: this job only needs vendor/bin/pint on disk. Skipping
+      # package:discover keeps it independent of whether the application boots,
+      # so a formatting failure reads as a formatting failure.
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-scripts
+
+      # ACMR — added, copied, modified, renamed. Deleted files are excluded
+      # because Pint cannot check a path that no longer exists.
+      - name: Collect changed PHP files
+        id: changed
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          git diff --name-only --diff-filter=ACMR \
+            "FETCH_HEAD...HEAD" -- '*.php' > changed.txt
+          echo "count=$(wc -l < changed.txt)" >> "$GITHUB_OUTPUT"
+          cat changed.txt
+
+      # -d '\n' so a path containing a space stays one argument. The `--` guards
+      # against a filename that starts with a dash being read as an option.
+      # -v prints the diff Pint would apply. Without it a failure is a list of
+      # rule names truncated to the terminal width, which is not enough to act
+      # on — the first real failure this gate produced could not be read.
+      - name: Run Pint
+        if: steps.changed.outputs.count != '0'
+        run: xargs -a changed.txt -d '\n' ./vendor/bin/pint --test -v --

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,10 @@ name: Lint
 on:
   pull_request:
     branches: [main]
+  # This repository drops pull_request synchronize events often enough that a
+  # pushed fix can sit with no run at all. workflow_dispatch is the way back in;
+  # it compares against main, which is what a PR to main would have used anyway.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -61,7 +65,8 @@ jobs:
         id: changed
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "${{ github.base_ref }}"
+          base="${{ github.base_ref }}"
+          git fetch --no-tags origin "${base:-main}"
           git diff --name-only --diff-filter=ACMR \
             "FETCH_HEAD...HEAD" -- '*.php' > changed.txt
           echo "count=$(wc -l < changed.txt)" >> "$GITHUB_OUTPUT"

--- a/tests/Feature/TenantModelSchemaTest.php
+++ b/tests/Feature/TenantModelSchemaTest.php
@@ -39,7 +39,37 @@ class TenantModelSchemaTest extends TestCase
      * @var list<class-string<Model>>
      */
     private const MISSING_TEAM_ID = [
-        // Filled from the run this test's first commit produced — see the PR.
+        \App\Models\ABTest::class,
+        \App\Models\ABTestAssignment::class,
+        \App\Models\AbandonedCart::class,
+        \App\Models\AnalyticsEvent::class,
+        \App\Models\CartRecoveryAttempt::class,
+        \App\Models\CartRecoveryCampaign::class,
+        \App\Models\CustomerGroup::class,
+        \App\Models\CustomerMetric::class,
+        \App\Models\CustomerSegment::class,
+        \App\Models\Discount::class,
+        \App\Models\GiftCard::class,
+        \App\Models\GiftCardTransaction::class,
+        \App\Models\GiftRegistry::class,
+        \App\Models\GiftRegistryItem::class,
+        \App\Models\GiftRegistryPurchase::class,
+        \App\Models\InventoryAdjustment::class,
+        \App\Models\InventoryItem::class,
+        \App\Models\InventoryLevel::class,
+        \App\Models\InventoryLocation::class,
+        \App\Models\Menu::class,
+        \App\Models\MenuItem::class,
+        \App\Models\ProductInteraction::class,
+        \App\Models\ProductOption::class,
+        \App\Models\ProductPerformance::class,
+        \App\Models\ProductRecommendation::class,
+        \App\Models\ProductTaxonomyValue::class,
+        \App\Models\ProductVariant::class,
+        \App\Models\RecommendationRule::class,
+        \App\Models\SeoSetting::class,
+        \App\Models\TaxonomyAttribute::class,
+        \App\Models\TaxonomyCategory::class,
     ];
 
     public function test_tenant_models_have_a_team_id_column(): void

--- a/tests/Feature/TenantModelSchemaTest.php
+++ b/tests/Feature/TenantModelSchemaTest.php
@@ -2,6 +2,37 @@
 
 namespace Tests\Feature;
 
+use App\Models\ABTest;
+use App\Models\ABTestAssignment;
+use App\Models\AbandonedCart;
+use App\Models\AnalyticsEvent;
+use App\Models\CartRecoveryAttempt;
+use App\Models\CartRecoveryCampaign;
+use App\Models\CustomerGroup;
+use App\Models\CustomerMetric;
+use App\Models\CustomerSegment;
+use App\Models\Discount;
+use App\Models\GiftCard;
+use App\Models\GiftCardTransaction;
+use App\Models\GiftRegistry;
+use App\Models\GiftRegistryItem;
+use App\Models\GiftRegistryPurchase;
+use App\Models\InventoryAdjustment;
+use App\Models\InventoryItem;
+use App\Models\InventoryLevel;
+use App\Models\InventoryLocation;
+use App\Models\Menu;
+use App\Models\MenuItem;
+use App\Models\ProductInteraction;
+use App\Models\ProductOption;
+use App\Models\ProductPerformance;
+use App\Models\ProductRecommendation;
+use App\Models\ProductTaxonomyValue;
+use App\Models\ProductVariant;
+use App\Models\RecommendationRule;
+use App\Models\SeoSetting;
+use App\Models\TaxonomyAttribute;
+use App\Models\TaxonomyCategory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Schema;
@@ -39,37 +70,37 @@ class TenantModelSchemaTest extends TestCase
      * @var list<class-string<Model>>
      */
     private const MISSING_TEAM_ID = [
-        \App\Models\ABTest::class,
-        \App\Models\ABTestAssignment::class,
-        \App\Models\AbandonedCart::class,
-        \App\Models\AnalyticsEvent::class,
-        \App\Models\CartRecoveryAttempt::class,
-        \App\Models\CartRecoveryCampaign::class,
-        \App\Models\CustomerGroup::class,
-        \App\Models\CustomerMetric::class,
-        \App\Models\CustomerSegment::class,
-        \App\Models\Discount::class,
-        \App\Models\GiftCard::class,
-        \App\Models\GiftCardTransaction::class,
-        \App\Models\GiftRegistry::class,
-        \App\Models\GiftRegistryItem::class,
-        \App\Models\GiftRegistryPurchase::class,
-        \App\Models\InventoryAdjustment::class,
-        \App\Models\InventoryItem::class,
-        \App\Models\InventoryLevel::class,
-        \App\Models\InventoryLocation::class,
-        \App\Models\Menu::class,
-        \App\Models\MenuItem::class,
-        \App\Models\ProductInteraction::class,
-        \App\Models\ProductOption::class,
-        \App\Models\ProductPerformance::class,
-        \App\Models\ProductRecommendation::class,
-        \App\Models\ProductTaxonomyValue::class,
-        \App\Models\ProductVariant::class,
-        \App\Models\RecommendationRule::class,
-        \App\Models\SeoSetting::class,
-        \App\Models\TaxonomyAttribute::class,
-        \App\Models\TaxonomyCategory::class,
+        ABTest::class,
+        ABTestAssignment::class,
+        AbandonedCart::class,
+        AnalyticsEvent::class,
+        CartRecoveryAttempt::class,
+        CartRecoveryCampaign::class,
+        CustomerGroup::class,
+        CustomerMetric::class,
+        CustomerSegment::class,
+        Discount::class,
+        GiftCard::class,
+        GiftCardTransaction::class,
+        GiftRegistry::class,
+        GiftRegistryItem::class,
+        GiftRegistryPurchase::class,
+        InventoryAdjustment::class,
+        InventoryItem::class,
+        InventoryLevel::class,
+        InventoryLocation::class,
+        Menu::class,
+        MenuItem::class,
+        ProductInteraction::class,
+        ProductOption::class,
+        ProductPerformance::class,
+        ProductRecommendation::class,
+        ProductTaxonomyValue::class,
+        ProductVariant::class,
+        RecommendationRule::class,
+        SeoSetting::class,
+        TaxonomyAttribute::class,
+        TaxonomyCategory::class,
     ];
 
     public function test_tenant_models_have_a_team_id_column(): void

--- a/tests/Feature/TenantModelSchemaTest.php
+++ b/tests/Feature/TenantModelSchemaTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * `App\Traits\IsTenantModel` is a `team()` BelongsTo relation and nothing else.
+ * A model that uses it therefore promises a `team_id` column — and 31 of the 37
+ * models that use it have no such column on their table, so the relation is
+ * dead on arrival and any tenant scope added later would raise an unknown-column
+ * error rather than isolating anything.
+ *
+ * #958 records two of these, because those two happen to be registered as
+ * Filament resources in a tenant-scoped panel. They are not special; they are
+ * the two that were noticed.
+ *
+ * This test is a ratchet. The allow-list below can only shrink: a model may not
+ * newly join it, and every entry removed is a table that got its column. It is
+ * deliberately a list of names rather than a count, so shrinking it requires
+ * naming what was fixed.
+ */
+class TenantModelSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Models using IsTenantModel whose table has no team_id column today.
+     *
+     * Not a to-do list to be worked top to bottom. `team_id` is nullable with
+     * `default(1)`, so adding the column to a table that already holds rows
+     * silently attributes every one of them to team 1 — which is how the
+     * existing mess was made. These land with the tenant scope in wave 1.5,
+     * where unattributable rows are quarantined rather than assigned.
+     *
+     * @var list<class-string<Model>>
+     */
+    private const MISSING_TEAM_ID = [
+        // Filled from the run this test's first commit produced — see the PR.
+    ];
+
+    public function test_tenant_models_have_a_team_id_column(): void
+    {
+        $unexpected = [];
+        $fixed = [];
+
+        foreach ($this->tenantModels() as $class) {
+            $table = (new $class)->getTable();
+
+            if (! Schema::hasTable($table)) {
+                $unexpected[] = "{$class} -> table {$table} does not exist";
+
+                continue;
+            }
+
+            $hasColumn = Schema::hasColumn($table, 'team_id');
+            $allowed = in_array($class, self::MISSING_TEAM_ID, true);
+
+            if (! $hasColumn && ! $allowed) {
+                $unexpected[] = "{$class} -> {$table} has no team_id column";
+            }
+
+            if ($hasColumn && $allowed) {
+                $fixed[] = $class;
+            }
+        }
+
+        $this->assertSame([], $unexpected, implode("\n", [
+            'These models use IsTenantModel but their table has no team_id column,',
+            'so team() is a relation to nothing and a tenant scope on them would',
+            'raise an unknown-column error rather than isolating anything.',
+            '',
+            'Either drop the trait from the model or add the column with the row',
+            'attribution decided rather than defaulted.',
+            '',
+            ...$unexpected,
+        ]));
+
+        $this->assertSame([], $fixed,
+            "These now have a team_id column and must be removed from MISSING_TEAM_ID:\n".implode("\n", $fixed));
+    }
+
+    /**
+     * Every model class under app/Models that uses the trait.
+     *
+     * Read from the source rather than from a hand-kept list, so a model that
+     * adopts the trait is covered without anyone remembering to add it here.
+     *
+     * @return list<class-string<Model>>
+     */
+    private function tenantModels(): array
+    {
+        $models = [];
+
+        foreach (glob(app_path('Models/*.php')) as $file) {
+            if (! str_contains(file_get_contents($file), 'IsTenantModel')) {
+                continue;
+            }
+
+            $class = 'App\\Models\\'.basename($file, '.php');
+
+            if (class_exists($class) && is_subclass_of($class, Model::class)) {
+                $models[] = $class;
+            }
+        }
+
+        sort($models);
+
+        return $models;
+    }
+}

--- a/tests/Feature/TenantModelSchemaTest.php
+++ b/tests/Feature/TenantModelSchemaTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Models\AbandonedCart;
 use App\Models\ABTest;
 use App\Models\ABTestAssignment;
-use App\Models\AbandonedCart;
 use App\Models\AnalyticsEvent;
 use App\Models\CartRecoveryAttempt;
 use App\Models\CartRecoveryCampaign;


### PR DESCRIPTION
`App\Traits\IsTenantModel` is a `team()` BelongsTo relation and nothing else. A model that uses it promises a `team_id` column.

**31 of the 37 models that use it have no such column.** Their `team()` relation is dead on arrival, and any tenant scope added later would raise an unknown-column error on them rather than isolating anything.

#958 records two of these — `Discount` and `Menu` — because those two happen to be registered as Filament resources in a tenant-scoped panel. They are not special. They are the two that were noticed.

| | |
| --- | --- |
| Have `team_id` | `Coupon`, `Customer`, `Order`, `Product`, `ProductCategory`, `ProductCollection` |
| Do not | the other 31, listed in `MISSING_TEAM_ID` |

## The list came from CI, not from me

The first commit runs the test with an **empty** allow-list, so the failure output enumerates the real set from a migrated schema. The second commit fills it in. The first run is in this PR's history — the list is machine-produced, not a table-name guess I made and then trusted.

## This is a ratchet, not a to-do list

The allow-list can only shrink: a model may not newly join it, and any entry whose table gains the column fails the test until it is removed. It is deliberately names rather than a count, so shrinking it requires saying what was fixed.

**It should not be worked top to bottom.** `team_id` is nullable with `default(1)`, so adding the column to a table that already holds rows silently attributes every one of them to team 1 — which is precisely how the current mess was made. These land with the tenant scope in wave 1.5, where unattributable rows are quarantined rather than assigned. The gate this closes is the accidental one: nobody adds a 32nd.

## What this is not

Not the tenant scope. #939, #950 and #952 stay open — this only establishes which models could carry a scope at all. That question had no answer before, and #958's inventory of two was wrong by 29.


---

## Two Lint fixes rode along

Not planned, but this PR is where both showed up.

**Pint now prints its diff.** The gate's first real failure — on this PR, catching this PR's own new file — reported `unary_operator_spaces, not_operato…`, a rule-name list truncated to the terminal width. That is not something a contributor can act on, and it was wrong besides: the actual problem was import ordering (`ordered_imports` compares case-insensitively, so `AbandonedCart` sorts before `ABTest`). `--test -v` prints the diff, which said so in two lines.

**The Lint job can be dispatched manually again.** This repository drops `pull_request` synchronize events often enough that a pushed fix sits with no run at all — three pushes on this branch produced nothing, and closing and reopening the PR did not help either. `workflow_dispatch` is the way back in, with `base_ref` falling back to `main`, which is what a PR to main compares against anyway.
