### PR TITLE
fix: #958 — admin panel resources on tables with no team_id

### DIFF
--- a/app/Filament/Admin/Resources/ChatConversations/Pages/ListChatConversations.php
+++ b/app/Filament/Admin/Resources/ChatConversations/Pages/ListChatConversations.php
@@ -4,8 +4,8 @@ namespace App\Filament\Admin\Resources\ChatConversations\Pages;
 
 use App\Filament\Admin\Pages\ChatAgentDashboard;
 use App\Filament\Admin\Resources\ChatConversations\ChatConversationResource;
-use Filament\Resources\Pages\ListRecords;
 use Filament\Actions\Action;
+use Filament\Resources\Pages\ListRecords;
 
 class ListChatConversations extends ListRecords
 {

--- a/app/Filament/Admin/Resources/ChatConversations/Pages/ListChatConversations.php
+++ b/app/Filament/Admin/Resources/ChatConversations/Pages/ListChatConversations.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources\ChatConversations\Pages;
 
+use App\Filament\Admin\Pages\ChatAgentDashboard;
 use App\Filament\Admin\Resources\ChatConversations\ChatConversationResource;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Actions\Action;
@@ -15,7 +16,13 @@ class ListChatConversations extends ListRecords
         return [
             Action::make('agent_dashboard')
                 ->label('Agent Dashboard')
-                ->url(route('filament.admin.pages.chat-agent-dashboard'))
+                // ChatAgentDashboard::getUrl() rather than route(): the admin
+                // panel is tenant-scoped, so that route is admin/{tenant}/... and
+                // the bare route() call had to rely on a URL default set by
+                // Filament's tenancy middleware. getUrl() passes the current
+                // tenant itself. Deferred too — the action is built before the
+                // URL is needed.
+                ->url(fn () => ChatAgentDashboard::getUrl())
                 ->color('primary'),
         ];
     }

--- a/app/Filament/Admin/Resources/Discounts/DiscountResource.php
+++ b/app/Filament/Admin/Resources/Discounts/DiscountResource.php
@@ -2,22 +2,16 @@
 
 namespace App\Filament\Admin\Resources\Discounts;
 
-use Filament\Schemas\Schema;
-use Filament\Actions\EditAction;
-use Filament\Actions\BulkActionGroup;
-use Filament\Actions\DeleteBulkAction;
-use App\Filament\Admin\Resources\Discounts\Pages\ListDiscounts;
 use App\Filament\Admin\Resources\Discounts\Pages\CreateDiscount;
 use App\Filament\Admin\Resources\Discounts\Pages\EditDiscount;
-use App\Filament\Admin\Resources\DiscountResource\Pages;
-use App\Filament\Admin\Resources\DiscountResource\RelationManagers;
+use App\Filament\Admin\Resources\Discounts\Pages\ListDiscounts;
 use App\Models\Discount;
-use Filament\Forms;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
 use Filament\Resources\Resource;
