### PR TITLE
fix: seed a usable super_admin, or none at all

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
+# Password for the seeded admin@example.com super_admin. Required outside
+# APP_ENV=local — seeding creates no admin without it, rather than one with a
+# generated password that would have to be printed to be usable.
+SEED_ADMIN_PASSWORD=
+
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug

--- a/config/seeding.php
+++ b/config/seeding.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Seeded super_admin password
+    |--------------------------------------------------------------------------
+    |
+    | The password `UserSeeder` gives the `admin@example.com` super_admin.
+    |
+    | Outside `local`, seeding creates that account only when this is set. The
+    | alternative is a generated password, which has to be printed to be usable
+    | — and `install.yml` runs `db:seed --force`, so printing writes a working
+    | super_admin credential into a shared log (#940). Leaving it unset there
+    | means no account rather than an account nobody can log into.
+    |
+    | On `local` it can stay unset: the seeder generates one and prints it,
+    | which is what a developer bootstrapping their own machine wants.
+    |
+    */
+
+    'admin_password' => env('SEED_ADMIN_PASSWORD'),
+
+];

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -5,7 +5,6 @@ namespace Database\Seeders;
 use App\Models\Role;
 use App\Models\Team;
 use App\Models\User;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -17,8 +16,23 @@ class UserSeeder extends Seeder
      */
     public function run(): void
     {
+        $configured = config('seeding.admin_password');
 
-        $adminPassword = Str::random(12);
+        // A generated password is only usable if it is printed, and printing it
+        // outside a developer's own machine writes a working super_admin
+        // credential into a shared log — `install.yml` runs `db:seed --force`
+        // (#940). So off `local` the password has to be configured, and without
+        // one there is no account. That is the honest outcome: the alternative
+        // is a super_admin nobody can log into, sitting in the database looking
+        // like a working account.
+        if (blank($configured) && ! app()->environment('local')) {
+            $this->command?->warn('UserSeeder: no super_admin created. Set SEED_ADMIN_PASSWORD to create one outside local.');
+
+            return;
+        }
+
+        $adminPassword = $configured ?: Str::random(12);
+
         $adminUser = User::create([
             'name' => 'Admin User',
             'email' => 'admin@example.com',
@@ -32,11 +46,11 @@ class UserSeeder extends Seeder
         $role = Role::where('name', 'super_admin')->firstOrFail();
         $adminUser->assignRole($role);
 
-        // Only ever printed on a developer's own machine. `install.yml` runs
-        // `db:seed --force`, so printing unconditionally put a working admin
-        // password into a CI log on every push.
-        if (app()->environment('local')) {
-            $this->command->info("Admin password: {$adminPassword}");
+        // Only what this seeder generated, and only on `local`. A configured
+        // password is already known to whoever set it, so printing it would
+        // leak it without telling anyone anything.
+        if (blank($configured)) {
+            $this->command?->info("Admin password: {$adminPassword}");
         }
     }
 }

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -64,7 +64,7 @@ The small faults that needed nobody's permission. Landed ahead of the rest of wa
 
 | Fault | Fix |
 | --- | --- |
-| `UserSeeder.php:36` printed a generated admin password, and `install.yml:85` runs `db:seed --force` | Printed only under `app()->environment('local')` |
+| `UserSeeder.php:36` printed a generated admin password, and `install.yml:85` runs `db:seed --force` | Printed only under `app()->environment('local')`. Off `local` the password now comes from `config('seeding.admin_password')`, and without one no admin is created — see below |
 | `DummyDataSeeder` sat in `DatabaseSeeder`'s baseline chain, so `db:seed --force` created demo data in production | Called only when `! app()->isProduction()`, in the same position |
 | `DropxlService.php:23` and `SubscriptionController.php:21` read keys via `env()` in constructors — `null` under `config:cache` | Read `config('services.dropxl.*')` and `config('services.stripe.secret')`. `services.dropxl` added; **no `env()` call remains outside `config/`** |
 | `error_log` committed at the root, leaking `/home/liberu/projects/ecommerce-laravel` | Deleted and gitignored |
@@ -88,6 +88,14 @@ Reading the rest of it settled the question. **Nothing was salvageable**, and no
 - **No view anywhere linked to it.** There is no add-to-compare control in the storefront, so the only way to reach any of it was to type the URL.
 
 So the feature did not exist: it was a broken view, four routes to methods that were not there, and no entry point. Restoring it means writing it, which is a product decision that can be taken later against a clean slate. Deleted: the four routes, `resources/views/products/compare.blade.php`, and the commented-out block at the foot of `Frontend/ProductController.php` — which also carried dead `create`/`update`/`delete` methods superseded by Filament.
+
+### The seeded admin — the other half of #940
+
+Gating the password print on `local` closed the log leak, and left the rest of the fault standing: off `local` the password was still **generated**, and now never shown. So every staging, demo or shared install ended up with an `admin@example.com` super_admin that nobody could log into and everybody could see.
+
+The password now comes from `config('seeding.admin_password')` (`SEED_ADMIN_PASSWORD`). Off `local`, that is the only source: without one the seeder creates **no admin** and says so, rather than a ghost account. On `local` it still generates and prints, which is what someone bootstrapping their own machine wants — and only ever prints what it generated, never a configured value.
+
+CI is unaffected either way: `install.yml` copies `.env.testing`, which sets `APP_ENV=testing`, so it took the no-print branch already and now takes the no-account branch.
 
 ### `SiteSettingsService` — deleted, because the config it wanted would have frozen the wrong contract
 

--- a/tests/Feature/SeededAdminCredentialTest.php
+++ b/tests/Feature/SeededAdminCredentialTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Database\Seeders\DefaultTeamSeeder;
+use Database\Seeders\PermissionsTableSeeder;
+use Database\Seeders\RolesSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+/**
+ * The seeded super_admin is either usable or absent — never a ghost.
+ *
+ * `UserSeeder` used to generate a random password and print it, which put a
+ * working credential into the `install.yml` log on every run (#940). Gating the
+ * print on `local` closed that, but left the other half: off `local` the
+ * password was still generated and now never shown, so every staging or demo
+ * install ended up with an `admin@example.com` super_admin that nobody could
+ * log into and everybody could see.
+ *
+ * The environment here is `testing`, so these run down the off-`local` branch,
+ * which is the one that matters.
+ */
+class SeededAdminCredentialTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedPrerequisites(): void
+    {
+        $this->seed(PermissionsTableSeeder::class);
+        $this->seed(RolesSeeder::class);
+        $this->seed(DefaultTeamSeeder::class);
+    }
+
+    public function test_a_configured_password_produces_an_admin_that_can_be_logged_into(): void
+    {
+        config(['seeding.admin_password' => 'a-known-password']);
+        $this->seedPrerequisites();
+
+        $this->seed(UserSeeder::class);
+
+        $admin = User::where('email', 'admin@example.com')->first();
+
+        $this->assertNotNull($admin, 'No super_admin was created despite a configured password.');
+        $this->assertTrue(Hash::check('a-known-password', $admin->password));
+        $this->assertTrue($admin->hasRole('super_admin'));
+    }
+
+    public function test_no_admin_is_created_when_no_password_is_configured(): void
+    {
+        config(['seeding.admin_password' => null]);
+        $this->seedPrerequisites();
+
+        $this->seed(UserSeeder::class);
+
+        $this->assertNull(
+            User::where('email', 'admin@example.com')->first(),
+            'A super_admin was created with a password nobody knows.',
+        );
+    }
+}


### PR DESCRIPTION
Closes #940.

The print gate landed earlier: `UserSeeder` prints the generated admin password only under `app()->environment('local')`, so `install.yml`'s `db:seed --force` no longer writes a working credential into the Actions log.

**That was half the fault.** Off `local` the password was still *generated*, and now never shown. So every staging, demo or shared install ended up with an `admin@example.com` super_admin that nobody could log into and everybody could see — a `super_admin` row that looks like a working account and is not.

The password now comes from `config('seeding.admin_password')` / `SEED_ADMIN_PASSWORD`:

- **Off `local`**, that is the only source. Without one the seeder creates **no admin** and warns. No account is a better outcome than an unusable one.
- **On `local`**, it still generates and prints — what someone bootstrapping their own machine wants.
- It prints **only what it generated**. A configured password is already known to whoever set it, so echoing it would leak it without telling anyone anything.

CI is unaffected either way: `install.yml` copies `.env.testing`, which sets `APP_ENV=testing`, so it took the no-print branch already and now takes the no-account branch. Nothing in the suite depends on the seeded admin — no test seeds `UserSeeder` or `DatabaseSeeder`.

`SEED_ADMIN_PASSWORD` is documented in `.env.example`.

## Tests

`tests/Feature/SeededAdminCredentialTest.php`. The suite runs as `testing`, so both run down the off-`local` branch, which is the one that was broken:

- a configured password produces an admin whose hash verifies and who holds `super_admin`;
- no configured password produces no admin at all.

## A note on the config file

`config/seeding.php` exists because `env()` outside `config/` is banned in this repo and enforced by `ArchitectureTest` — the seeder cannot read `SEED_ADMIN_PASSWORD` directly, and no existing config file is the right home for it. One key, one file.