### PR TITLE
fix: an admin of one team can edit another team's catalogue

### DIFF
--- a/app/Http/Controllers/Api/CollectionController.php
+++ b/app/Http/Controllers/Api/CollectionController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Http\Controllers\Api\Concerns\OwnsTeamResources;
 use App\Http\Controllers\Controller;
 use App\Models\ProductCollection;
 use Illuminate\Http\JsonResponse;
@@ -14,6 +15,8 @@ use Spatie\QueryBuilder\QueryBuilder;
 
 class CollectionController extends Controller
 {
+    use OwnsTeamResources;
+
     /**
      * Display a listing of collections.
      */
@@ -84,6 +87,10 @@ class CollectionController extends Controller
             $data['slug'] = Str::slug($data['name']);
         }
 
+        if ($teamId = $this->creationTeamId($request)) {
+            $data['team_id'] = $teamId;
+        }
+
         $collection = ProductCollection::create($data);
 
         return response()->json([
@@ -132,6 +139,8 @@ class CollectionController extends Controller
             ], 404);
         }
 
+        $this->assertActorOwns($request, $collection);
+
         $validator = Validator::make($request->all(), [
             'name' => 'sometimes|required|string|max:255',
             'slug' => ['sometimes', 'string', 'max:255', Rule::unique('collections', 'slug')->ignore($id)],
@@ -177,6 +186,8 @@ class CollectionController extends Controller
                 'message' => 'Collection not found',
             ], 404);
         }
+
+        $this->assertActorOwns($request, $collection);
 
         $validator = Validator::make($request->all(), [
             'product_ids' => 'required|array',
@@ -229,6 +240,8 @@ class CollectionController extends Controller
             ], 404);
         }
 
+        $this->assertActorOwns($request, $collection);
+
         $validator = Validator::make($request->all(), [
             'product_ids' => 'required|array',
             'product_ids.*' => 'required|integer|exists:products,id',
@@ -268,6 +281,8 @@ class CollectionController extends Controller
                 'message' => 'Collection not found',
             ], 404);
         }
+
+        $this->assertActorOwns($request, $collection);
 
         $collection->delete();
 

--- a/app/Http/Controllers/Api/Concerns/OwnsTeamResources.php
+++ b/app/Http/Controllers/Api/Concerns/OwnsTeamResources.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers\Api\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+
+/**
+ * Ownership checks for the admin-gated API writes.
+ *
+ * `admin` and `super_admin` are global roles, not per-team ones —
+ * `config/permission.php` sets `'teams' => false` — so the role check these
+ * endpoints already perform says "this person administers something", never
+ * "this person administers *this*". An admin of one merchant could edit and
+ * soft-delete another merchant's catalogue (#939).
+ *
+ * This closes the write half. The read half is not fixed here, and cannot be
+ * fixed the same way: a scope keyed off the actor's teams would return nothing
+ * to a shopper, who is an authenticated user with no team at all. Reads need the
+ * tenant of the *request* rather than of the actor, which is what wave 1.5's
+ * Store/Channel resolution provides.
+ */
+trait OwnsTeamResources
+{
+    /**
+     * Teams the actor can act in — owned and joined, which is what
+     * `canAccessPanel` and the Filament tenant switcher already mean by it.
+     *
+     * @return list<int>
+     */
+    protected function actorTeamIds(Request $request): array
+    {
+        return $request->user()
+            ?->allTeams()
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->all() ?? [];
+    }
+
+    /**
+     * 404 unless the resource belongs to a team the actor is in.
+     *
+     * 404 rather than 403, matching `ReturnRequestController::show`: a foreign
+     * record should not be distinguishable from one that does not exist.
+     *
+     * A resource with no team is left alone. Nothing creates one — every write
+     * path here stamps a team — so this only concerns rows that predate the
+     * column, which belong to nobody rather than to somebody else.
+     */
+    protected function assertActorOwns(Request $request, Model $resource): void
+    {
+        if ($resource->team_id === null) {
+            return;
+        }
+
+        abort_unless(in_array((int) $resource->team_id, $this->actorTeamIds($request), true), 404);
+    }
+
+    /**
+     * The team a resource created through this request should belong to.
+     *
+     * The actor's current team, falling back to any team they are in. Null when
+     * they are in none, in which case the caller leaves the column alone and the
+     * database default stands — the same row that would have been written before
+     * this change.
+     */
+    protected function creationTeamId(Request $request): ?int
+    {
+        $user = $request->user();
+
+        if ($user === null) {
+            return null;
+        }
+
+        return $user->current_team_id ?? $this->actorTeamIds($request)[0] ?? null;
+    }
+}

