### PR TITLE
feat: derive store_id from team_id on the commerce tables — wave 1.5, step 2

### DIFF
--- a/database/migrations/2026_08_08_000002_add_store_id_to_team_scoped_tables.php
+++ b/database/migrations/2026_08_08_000002_add_store_id_to_team_scoped_tables.php
@@ -1,0 +1,108 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+/**
+ * Wave 1.5, step 2: give every team-scoped commerce table a `store_id`, derived
+ * from the `team_id` it already carries.
+ *
+ * The scope that follows reads `store_id`, and a scope cannot precede the data
+ * it reads. This is the data.
+ *
+ * The plan expected a constant — a single-store deployment has one store, so
+ * every row gets it. Deriving from `team_id` instead costs nothing and is
+ * correct on a deployment that already has several teams, where a constant
+ * would hand one merchant's rows to another. Where there is one team the two
+ * approaches produce the same thing.
+ *
+ * Rows whose `team_id` is null keep a null `store_id`. They belong to nobody
+ * rather than to whoever sorts first — the same rule the API write guard uses,
+ * and the opposite of the `default(1)` that produced the mess wave 2 is
+ * unpicking.
+ */
+return new class extends Migration
+{
+    /**
+     * The commerce tables carrying `team_id`, from the two migrations that added
+     * it. `teams`, `team_user`, `team_invitations` and `stores` are excluded:
+     * their `team_id` is the membership graph itself, which is Team-grained by
+     * definition and has no store.
+     */
+    private const TABLES = [
+        'product_categories', 'products', 'payment_methods', 'customers', 'wishlists',
+        'orders', 'coupons', 'groups', 'product_reviews', 'downloadable_products',
+        'images', 'cart_items', 'collections', 'invoices', 'articles', 'product_rating',
+    ];
+
+    public function up(): void
+    {
+        $this->giveEveryTeamAStore();
+
+        foreach (self::TABLES as $table) {
+            if (! Schema::hasTable($table) || ! Schema::hasColumn($table, 'team_id')) {
+                continue;
+            }
+
+            if (! Schema::hasColumn($table, 'store_id')) {
+                Schema::table($table, function (Blueprint $blueprint) {
+                    // Nullable and unconstrained, deliberately. A row with no
+                    // team has no store, and a foreign key would force a
+                    // default — which is exactly the mistake being unpicked.
+                    $blueprint->unsignedBigInteger('store_id')->nullable()->after('team_id')->index();
+                });
+            }
+
+            DB::table($table)
+                ->whereNotNull('team_id')
+                ->whereNull('store_id')
+                ->update([
+                    'store_id' => DB::raw('(select min(id) from stores where stores.team_id = '.$table.'.team_id)'),
+                ]);
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (self::TABLES as $table) {
+            if (Schema::hasTable($table) && Schema::hasColumn($table, 'store_id')) {
+                Schema::table($table, function (Blueprint $blueprint) {
+                    $blueprint->dropColumn('store_id');
+                });
+            }
+        }
+    }
+
+    /**
+     * One store per team, so the derivation above has something to find.
+     *
+     * The first team already has one — the initial-channel migration created it.
+     * The stores made here have no channel, so no hostname resolves to them:
+     * a merchant whose storefront has not been configured is unreachable rather
+     * than served from somebody else's domain.
+     */
+    private function giveEveryTeamAStore(): void
+    {
+        if (! Schema::hasTable('teams')) {
+            return;
+        }
+
+        $now = now();
+
+        DB::table('teams')
+            ->whereNotIn('id', DB::table('stores')->whereNotNull('team_id')->pluck('team_id'))
+            ->orderBy('id')
+            ->each(function ($team) use ($now) {
+                DB::table('stores')->insert([
+                    'team_id' => $team->id,
+                    'name' => $team->name,
+                    'slug' => Str::slug($team->name).'-'.$team->id,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            });
+    }
+};

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -183,7 +183,15 @@ Three decisions collided:
 
 That initial-channel migration is not the fallback this wave rules out. A fallback answers for hosts nobody configured; this configures the host the deployment already answers on, which on a single-store deployment is the whole truth. It refuses to run if any store or channel already exists, so it can never claim hostnames from a deployment set up by hand.
 
-**2. Backfill `store_id` alone.** On a today-single-store deployment this is a constant, so it needs no rehearsal — which is exactly why it can be separated from wave 2 without breaking that wave's rehearse-once discipline.
+**2. Backfill `store_id` alone.** — ✅ **done**
+
+On a today-single-store deployment this is a constant, so it needs no rehearsal — which is exactly why it can be separated from wave 2 without breaking that wave's rehearse-once discipline.
+
+It was **derived from `team_id`** rather than written as a constant. The 16 tables that carry `team_id` gained a nullable `store_id`, filled from the row's own team; every team without a store got one first. On a single-team deployment the two approaches agree, and on a deployment that already has several teams the constant would have handed one merchant's rows to another. Rows with a null `team_id` keep a null `store_id` — they belong to nobody rather than to whoever sorts first.
+
+The stores created for the other teams have **no channel**, so no hostname resolves to them. A merchant whose storefront has not been configured is unreachable, rather than served from somebody else's domain.
+
+`teams`, `team_user`, `team_invitations` and `stores` are excluded: their `team_id` is the membership graph itself, Team-grained by definition.
 
 **3. Ship the tenant scope.** One global scope with two modes, rather than two scoping systems that must agree:
 

--- a/tests/Feature/StoreBackfillTest.php
+++ b/tests/Feature/StoreBackfillTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * Wave 1.5, step 2: every team-scoped commerce table carries a `store_id`, and
+ * it is derived from the team that owns the row.
+ *
+ * The scope in step 3 reads this column. A scope over a column that is empty,
+ * or filled with a constant that lumps merchants together, is worse than no
+ * scope — it looks like a control.
+ */
+class StoreBackfillTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * `team_id` on these is the membership graph itself, which is Team-grained
+     * by definition. `stores.team_id` is the ownership edge the derivation reads.
+     */
+    private const NOT_COMMERCE = ['teams', 'team_user', 'team_invitations', 'stores'];
+
+    public function test_every_team_scoped_table_has_a_store_id(): void
+    {
+        $missing = [];
+
+        foreach (Schema::getTableListing() as $table) {
+            $table = str_contains($table, '.') ? explode('.', $table)[1] : $table;
+
+            if (in_array($table, self::NOT_COMMERCE, true)) {
+                continue;
+            }
+
+            if (Schema::hasColumn($table, 'team_id') && ! Schema::hasColumn($table, 'store_id')) {
+                $missing[] = $table;
+            }
+        }
+
+        $this->assertSame([], $missing, implode("\n", [
+            'These tables are team-scoped but carry no store_id, so the storefront scope cannot reach them:',
+            ...$missing,
+        ]));
+    }
+
+    /**
+     * The derivation itself, run against rows that exist — which the migration
+     * cannot be observed doing on a fresh database, because there are none.
+     *
+     * Re-running `up()` is safe by construction: it only fills rows whose
+     * `store_id` is null, and only creates stores for teams that have none.
+     */
+    public function test_a_row_is_backfilled_with_its_own_teams_store(): void
+    {
+        $mine = Team::factory()->create(['user_id' => User::factory()->create()->id]);
+        $theirs = Team::factory()->create(['user_id' => User::factory()->create()->id]);
+
+        $myProduct = Product::factory()->create(['team_id' => $mine->id]);
+        $theirProduct = Product::factory()->create(['team_id' => $theirs->id]);
+
+        // Both teams were created after the migration ran, so neither has a
+        // store and neither product has a store_id — the state a deployment is
+        // in when the migration arrives.
+        DB::table('products')->whereIn('id', [$myProduct->id, $theirProduct->id])->update(['store_id' => null]);
+
+        $this->runTheBackfill();
+
+        $mineStoreId = DB::table('products')->where('id', $myProduct->id)->value('store_id');
+        $theirsStoreId = DB::table('products')->where('id', $theirProduct->id)->value('store_id');
+
+        $this->assertNotNull($mineStoreId, 'The product was left with no store, so nothing can scope it.');
+        $this->assertNotSame(
+            $mineStoreId,
+            $theirsStoreId,
+            'Two merchants were given the same store, which is the mis-attribution this is meant to avoid.',
+        );
+        $this->assertSame($mine->id, (int) DB::table('stores')->where('id', $mineStoreId)->value('team_id'));
+        $this->assertSame($theirs->id, (int) DB::table('stores')->where('id', $theirsStoreId)->value('team_id'));
+    }
+
+    public function test_a_row_belonging_to_no_team_is_left_alone(): void
+    {
+        $orphan = Product::factory()->create(['team_id' => null]);
+        DB::table('products')->where('id', $orphan->id)->update(['store_id' => null]);
+
+        $this->runTheBackfill();
+
+        $this->assertNull(
+            DB::table('products')->where('id', $orphan->id)->value('store_id'),
+            'A row that belongs to nobody was given a store, which is how default(1) started.',
+        );
+    }
+
+    private function runTheBackfill(): void
+    {
+        $migration = require database_path('migrations/2026_08_08_000002_add_store_id_to_team_scoped_tables.php');
+
+        $migration->up();
+    }
+}


### PR DESCRIPTION
Step 2 of wave 1.5. The scope in step 3 reads `store_id`, and **a scope cannot precede the data it reads** — this is the data.

The 16 tables carrying `team_id` gain a nullable `store_id`, filled from the row's own team. Every team without a store gets one first.

## Derived, not constant

The plan expected a constant: a single-store deployment has one store, so every row gets it. Deriving from `team_id` costs nothing and is **correct on a deployment that already has several teams**, where a constant would hand one merchant's rows to another. Where there is one team the two produce the same thing.

Rows with a null `team_id` keep a null `store_id`. They belong to nobody rather than to whoever sorts first — the opposite of the `default(1)` that produced the mess wave 2 is unpicking. `store_id` is nullable and unconstrained for the same reason: a foreign key would force a default.

The stores created for the other teams have **no channel**, so no hostname resolves to them. A merchant whose storefront has not been configured is unreachable rather than served from somebody else's domain.

`teams`, `team_user`, `team_invitations` and `stores` are excluded — their `team_id` is the membership graph itself, Team-grained by definition, and `stores.team_id` is the ownership edge the derivation reads.

## Tests

A fresh database has no rows, so a migration's backfill cannot be observed doing anything on one. `tests/Feature/StoreBackfillTest.php` re-runs `up()` against rows that exist — safe by construction, since it only fills null `store_id`s and only creates stores for teams that have none:

- two products belonging to two teams get **two different** stores, each matching its own team;
- a product belonging to no team is left with a null `store_id`;
- every table carrying `team_id` carries `store_id` — a ratchet, so a new team-scoped table that skips it fails here rather than silently falling outside the scope.

## Next

Step 3: one global scope, two modes — storefront scopes to the resolved store, panels scope to the tenant's stores — and the 404 on an unresolved host turns on with it. That step closes #939, #950 and #952.