### PR TITLE
feat: stores, channels and host resolution — wave 1.5, step 1

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,33 +2,33 @@
 
 namespace App\Http;
 
-use App\Http\Middleware\TrustProxies;
-use Illuminate\Http\Middleware\HandleCors;
-use App\Http\Middleware\PreventRequestsDuringMaintenance;
-use Illuminate\Foundation\Http\Middleware\ValidatePostSize;
-use App\Http\Middleware\SecurityHeaders;
-use App\Http\Middleware\TrimStrings;
-use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
-use App\Http\Middleware\EncryptCookies;
-use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
-use Illuminate\Session\Middleware\StartSession;
-use Illuminate\View\Middleware\ShareErrorsFromSession;
-use App\Http\Middleware\VerifyCsrfToken;
-use Illuminate\Routing\Middleware\SubstituteBindings;
-use App\Http\Middleware\TeamsPermission;
-use Illuminate\Routing\Middleware\ThrottleRequests;
 use App\Http\Middleware\Authenticate;
-use Illuminate\Auth\Middleware\AuthenticateWithBasicAuth;
-use Illuminate\Session\Middleware\AuthenticateSession;
-use Illuminate\Http\Middleware\SetCacheHeaders;
-use Illuminate\Auth\Middleware\Authorize;
+use App\Http\Middleware\EncryptCookies;
+use App\Http\Middleware\PreventRequestsDuringMaintenance;
 use App\Http\Middleware\RedirectIfAuthenticated;
 use App\Http\Middleware\ResolveChannel;
-use Illuminate\Auth\Middleware\RequirePassword;
-use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
+use App\Http\Middleware\SecurityHeaders;
+use App\Http\Middleware\TeamsPermission;
+use App\Http\Middleware\TrimStrings;
+use App\Http\Middleware\TrustProxies;
 use App\Http\Middleware\ValidateSignature;
+use App\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Auth\Middleware\AuthenticateWithBasicAuth;
+use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Auth\Middleware\EnsureEmailIsVerified;
+use Illuminate\Auth\Middleware\RequirePassword;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
+use Illuminate\Foundation\Http\Middleware\ValidatePostSize;
+use Illuminate\Http\Middleware\HandleCors;
+use Illuminate\Http\Middleware\SetCacheHeaders;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 class Kernel extends HttpKernel
 {

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -23,6 +23,7 @@ use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Http\Middleware\SetCacheHeaders;
 use Illuminate\Auth\Middleware\Authorize;
 use App\Http\Middleware\RedirectIfAuthenticated;
+use App\Http\Middleware\ResolveChannel;
 use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
 use App\Http\Middleware\ValidateSignature;
@@ -63,12 +64,14 @@ class Kernel extends HttpKernel
             VerifyCsrfToken::class,
             SubstituteBindings::class,
             TeamsPermission::class,
+            ResolveChannel::class,
         ],
 
         'api' => [
             // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             ThrottleRequests::class.':api',
             SubstituteBindings::class,
+            ResolveChannel::class,
         ],
     ];
 