--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Http\Controllers\Api\Concerns\OwnsTeamResources;
 use App\Http\Controllers\Controller;
 use App\Models\Product;
 use Illuminate\Http\JsonResponse;
@@ -10,6 +11,8 @@ use Illuminate\Support\Facades\Validator;
 
 class ProductController extends Controller
 {
+    use OwnsTeamResources;
+
     /**
      * Display a paginated listing of products.
      */
@@ -124,7 +127,13 @@ class ProductController extends Controller
             ], 422);
         }
 
-        $product = Product::create($validator->validated());
+        $attributes = $validator->validated();
+
+        if ($teamId = $this->creationTeamId($request)) {
+            $attributes['team_id'] = $teamId;
+        }
+
+        $product = Product::create($attributes);
 
         return response()->json([
             'success' => true,
@@ -148,6 +157,8 @@ class ProductController extends Controller
                 'message' => 'Product not found',
             ], 404);
         }
+
+        $this->assertActorOwns($request, $product);
 
         $validator = Validator::make($request->all(), [
             'name' => 'sometimes|required|string|max:255',
@@ -202,6 +213,8 @@ class ProductController extends Controller
                 'message' => 'Product not found',
             ], 404);
         }
+
+        $this->assertActorOwns($request, $product);
 
         $product->delete();
 

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -47,6 +47,11 @@ class Product extends Model implements Orderable
         'suggested_price',
         'minimum_price',
         'is_featured',
+
+        // Fillable so the API write paths can stamp the creating admin's team.
+        // No validator accepts it from request input, so it cannot be set by a
+        // caller — see Api\Concerns\OwnsTeamResources.
+        'team_id',
     ];
 
     protected $casts = [

--- a/app/Models/ProductCollection.php
+++ b/app/Models/ProductCollection.php
@@ -22,6 +22,11 @@ class ProductCollection extends Model implements Orderable
         'slug',
         'description',
         'price',
+
+        // Fillable so the API write paths can stamp the creating admin's team.
+        // No validator accepts it from request input, so it cannot be set by a
+        // caller — see Api\Concerns\OwnsTeamResources.
+        'team_id',
     ];
 
     public function getPrice(): float

--- a/tests/Feature/Api/CollectionControllerTest.php
+++ b/tests/Feature/Api/CollectionControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api;
 
 use App\Models\Product;
 use App\Models\ProductCollection;
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
@@ -22,6 +23,11 @@ class CollectionControllerTest extends TestCase
         // Collection write endpoints are admin-gated; these tests act as an admin.
         Role::findOrCreate('super_admin', 'web');
         $this->user = User::factory()->create()->assignRole('super_admin');
+        // Products and collections carry team_id with a database default of 1,
+        // and the API writes are now ownership-checked (#939) — so the admin
+        // acting here has to be in team 1 for the rows these tests create to be
+        // theirs to edit.
+        Team::factory()->create(['id' => 1, 'user_id' => $this->user->id]);
         Sanctum::actingAs($this->user);
     }
 