-use Filament\Tables;
+use Filament\Schemas\Schema;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class DiscountResource extends Resource
 {
@@ -37,8 +31,7 @@ class DiscountResource extends Resource
      */
     protected static bool $isScopedToTenant = false;
 
-
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-tag';
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-tag';
 
     protected static ?int $navigationSort = 7;
 

--- a/app/Filament/Admin/Resources/Discounts/DiscountResource.php
+++ b/app/Filament/Admin/Resources/Discounts/DiscountResource.php
@@ -23,6 +23,21 @@ class DiscountResource extends Resource
 {
     protected static ?string $model = Discount::class;
 
+    /*
+     * Not tenant-scoped, because there is nothing to scope by: this panel is
+     * Team-tenanted on the `team` relationship, and discounts has no team_id
+     * column. Filament would emit whereBelongsTo($tenant, 'team') and the query
+     * would name a column that is not there.
+     *
+     * The consequence is that every tenant sees the same discounts. That is not
+     * a design intent, it is the current data model stated out loud — #958.
+     * The column, and the scoping that becomes possible with it, land in wave
+     * 1.5, where existing rows are attributed deliberately rather than defaulted
+     * to team 1.
+     */
+    protected static bool $isScopedToTenant = false;
+
+
     protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-tag';
 
     protected static ?int $navigationSort = 7;

--- a/app/Filament/Admin/Resources/Menus/MenuResource.php
+++ b/app/Filament/Admin/Resources/Menus/MenuResource.php
@@ -24,6 +24,21 @@ class MenuResource extends Resource
 {
     protected static ?string $model = Menu::class;
 
+    /*
+     * Not tenant-scoped, because there is nothing to scope by: this panel is
+     * Team-tenanted on the `team` relationship, and menus has no team_id
+     * column. Filament would emit whereBelongsTo($tenant, 'team') and the query
+     * would name a column that is not there.
+     *
+     * The consequence is that every tenant sees the same menus and their items. That is not
+     * a design intent, it is the current data model stated out loud — #958.
+     * The column, and the scoping that becomes possible with it, land in wave
+     * 1.5, where existing rows are attributed deliberately rather than defaulted
+     * to team 1.
+     */
+    protected static bool $isScopedToTenant = false;
+
+
     protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-bars-4';
 
     protected static ?int $navigationSort = 9;

--- a/app/Filament/Admin/Resources/Menus/MenuResource.php
+++ b/app/Filament/Admin/Resources/Menus/MenuResource.php
@@ -2,23 +2,17 @@
 
 namespace App\Filament\Admin\Resources\Menus;
 
-use Filament\Schemas\Schema;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Actions\EditAction;
-use Filament\Actions\BulkActionGroup;
-use Filament\Actions\DeleteBulkAction;
-use App\Filament\Admin\Resources\Menus\Pages\ListMenus;
 use App\Filament\Admin\Resources\Menus\Pages\CreateMenu;
 use App\Filament\Admin\Resources\Menus\Pages\EditMenu;
-use App\Filament\Admin\Resources\MenuResource\Pages;
-use App\Filament\Admin\Resources\MenuResource\RelationManagers;
+use App\Filament\Admin\Resources\Menus\Pages\ListMenus;
 use App\Models\Menu;
-use Filament\Forms;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
 use Filament\Resources\Resource;
-use Filament\Tables;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class MenuResource extends Resource
 {
@@ -38,8 +32,7 @@ class MenuResource extends Resource
      */
     protected static bool $isScopedToTenant = false;
 
-
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-bars-4';
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-bars-4';
 
     protected static ?int $navigationSort = 9;
 

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,19 +2,26 @@
 
 namespace App\Providers\Filament;
 
-use Filament\Actions\Action;
-use Filament\Widgets\AccountWidget;
-use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
-use BezhanSalleh\FilamentShield\Resources\Roles\RoleResource;
 use App\Filament\Admin\Resources\MenuItemResource;
 use App\Filament\Admin\Resources\MenuResource;
+use App\Filament\Admin\Widgets\CustomerDemographicsWidget;
+use App\Filament\Admin\Widgets\CustomerGrowthWidget;
+use App\Filament\Admin\Widgets\InventoryStatsWidget;
+use App\Filament\Admin\Widgets\LowStockInventoryWidget;
+use App\Filament\Admin\Widgets\RecentOrdersWidget;
+use App\Filament\Admin\Widgets\SalesOverviewWidget;
+use App\Filament\Admin\Widgets\SalesTrendsChart;
+use App\Filament\Admin\Widgets\TopProductsWidget;
 use App\Filament\App\Pages;
 use App\Filament\App\Pages\EditProfile;
 use App\Http\Middleware\TeamsPermission;
 use App\Models\Menu;
 use App\Models\MenuItem;
 use App\Models\Team;
+use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
+use BezhanSalleh\FilamentShield\Resources\Roles\RoleResource;
 use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
+use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -24,6 +31,7 @@ use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
 use Filament\Widgets;
+use Filament\Widgets\AccountWidget;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
@@ -31,10 +39,8 @@ use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
-use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Http\Controllers\AuthenticatedSessionController;
 use Laravel\Jetstream\Features;
-use Laravel\Jetstream\Jetstream;
 
 class AdminPanelProvider extends PanelProvider
 {
@@ -68,14 +74,14 @@ class AdminPanelProvider extends PanelProvider
                 // Pages\ApiTokenManagerPage::class,
             ])->widgets([
                 AccountWidget::class,
-                \App\Filament\Admin\Widgets\SalesOverviewWidget::class,
-                \App\Filament\Admin\Widgets\SalesTrendsChart::class,
-                \App\Filament\Admin\Widgets\TopProductsWidget::class,
-                \App\Filament\Admin\Widgets\CustomerDemographicsWidget::class,
-                \App\Filament\Admin\Widgets\CustomerGrowthWidget::class,
-                \App\Filament\Admin\Widgets\InventoryStatsWidget::class,
-                \App\Filament\Admin\Widgets\LowStockInventoryWidget::class,
-                \App\Filament\Admin\Widgets\RecentOrdersWidget::class,
+                SalesOverviewWidget::class,
+                SalesTrendsChart::class,
+                TopProductsWidget::class,
+                CustomerDemographicsWidget::class,
+                CustomerGrowthWidget::class,
+                InventoryStatsWidget::class,
+                LowStockInventoryWidget::class,
+                RecentOrdersWidget::class,
                 // Widgets\FilamentInfoWidget::class,
             ])
             ->middleware([
@@ -151,6 +157,6 @@ class AdminPanelProvider extends PanelProvider
 
     public function shouldRegisterMenuItem(): bool
     {
-        return true; //auth()->user()?->hasVerifiedEmail() && Filament::hasTenancy() && Filament::getTenant();
+        return true; // auth()->user()?->hasVerifiedEmail() && Filament::hasTenancy() && Filament::getTenant();
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers\Filament;
 use Filament\Actions\Action;
 use Filament\Widgets\AccountWidget;
 use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
+use BezhanSalleh\FilamentShield\Resources\Roles\RoleResource;
 use App\Filament\Admin\Resources\MenuItemResource;
 use App\Filament\Admin\Resources\MenuResource;
 use App\Filament\App\Pages;
@@ -133,7 +134,19 @@ class AdminPanelProvider extends PanelProvider
 
     public function boot(): void
     {
-       
+        /*
+         * Shield's RoleResource is registered into this panel by its plugin, and
+         * this panel is Team-tenanted on the `team` relationship. App\Models\Role
+         * has no such relationship — `config/permission.php` sets 'teams' => false,
+         * so roles are global here — and Filament throws a LogicException the
+         * moment anything queries Role inside the panel. That is every page in
+         * /admin, because the navigation resolves resources on each render.
+         *
+         * scopeToTenant(false) is Filament's own escape hatch for a resource that
+         * is genuinely shared across tenants, which a global role is. It cannot be
+         * set as a property here because the class belongs to the package.
+         */
+        RoleResource::scopeToTenant(false);
     }
 
     public function shouldRegisterMenuItem(): bool

--- a/tests/Feature/Filament/AdminPanelTenancyTest.php
+++ b/tests/Feature/Filament/AdminPanelTenancyTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Admin\Resources\Categories\Pages\ListCategories;
+use App\Filament\Admin\Resources\ChatConversations\Pages\ListChatConversations;
+use App\Filament\Admin\Resources\Coupons\Pages\ListCoupons;
+use App\Filament\Admin\Resources\Discounts\Pages\ListDiscounts;
+use App\Filament\Admin\Resources\Menus\Pages\ListMenus;
+use App\Filament\Admin\Resources\Pages\Pages\ListPages;
+use App\Filament\Admin\Resources\Products\Pages\ListProducts;
+use App\Filament\Admin\Resources\Stores\Pages\ListStores;
+use App\Filament\Admin\Resources\TaxClasses\Pages\ListTaxClasses;
+use App\Filament\Admin\Resources\Users\Pages\ListUsers;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * The /admin panel is Team-tenant-scoped too (`ownershipRelationship: 'team'`),
+ * which the sibling AppPanelTenancyTest covers for /app but nothing covered
+ * here.
+ *
+ * That gap is what #958 is: `DiscountResource` and `MenuResource` are registered
+ * in this tenant-scoped panel while `discounts` and `menus` carry no `team_id`.
+ * Filament's `scopeEloquentQueryToTenant` sees a `BelongsTo` — the models do
+ * declare `team()`, through `IsTenantModel` — and emits
+ * `whereBelongsTo($tenant, 'team')`, so the query names a column that is not
+ * there.
+ *
+ * Mounting every list page is the cheapest way to hold that shut for all ten
+ * resources rather than the two somebody happened to notice.
+ */
+class AdminPanelTenancyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingInAdminPanel(): Team
+    {
+        // Allow all authorization so this isolates the TENANCY wiring rather
+        // than the Shield permission layer — same reasoning as AppPanelTenancyTest.
+        Gate::before(fn () => true);
+        Role::findOrCreate('super_admin', 'web');
+        $user = User::factory()->withPersonalTeam()->create()->assignRole('super_admin');
+        $team = $user->ownedTeams()->first();
+        $this->actingAs($user);
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+        Filament::setTenant($team);
+
+        return $team;
+    }
+
+    public function test_every_admin_panel_list_page_mounts(): void
+    {
+        $this->actingInAdminPanel();
+
+        $pages = [
+            ListCategories::class, ListChatConversations::class, ListCoupons::class,
+            ListDiscounts::class, ListMenus::class, ListPages::class,
+            ListProducts::class, ListStores::class, ListTaxClasses::class,
+            ListUsers::class,
+        ];
+
+        foreach ($pages as $page) {
+            Livewire::test($page)->assertSuccessful();
+        }
+    }
+}

--- a/tests/Feature/Filament/AdminPanelTenancyTest.php
+++ b/tests/Feature/Filament/AdminPanelTenancyTest.php
@@ -85,7 +85,8 @@ class AdminPanelTenancyTest extends TestCase
             $response = $this->get($page::getUrl(tenant: $team));
 
             if ($response->getStatusCode() >= 300) {
-                $failures[] = class_basename($page).' -> '.$response->getStatusCode();
+                $failures[] = class_basename($page).' -> '.$response->getStatusCode()
+                    .($response->exception ? ' :: '.$response->exception::class.': '.$response->exception->getMessage() : '');
             }
         }
 

--- a/tests/Feature/Filament/AdminPanelTenancyTest.php
+++ b/tests/Feature/Filament/AdminPanelTenancyTest.php
@@ -55,9 +55,20 @@ class AdminPanelTenancyTest extends TestCase
         return $team;
     }
 
-    public function test_every_admin_panel_list_page_mounts(): void
+    /**
+     * Over HTTP rather than through Livewire::test, and that is the whole point.
+     *
+     * Filament 5 registers the tenant scope as a global scope from its tenancy
+     * middleware — `BelongsToTenant` says so in as many words: "scoping is
+     * applied via global scopes registered after tenant identification in
+     * middleware". Mounting a page with Livewire::test skips that middleware, so
+     * no scope is ever registered and the page renders clean whether or not the
+     * table could survive being scoped. A first version of this test did exactly
+     * that and passed against the known-broken resources.
+     */
+    public function test_every_admin_panel_list_page_responds(): void
     {
-        $this->actingInAdminPanel();
+        $team = $this->actingInAdminPanel();
 
         $pages = [
             ListCategories::class, ListChatConversations::class, ListCoupons::class,
@@ -67,7 +78,8 @@ class AdminPanelTenancyTest extends TestCase
         ];
 
         foreach ($pages as $page) {
-            Livewire::test($page)->assertSuccessful();
+            $this->get($page::getUrl(tenant: $team))
+                ->assertSuccessful();
         }
     }
 }

--- a/tests/Feature/Filament/AdminPanelTenancyTest.php
+++ b/tests/Feature/Filament/AdminPanelTenancyTest.php
@@ -77,9 +77,18 @@ class AdminPanelTenancyTest extends TestCase
             ListUsers::class,
         ];
 
+        // Collected rather than asserted one at a time: the first failure would
+        // otherwise hide the rest, and the point is the whole set.
+        $failures = [];
+
         foreach ($pages as $page) {
-            $this->get($page::getUrl(tenant: $team))
-                ->assertSuccessful();
+            $response = $this->get($page::getUrl(tenant: $team));
+
+            if ($response->getStatusCode() >= 300) {
+                $failures[] = class_basename($page).' -> '.$response->getStatusCode();
+            }
         }
+
+        $this->assertSame([], $failures, "Admin panel list pages that do not respond 2xx:\n".implode("\n", $failures));
     }
 }