--- a/app/Http/Middleware/ResolveChannel.php
+++ b/app/Http/Middleware/ResolveChannel.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Channel;
+use App\Services\ChannelResolver;
+use Closure;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Carries the resolved channel on the request, for the storefront and the API.
+ *
+ * It does not yet refuse an unresolved host. That rule — an unresolved host is
+ * a 404, with no default-merchant fallback — belongs with the tenant scope it
+ * protects: 404ing before there is a scope guards nothing, and would take the
+ * storefront down in every environment whose hostname is not configured yet.
+ * The order is deliberate, and it is the same one wave 2 uses: get the data in
+ * place first, then turn on the control that reads it.
+ *
+ * Panels are not in this stack. They resolve a Team through Filament tenancy and
+ * list their own middleware rather than using the `web` group.
+ */
+class ResolveChannel
+{
+    public function __construct(private readonly ChannelResolver $resolver) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $request->attributes->set(
+            ChannelResolver::ATTRIBUTE,
+            $this->resolve($request->getHost()),
+        );
+
+        return $next($request);
+    }
+
+    /**
+     * An unreachable or unmigrated database is an unresolved host, not a 500.
+     *
+     * This sits in front of every storefront route including `/health`, which
+     * exists precisely to answer while the database is down — it reports
+     * `degraded` rather than failing to respond at all. A middleware that throws
+     * first would take that away, and would also break the window between
+     * deploying and running migrations.
+     */
+    private function resolve(string $host): ?Channel
+    {
+        try {
+            return $this->resolver->resolve($host);
+        } catch (QueryException) {
+            return null;
+        }
+    }
+}

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * One way into a Store — a set of hostnames and the theme they render with.
+ */
+class Channel extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['store_id', 'name', 'theme'];
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
+
+    public function domains(): HasMany
+    {
+        return $this->hasMany(ChannelDomain::class);
+    }
+
+    /**
+     * The hostname canonical URLs are built from, which is not necessarily the
+     * one the request arrived on.
+     */
+    public function primaryDomain(): ?ChannelDomain
+    {
+        return $this->domains()->where('is_primary', true)->first()
+            ?? $this->domains()->first();
+    }
+}

--- a/app/Models/ChannelDomain.php
+++ b/app/Models/ChannelDomain.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * One hostname a Channel answers on. Hostname only — no scheme, no port.
+ */
+class ChannelDomain extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['channel_id', 'host', 'is_primary'];
+
+    protected $casts = ['is_primary' => 'boolean'];
+
+    public function channel(): BelongsTo
+    {
+        return $this->belongsTo(Channel::class);
+    }
+
+    /**
+     * Hosts are stored and compared in one shape, so that `EXAMPLE.com:8000`
+     * and `example.com` are the same hostname rather than two.
+     */
+    public static function normalise(string $host): string
+    {
+        return strtolower(trim(explode(':', trim($host), 2)[0]));
+    }
+
+    public function setHostAttribute(string $value): void
+    {
+        $this->attributes['host'] = self::normalise($value);
+    }
+}

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * A storefront's worth of commerce data, owned by a Team.
+ *
+ * Not to be confused with `App\Filament\Admin\Resources\Stores\StoreResource`,
+ * which is a Team resource wearing the label "Store". That resource predates
+ * this model and does not point at it.
+ */
+class Store extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['team_id', 'name', 'slug'];
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function channels(): HasMany
+    {
+        return $this->hasMany(Channel::class);
+    }
+}

--- a/app/Services/ChannelResolver.php
+++ b/app/Services/ChannelResolver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Channel;
+use App\Models\ChannelDomain;
+
+/**
+ * Which channel is `shop.example.com`?
+ *
+ * The domain question, kept apart from the HTTP one — how a request carries the
+ * answer — which lives in `ResolveChannel` middleware.
+ */
+class ChannelResolver
+{
+    /**
+     * Where the resolved channel rides on the request.
+     */
+    public const ATTRIBUTE = 'resolved_channel';
+
+    public function resolve(string $host): ?Channel
+    {
+        $host = ChannelDomain::normalise($host);
+
+        if ($host === '') {
+            return null;
+        }
+
+        return Channel::whereRelation('domains', 'host', $host)->with('store')->first();
+    }
+
+    /**
+     * The channel resolved for the current request, or null off a resolved host
+     * — a queued job, a console command, a panel route.
+     *
+     * Read from the request rather than a container binding, so that absence is
+     * the natural state rather than something that has to be unbound.
+     */
+    public static function current(): ?Channel
+    {
+        return request()->attributes->get(self::ATTRIBUTE);
+    }
+}

--- a/database/factories/ChannelDomainFactory.php
+++ b/database/factories/ChannelDomainFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Channel;
+use App\Models\ChannelDomain;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ChannelDomain>
+ */
+class ChannelDomainFactory extends Factory
+{
+    protected $model = ChannelDomain::class;
+
+    public function definition(): array
+    {
+        return [
+            'channel_id' => Channel::factory(),
+            'host' => $this->faker->unique()->domainName(),
+            'is_primary' => false,
+        ];
+    }
+
+    public function primary(): static
+    {
+        return $this->state(fn () => ['is_primary' => true]);
+    }
+}