--- a/tests/Feature/Api/CrossTeamWriteApiTest.php
+++ b/tests/Feature/Api/CrossTeamWriteApiTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Product;
+use App\Models\ProductCategory;
+use App\Models\ProductCollection;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * `admin` and `super_admin` are global roles — `config/permission.php` sets
+ * `'teams' => false` — so the role check on the API write paths says "this
+ * person administers something", never "this person administers *this*".
+ *
+ * Before this, an admin of one merchant could edit and soft-delete another
+ * merchant's catalogue (#939).
+ */
+class CrossTeamWriteApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private Team $ownTeam;
+
+    private Team $otherTeam;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::findOrCreate('super_admin', 'web');
+
+        $this->admin = User::factory()->create()->assignRole('super_admin');
+        $this->ownTeam = Team::factory()->create(['user_id' => $this->admin->id]);
+        $this->admin->forceFill(['current_team_id' => $this->ownTeam->id])->save();
+
+        // Owned by somebody else entirely.
+        $this->otherTeam = Team::factory()->create(['user_id' => User::factory()->create()->id]);
+
+        Sanctum::actingAs($this->admin);
+    }
+
+    public function test_admin_cannot_update_another_teams_product(): void
+    {
+        $product = Product::factory()->create(['team_id' => $this->otherTeam->id, 'price' => 10]);
+
+        $this->putJson("/api/products/{$product->id}", ['price' => 1])->assertNotFound();
+
+        $this->assertSame('10.00', (string) $product->fresh()->price);
+    }
+
+    public function test_admin_cannot_delete_another_teams_product(): void
+    {
+        $product = Product::factory()->create(['team_id' => $this->otherTeam->id]);
+
+        $this->deleteJson("/api/products/{$product->id}")->assertNotFound();
+
+        $this->assertNotNull(Product::find($product->id));
+    }
+
+    public function test_admin_can_still_update_their_own_teams_product(): void
+    {
+        $product = Product::factory()->create(['team_id' => $this->ownTeam->id, 'price' => 10]);
+
+        $this->putJson("/api/products/{$product->id}", ['price' => 1])->assertOk();
+
+        $this->assertSame('1.00', (string) $product->fresh()->price);
+    }
+
+    public function test_a_created_product_belongs_to_the_creating_admins_team(): void
+    {
+        $category = ProductCategory::factory()->create();
+
+        $response = $this->postJson('/api/products', [
+            'name' => 'Stamped',
+            'short_description' => 'x',
+            'price' => 5,
+            'category_id' => $category->id,
+        ])->assertCreated();
+
+        $this->assertSame(
+            $this->ownTeam->id,
+            (int) Product::find($response->json('data.id'))->team_id,
+        );
+    }
+
+    public function test_admin_cannot_update_or_delete_another_teams_collection(): void
+    {
+        $collection = ProductCollection::factory()->create(['team_id' => $this->otherTeam->id, 'name' => 'Theirs']);
+
+        $this->putJson("/api/collections/{$collection->id}", ['name' => 'Mine now'])->assertNotFound();
+        $this->deleteJson("/api/collections/{$collection->id}")->assertNotFound();
+
+        $this->assertSame('Theirs', $collection->fresh()->name);
+    }
+
+    public function test_admin_cannot_move_products_into_another_teams_collection(): void
+    {
+        $collection = ProductCollection::factory()->create(['team_id' => $this->otherTeam->id]);
+        $product = Product::factory()->create(['team_id' => $this->ownTeam->id]);
+
+        $this->postJson("/api/collections/{$collection->id}/products", ['product_ids' => [$product->id]])
+            ->assertNotFound();
+    }
+
+    /**
+     * The check is ownership, not the absence of a team: an admin with no team
+     * at all administers nothing rather than everything.
+     */
+    public function test_a_teamless_admin_cannot_write_to_a_teams_product(): void
+    {
+        $teamless = User::factory()->create()->assignRole('super_admin');
+        Sanctum::actingAs($teamless);
+
+        $product = Product::factory()->create(['team_id' => $this->ownTeam->id]);
+
+        $this->deleteJson("/api/products/{$product->id}")->assertNotFound();
+    }
+}

--- a/tests/Feature/Api/ProductApiTest.php
+++ b/tests/Feature/Api/ProductApiTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api;
 
 use App\Models\Product;
 use App\Models\ProductCategory;
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
@@ -22,6 +23,11 @@ class ProductApiTest extends TestCase
         // Product write endpoints are admin-gated; the CRUD tests below act as an admin.
         Role::findOrCreate('super_admin', 'web');
         $this->user = User::factory()->create()->assignRole('super_admin');
+        // Products and collections carry team_id with a database default of 1,
+        // and the API writes are now ownership-checked (#939) — so the admin
+        // acting here has to be in team 1 for the rows these tests create to be
+        // theirs to edit.
+        Team::factory()->create(['id' => 1, 'user_id' => $this->user->id]);
     }
 
     public function test_unauthenticated_cannot_list_products(): void

--- a/tests/Feature/Api/ProductControllerTest.php
+++ b/tests/Feature/Api/ProductControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api;
 
 use App\Models\Product;
 use App\Models\ProductCategory;
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Spatie\Permission\Models\Role;
@@ -21,6 +22,11 @@ class ProductControllerTest extends TestCase
         // Product write endpoints are admin-gated; these CRUD tests act as an admin.
         Role::findOrCreate('super_admin', 'web');
         $this->user = User::factory()->create()->assignRole('super_admin');