### PR DESCRIPTION
#958 asked whether two Filament resources in a tenant-scoped panel crash or leak. Answering it turned up something worse standing in front of it.

## `/admin` throws on every page

Shield's `RoleResource` is registered into the admin panel by its plugin, and that panel is Team-tenanted on the `team` relationship. **`App\Models\Role` has no such relationship** — `config/permission.php` sets `'teams' => false`, so roles are global here — and Filament throws:

```
LogicException: The model [App\Models\Role] does not have a relationship named [team].
```

the moment anything queries `Role` inside the panel. The navigation resolves resources on every render, so that is **every page in `/admin`**, not just the roles screen.

`Resource::scopeToTenant(false)` is Filament's own escape hatch for a resource genuinely shared across tenants, which a global role is. It has to be called from `AdminPanelProvider::boot()` rather than declared as a property, because the class belongs to the package.

## And the answer to #958 is: it crashes

It does not leak. `discounts` and `menus` have no `team_id`, but their models *do* declare `team()` through `IsTenantModel`, so Filament emits `whereBelongsTo($tenant, 'team')` and the query names a column that is not there.

Both resources get `$isScopedToTenant = false`. Every tenant now sees the same discounts and menus — **that is not a design intent, it is the current data model stated out loud.** The column, and the scoping it makes possible, land in wave 1.5 where existing rows are attributed deliberately rather than defaulted to team 1.

## The test, and why the first two versions of it were worthless

`AppPanelTenancyTest` mounts every `/app` list page. Nothing did that for `/admin`, which is tenant-scoped in exactly the same way — and #958 is what lived in that gap.

Two false starts, both instructive enough to keep in the history:

1. **`Livewire::test($page)->assertSuccessful()` passes against the broken resources.** Filament 5 registers the tenant scope as a global scope *from its tenancy middleware* — `BelongsToTenant` says so in as many words. Mounting a page through Livewire skips that middleware, so no scope is ever registered and the page renders clean whether or not the table could survive being scoped. The test now goes over HTTP.
2. **Asserting per page hid the set.** The first failure masked the other nine, and nine of those turned out to be knock-on 403s from the first request's 500. The test now collects every failure with the exception behind it and asserts once.

## Also fixed

`ListChatConversations` built its header action with `route('filament.admin.pages.chat-agent-dashboard')` and no parameters. That route is `admin/{tenant}/...`, so it only ever resolved because Filament's tenancy middleware had set a URL default earlier in the request. `ChatAgentDashboard::getUrl()` passes the current tenant itself, and deferring it behind a closure means the URL is built when it is needed rather than when the action is constructed.

1284 tests pass.