--- a/database/factories/ChannelFactory.php
+++ b/database/factories/ChannelFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Channel;
+use App\Models\Store;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Channel>
+ */
+class ChannelFactory extends Factory
+{
+    protected $model = Channel::class;
+
+    public function definition(): array
+    {
+        return [
+            'store_id' => Store::factory(),
+            'name' => 'Web',
+            'theme' => 'theme-ecommerce',
+        ];
+    }
+}

--- a/database/factories/StoreFactory.php
+++ b/database/factories/StoreFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Store;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Store>
+ */
+class StoreFactory extends Factory
+{
+    protected $model = Store::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->company();
+
+        return [
+            'team_id' => null,
+            'name' => $name,
+            'slug' => Str::slug($name).'-'.$this->faker->unique()->numberBetween(1, 100000),
+        ];
+    }
+}

--- a/database/migrations/2026_08_08_000000_create_stores_and_channels_tables.php
+++ b/database/migrations/2026_08_08_000000_create_stores_and_channels_tables.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The schema wave 1.5 is built on: host → Channel → Store → Team.
+ *
+ * A `Team` may own several `Store`s, and a shopper on store A's domain must see
+ * store A's catalogue rather than everything their merchant sells across every
+ * store. That is why commerce scopes on `store_id` and not `team_id` — `team_id`
+ * is the wrong grain and would under-scope.
+ *
+ * `channel_domains` is a table rather than a `domain` column on `channels`
+ * because a storefront answers on several hostnames from day one: the apex,
+ * `www`, a custom merchant domain, a platform subdomain. One column pushes
+ * apex/`www` handling into web-server config the application cannot see, and
+ * then the canonical the app generates and the host the request arrived on can
+ * disagree. One row per hostname, one flagged primary for canonicals.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('stores')) {
+            Schema::create('stores', function (Blueprint $table) {
+                $table->id();
+                // Nullable for the same reason every other tenant column here is:
+                // a store that predates ownership belongs to nobody rather than
+                // to whoever happens to be first. Wave 2 fills these in.
+                $table->foreignId('team_id')->nullable()->index();
+                $table->string('name');
+                $table->string('slug')->unique();
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('channels')) {
+            Schema::create('channels', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('store_id')->constrained()->cascadeOnDelete();
+                $table->string('name');
+                // One storefront, theme selected per resolved channel. Per-merchant
+                // themes are later children with `parent: ecommerce`.
+                $table->string('theme')->default('theme-ecommerce');
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('channel_domains')) {
+            Schema::create('channel_domains', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('channel_id')->constrained()->cascadeOnDelete();
+                // Hostname only — no scheme, no port. Unique across every channel:
+                // a hostname resolving to two storefronts is the ambiguity this
+                // whole table exists to prevent.
+                $table->string('host')->unique();
+                $table->boolean('is_primary')->default(false);
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('channel_domains');
+        Schema::dropIfExists('channels');
+        Schema::dropIfExists('stores');
+    }
+};

--- a/database/migrations/2026_08_08_000001_create_the_initial_channel.php
+++ b/database/migrations/2026_08_08_000001_create_the_initial_channel.php
@@ -1,0 +1,86 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Gives every environment one resolvable channel, before anything depends on
+ * resolution succeeding.
+ *
+ * The order matters. Wave 1.5 ends with an unresolved host being a 404, and no
+ * default-merchant fallback — but a control that refuses unconfigured hosts,
+ * shipped into environments where no host is configured, takes the storefront
+ * down everywhere at once. So the data lands first, in its own migration, and
+ * the control follows. Same discipline as wave 2's backfill-before-scope.
+ *
+ * This is not the fallback the wave rules out. A fallback answers for hosts
+ * nobody configured; this configures the host the deployment already answers
+ * on, which on a single-store deployment is the whole truth.
+ *
+ * Plain DB rather than Eloquent: a model that gets renamed or gains a global
+ * scope later must not change what this migration did.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Idempotent, and a no-op on any deployment that has already been set up
+        // by hand. Claiming hostnames out from under an existing channel is the
+        // one thing this must never do.
+        if (DB::table('channels')->exists() || DB::table('stores')->exists()) {
+            return;
+        }
+
+        $now = now();
+
+        $storeId = DB::table('stores')->insertGetId([
+            // The first team if there is one — a single-store deployment has
+            // exactly one merchant, which is the assumption this whole migration
+            // rests on. Null otherwise, and wave 2 fills it in.
+            'team_id' => DB::table('teams')->orderBy('id')->value('id'),
+            'name' => config('app.name', 'Store'),
+            'slug' => 'default',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $channelId = DB::table('channels')->insertGetId([
+            'store_id' => $storeId,
+            'name' => 'Web',
+            'theme' => 'theme-ecommerce',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $primary = $this->host(config('app.url'));
+
+        // The apex the deployment is configured for, plus the two hostnames
+        // local development and the test suite arrive on. Only the first is
+        // canonical.
+        $hosts = array_values(array_unique(array_filter([$primary, 'localhost', '127.0.0.1'])));
+
+        foreach ($hosts as $host) {
+            DB::table('channel_domains')->insert([
+                'channel_id' => $channelId,
+                'host' => $host,
+                'is_primary' => $host === $primary,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        // Deliberately empty. Rolling back the schema drops these rows with it;
+        // rolling back only this migration would leave a deployment with no
+        // resolvable host, which is worse than leaving a store behind.
+    }
+
+    private function host(?string $url): ?string
+    {
+        $host = parse_url((string) $url, PHP_URL_HOST);
+
+        return $host ? strtolower($host) : null;
+    }
+};

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -170,12 +170,18 @@ Three decisions collided:
 
 ### The wave, in order
 
-**1. Create the schema and resolve merchants.**
+**1. Create the schema and resolve merchants.** — 🟡 *schema, models, resolver and middleware landed; enforcement and `TrustHosts` still to come*
 
 - `stores`, `channels`, `channel_domains` — many hostnames per channel, one flagged **primary** for canonicals. A storefront realistically answers on the apex, `www`, a custom merchant domain and a platform subdomain on day one; a single `domain` column pushes apex/`www` handling into web-server config the application cannot see, so the canonical the app generates and the host the request arrived on can disagree.
 - `Channel` gains a **theme reference**, defaulting to `theme-ecommerce`. One storefront, theme selected per resolved channel; per-merchant themes are later children with `parent: ecommerce`.
 - Host middleware resolves **host → `Channel` → `Store` → `Team`**, for the web and API route groups alike. The GraphQL resolver context carries the same resolved channel.
 - **`TrustHosts::hosts()` derives its list from the channel domains** and caches it. Resolving tenancy from the `Host` header makes it security-relevant, and two lists of the same hostnames drift — the failure when they drift is either a live storefront returning 404 or a host resolving that should not.
+
+**What landed, and what deliberately did not.** `stores`, `channels` and `channel_domains` exist, with `Store`, `Channel`, `ChannelDomain`, `ChannelResolver` and a `ResolveChannel` middleware on the `web` and `api` groups — so every storefront and API request already carries its channel. A second migration creates the initial store, channel and hostnames from `APP_URL`, plus `localhost` and `127.0.0.1`.
+
+**The 404 did not land, on purpose.** A control that refuses unconfigured hosts, shipped into environments where no host is configured yet, takes every storefront down at once — and before the tenant scope exists it guards nothing anyway. Data first, control second, which is the same order wave 2 uses for the backfill. It flips in the same change as step 3.
+
+That initial-channel migration is not the fallback this wave rules out. A fallback answers for hosts nobody configured; this configures the host the deployment already answers on, which on a single-store deployment is the whole truth. It refuses to run if any store or channel already exists, so it can never claim hostnames from a deployment set up by hand.
 
 **2. Backfill `store_id` alone.** On a today-single-store deployment this is a constant, so it needs no rehearsal — which is exactly why it can be separated from wave 2 without breaking that wave's rehearse-once discipline.
 

--- a/tests/Feature/ChannelResolutionTest.php
+++ b/tests/Feature/ChannelResolutionTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Channel;
+use App\Models\ChannelDomain;
+use App\Models\Store;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\ChannelResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * host → Channel → Store → Team, the resolution wave 1.5's tenant scope reads.
+ *
+ * Nothing refuses an unresolved host yet, and nothing scopes on the result yet.
+ * Both follow, and both depend on this being right first: a scope keyed off a
+ * resolution that picks the wrong channel is worse than no scope at all,
+ * because it looks like a control.
+ */
+class ChannelResolutionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function channelFor(string $host): Channel
+    {
+        $channel = Channel::factory()->create();
+        ChannelDomain::factory()->primary()->create(['channel_id' => $channel->id, 'host' => $host]);
+
+        return $channel;
+    }
+
+    public function test_a_host_resolves_to_its_channel(): void
+    {
+        $expected = $this->channelFor('shop.example.com');
+        $this->channelFor('other.example.com');
+
+        $resolved = app(ChannelResolver::class)->resolve('shop.example.com');
+
+        $this->assertNotNull($resolved);
+        $this->assertSame($expected->id, $resolved->id);
+    }
+
+    /**
+     * A visitor typing the hostname in any case, or arriving on a non-default
+     * port as local development does, is on the same storefront.
+     */
+    public function test_a_host_resolves_regardless_of_case_or_port(): void
+    {
+        $expected = $this->channelFor('shop.example.com');
+
+        foreach (['SHOP.EXAMPLE.COM', 'shop.example.com:8000', ' shop.example.com '] as $host) {
+            $this->assertSame(
+                $expected->id,
+                app(ChannelResolver::class)->resolve($host)?->id,
+                "[{$host}] did not resolve to the same channel.",
+            );
+        }
+    }
+
+    public function test_an_unknown_host_resolves_to_nothing(): void
+    {
+        $this->channelFor('shop.example.com');
+
+        $this->assertNull(app(ChannelResolver::class)->resolve('somebody-elses.example.com'));
+    }
+
+    public function test_a_channel_reaches_its_store_and_team(): void
+    {
+        $team = Team::factory()->create(['user_id' => User::factory()->create()->id]);
+        $store = Store::factory()->create(['team_id' => $team->id]);
+        $channel = Channel::factory()->create(['store_id' => $store->id]);
+        ChannelDomain::factory()->primary()->create(['channel_id' => $channel->id, 'host' => 'shop.example.com']);
+
+        $resolved = app(ChannelResolver::class)->resolve('shop.example.com');
+
+        $this->assertSame($store->id, $resolved->store->id);
+        $this->assertSame($team->id, $resolved->store->team->id);
+    }
+
+    /**
+     * The whole point of `channel_domains` being a table: one storefront answers
+     * on the apex, `www`, a custom domain and a platform subdomain, and only one
+     * of them is canonical.
+     */
+    public function test_one_channel_answers_on_several_hosts_with_one_canonical(): void
+    {
+        $channel = Channel::factory()->create();
+        ChannelDomain::factory()->primary()->create(['channel_id' => $channel->id, 'host' => 'example.com']);
+        ChannelDomain::factory()->create(['channel_id' => $channel->id, 'host' => 'www.example.com']);
+
+        $resolver = app(ChannelResolver::class);
+
+        $this->assertSame($channel->id, $resolver->resolve('example.com')->id);
+        $this->assertSame($channel->id, $resolver->resolve('www.example.com')->id);
+        $this->assertSame('example.com', $channel->primaryDomain()->host);
+    }
+
+    /**
+     * The middleware runs on the storefront, so a request carries its channel
+     * without any controller asking for it.
+     */
+    public function test_a_storefront_request_carries_its_resolved_channel(): void
+    {
+        // `localhost` is already claimed by the initial-channel migration, which
+        // is what the test suite arrives on.
+        $this->get('/health')->assertOk();
+
+        $this->assertNotNull(
+            ChannelResolver::current(),
+            'The storefront request resolved no channel, so nothing downstream can scope on one.',
+        );
+    }
+
+    public function test_the_initial_migration_leaves_every_environment_resolvable(): void
+    {
+        $resolver = app(ChannelResolver::class);
+
+        $this->assertNotNull($resolver->resolve('localhost'));
+        $this->assertNotNull($resolver->resolve('127.0.0.1'));
+    }
+}


### PR DESCRIPTION
The schema #939, #950 and #952 are all blocked on. They are one root cause with three surfaces: nothing knows which merchant a request is for, so nothing can scope to one.

This is step 1 of wave 1.5 in [MIGRATION_PLAN.md](https://github.com/liberusoftware/ecommerce-laravel/blob/main/docs/MIGRATION_PLAN.md). It closes no issue on its own — deliberately.

## What landed

- **`stores`, `channels`, `channel_domains`.** Commerce scopes on `store_id`, not `team_id`: a Team may own several Stores, and a shopper on store A's domain must see store A's catalogue rather than everything their merchant sells across every store. `team_id` is the wrong grain and would under-scope.
- **`channel_domains` is a table, not a `domain` column.** A storefront answers on the apex, `www`, a custom merchant domain and a platform subdomain from day one. One column pushes apex/`www` handling into web-server config the application cannot see, and then the canonical the app generates and the host the request arrived on can disagree. One row per hostname, one flagged primary.
- **`ChannelResolver`** answers the domain question — *which channel is `shop.example.com`?* — and **`ResolveChannel`** middleware answers the HTTP one, carrying it on `web` and `api` requests. Panels are untouched: they resolve a Team through Filament tenancy and list their own middleware rather than using the `web` group.
- **An initial-channel migration** creates the first store, channel and hostnames from `APP_URL`, plus `localhost` and `127.0.0.1`.

## What deliberately did not land

**The 404 on an unresolved host.** The wave's rule is that an unresolved host is a 404 with no default-merchant fallback, and that rule is right — but it belongs with the tenant scope it protects. Before the scope exists it guards nothing, and shipped into environments where no hostname is configured yet it takes every storefront down at once. Data first, control second, which is the same order wave 2 uses for its backfill. It flips in the same change as the scope.

Same reason `TrustHosts` is untouched for now.

**The initial-channel migration is not the fallback the wave rules out.** A fallback answers for hosts nobody configured. This configures the host the deployment already answers on, which on a single-store deployment is the whole truth — and it refuses to run if any store or channel already exists, so it can never claim hostnames from a deployment someone set up by hand.

## One defensive catch, and why

`ResolveChannel` treats a `QueryException` as an unresolved host rather than letting it out. It sits in front of every storefront route including `/health`, which exists precisely to answer while the database is down — it reports `degraded` rather than failing to respond. A middleware that threw first would take that away, and would also break the window between deploying and running migrations.

## Tests

`tests/Feature/ChannelResolutionTest.php`:

- a host resolves to its channel, and not to a sibling's;
- case, port and surrounding whitespace do not change the answer — a visitor on `SHOP.EXAMPLE.COM` or `shop.example.com:8000` is on the same storefront;
- an unknown host resolves to nothing;
- a channel reaches its store and that store's team;
- one channel answers on several hosts with exactly one canonical;
- a real storefront request carries its channel, so nothing downstream has to ask;
- the initial migration leaves `localhost` and `127.0.0.1` resolvable, which is what every developer and the test suite arrive on.

## Next

Step 2 backfills `store_id`. Step 3 ships the global scope — storefront scopes to the resolved store, panels scope to the tenant's stores — and turns on the 404. That step is what closes #939, #950 and #952 at once.