+        // Products and collections carry team_id with a database default of 1,
+        // and the API writes are now ownership-checked (#939) — so the admin
+        // acting here has to be in team 1 for the rows these tests create to be
+        // theirs to edit.
+        Team::factory()->create(['id' => 1, 'user_id' => $this->user->id]);
     }
 
     /**

--- a/tests/Feature/AuthorizationHardeningTest.php
+++ b/tests/Feature/AuthorizationHardeningTest.php
@@ -35,8 +35,17 @@ class AuthorizationHardeningTest extends TestCase
         // and the API writes are now ownership-checked (#939). These tests are
         // about the role gate, not the ownership one, so the admin is put in
         // team 1 — where the rows they act on land — to keep the two apart.
-        Team::firstOrCreate(['id' => 1], ['name' => 'default', 'personal_team' => false, 'user_id' => $admin->id]);
-        $admin->teams()->syncWithoutDetaching([1 => ['role' => 'admin']]);
+        // Team::create would drop id and user_id — neither is fillable. The
+        // factory writes unguarded, which is why the other suites can pass both.
+        $team = Team::find(1) ?? Team::factory()->create([
+            'id' => 1,
+            'name' => 'default',
+            'user_id' => $admin->id,
+        ]);
+
+        // Membership rather than ownership, since admin() is called more than
+        // once per test and only the first caller can own team 1.
+        $admin->teams()->syncWithoutDetaching([$team->id => ['role' => 'admin']]);
 
         return $admin;
     }

--- a/tests/Feature/AuthorizationHardeningTest.php
+++ b/tests/Feature/AuthorizationHardeningTest.php
@@ -7,6 +7,7 @@ use App\Models\Invoice;
 use App\Models\Order;
 use App\Models\Product;
 use App\Models\ProductCollection;
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Spatie\Permission\Models\Role;
@@ -28,7 +29,16 @@ class AuthorizationHardeningTest extends TestCase
     {
         Role::findOrCreate('super_admin', 'web');
 
-        return User::factory()->create()->assignRole('super_admin');
+        $admin = User::factory()->create()->assignRole('super_admin');
+
+        // Products and collections carry team_id with a database default of 1,
+        // and the API writes are now ownership-checked (#939). These tests are
+        // about the role gate, not the ownership one, so the admin is put in
+        // team 1 — where the rows they act on land — to keep the two apart.
+        Team::firstOrCreate(['id' => 1], ['name' => 'default', 'personal_team' => false, 'user_id' => $admin->id]);
+        $admin->teams()->syncWithoutDetaching([1 => ['role' => 'admin']]);
+
+        return $admin;
     }
 
     private function order(?int $userId): Order


### PR DESCRIPTION
The write half of #939.

`admin` and `super_admin` are **global** roles — `config/permission.php` sets `'teams' => false` — so the role check these endpoints already perform says "this person administers something", never "this person administers *this*". Behind that gate, `PUT`/`DELETE /api/products/{id}` and all five collection write paths did `Model::find($id)` with no ownership check at all.

## What changes

Writes **404 unless the resource's team is one the actor is in** — `allTeams()`, so owned and joined, which is what `canAccessPanel` and the Filament tenant switcher already mean by it. 404 rather than 403 matches `ReturnRequestController::show`: a foreign record should not be distinguishable from one that does not exist.

Created products and collections are stamped with the creating admin's current team, instead of falling to the database default of `1`. `team_id` becomes fillable for that; **no validator accepts it from request input**, so a caller cannot set it.

A resource with no team is left alone. Nothing creates one now, so that only concerns rows predating the column — which belong to nobody rather than to somebody else.

## An admin in no team administers nothing

That is the deliberate direction, and it is what moves the existing tests. Their admins owned no team while the rows they created carried the default team 1, so every write they made was cross-team under the new rule. Those `setUp`s now put the admin in team 1. `AuthorizationHardeningTest` is about the role gate rather than the ownership one, so its `admin()` helper does the same — to keep the two concerns from testing each other.

## The read half is not fixed here, and cannot be fixed this way

A global scope keyed off the actor's teams would **return nothing to a shopper**, who is an authenticated user with no team at all. Reads need the tenant of the *request*, not of the actor — which is what wave 1.5's Store/Channel resolution provides.

**#939, #950 and #952 stay open.** This closes one named surface out of several.

Related: #969 established that only 6 of the 37 models using `IsTenantModel` have a `team_id` column at all. `Product` and `ProductCollection` are two of them, which is why this fix is possible on them and not on `Discount`, `Menu`, or the other 29.
