### PR TITLE
feat: scope the catalogue to the resolved store, and 404 an unresolved host

### DIFF
--- a/app/Http/Middleware/ResolveChannel.php
+++ b/app/Http/Middleware/ResolveChannel.php
@@ -12,12 +12,15 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Carries the resolved channel on the request, for the storefront and the API.
  *
- * It does not yet refuse an unresolved host. That rule — an unresolved host is
- * a 404, with no default-merchant fallback — belongs with the tenant scope it
- * protects: 404ing before there is a scope guards nothing, and would take the
- * storefront down in every environment whose hostname is not configured yet.
- * The order is deliberate, and it is the same one wave 2 uses: get the data in
- * place first, then turn on the control that reads it.
+ * An unresolved host is a 404, with no default-merchant fallback. That rule is
+ * half of the control: the scope narrows a resolved host to its own store, and
+ * this refuses a host that resolves to none — otherwise an unconfigured
+ * hostname is an unscoped one, which is the leak with extra steps.
+ *
+ * Single-merchant deployments and local development configure their one
+ * channel's domain, `localhost` included; the initial-channel migration does it
+ * for them. *A configured fallback is exactly how `default(1)` produced the mess
+ * wave 2 is unpicking.*
  *
  * Panels are not in this stack. They resolve a Team through Filament tenancy and
  * list their own middleware rather than using the `web` group.
@@ -28,10 +31,17 @@ class ResolveChannel
 
     public function handle(Request $request, Closure $next): Response
     {
-        $request->attributes->set(
-            ChannelResolver::ATTRIBUTE,
-            $this->resolve($request->getHost()),
-        );
+        $channel = $this->resolve($request->getHost());
+
+        $request->attributes->set(ChannelResolver::ATTRIBUTE, $channel);
+
+        // The one exemption. `/health` is a Kubernetes liveness and readiness
+        // probe, and probes arrive on the pod's own address rather than on any
+        // configured hostname. 404ing it would restart healthy pods, and it
+        // reads no tenant data — it reports whether the database answers.
+        if ($channel === null && ! $request->is('health')) {
+            abort(404);
+        }
 
         return $next($request);
     }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Interfaces\Orderable;
 use App\Notifications\ProductBackInStockNotification;
 use App\Services\TaxCalculator;
+use App\Traits\IsStoreScoped;
 use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -19,6 +20,7 @@ use Illuminate\Support\Str;
 class Product extends Model implements Orderable
 {
     use HasFactory;
+    use IsStoreScoped;
     use IsTenantModel;
     use SoftDeletes;
 

--- a/app/Models/ProductCategory.php
+++ b/app/Models/ProductCategory.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\IsStoreScoped;
 use App\Traits\IsTenantModel;
 use Biostate\FilamentMenuBuilder\Traits\Menuable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -10,6 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 class ProductCategory extends Model
 {
     use HasFactory;
+    use IsStoreScoped;
     use IsTenantModel;
     use Menuable;
 

--- a/app/Models/ProductCollection.php
+++ b/app/Models/ProductCollection.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Interfaces\Orderable;
+use App\Traits\IsStoreScoped;
 use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -12,6 +13,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class ProductCollection extends Model implements Orderable
 {
     use HasFactory;
+    use IsStoreScoped;
     use IsTenantModel;
     use SoftDeletes;
 

--- a/app/Services/StoreContext.php
+++ b/app/Services/StoreContext.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Store;
+
+/**
+ * Which store the current request is about.
+ *
+ * Reads and writes ask different questions, and conflating them is how tenant
+ * scopes go wrong. A read on a storefront is about the store that storefront
+ * belongs to. A write from a panel or a console command is about the store the
+ * row should end up in, which is not something the request can be asked.
+ */
+class StoreContext
+{
+    /**
+     * The store a read is scoped to, or null when there is nothing to scope by.
+     *
+     * Null off a resolved host — panels, console commands, queued jobs. Panels
+     * are already Team-scoped by Filament tenancy, so leaving them unfiltered
+     * here changes nothing about what a panel user can see; narrowing them to
+     * the tenant's stores is a refinement for later, not a control.
+     */
+    public static function forReads(): ?int
+    {
+        return ChannelResolver::current()?->store_id;
+    }
+
+    /**
+     * The store a new row belongs to.
+     *
+     * The resolved store when there is one. Otherwise the only store, if there
+     * is exactly one — that is not a guess, it is the whole truth on a
+     * single-store deployment, and it is what keeps a product created in a
+     * panel visible on the storefront that sells it.
+     *
+     * With several stores and no resolved host there is no answer, and the row
+     * is left unstamped rather than attributed to whichever store sorts first.
+     */
+    public static function forWrites(): ?int
+    {
+        return self::forReads() ?? self::theOnlyStoreId();
+    }
+
+    private static function theOnlyStoreId(): ?int
+    {
+        $stores = Store::query()->orderBy('id')->limit(2)->pluck('id');
+
+        return $stores->count() === 1 ? (int) $stores->first() : null;
+    }
+}

--- a/app/Traits/IsStoreScoped.php
+++ b/app/Traits/IsStoreScoped.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Store;
+use App\Services\StoreContext;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Scopes a model to the store the request resolved to.
+ *
+ * This is the control #939, #950 and #952 all describe the absence of. All three
+ * are one root cause with three surfaces — the Blade storefront, the GraphQL
+ * endpoint, the REST API — and each was previously going to be fixed at its own
+ * call site. Scoping at the caller is the original failure: it has to be
+ * remembered every time, and it was not.
+ *
+ * A global scope is remembered once. `withoutGlobalScope('store')` is the way
+ * out where a query genuinely spans stores, and it has to be written down,
+ * which is the point.
+ *
+ * Off a resolved host — panels, console, queues — the scope is inert. It is not
+ * the only control in those contexts: panels are Team-scoped by Filament
+ * tenancy, and the API write paths check ownership directly.
+ *
+ * Requires `store_id` on the table. Applying it to a model without one produces
+ * exactly the failure #958 was: a query naming a column that is not there.
+ */
+trait IsStoreScoped
+{
+    public static function bootIsStoreScoped(): void
+    {
+        static::addGlobalScope('store', function (Builder $query) {
+            $storeId = StoreContext::forReads();
+
+            if ($storeId === null) {
+                return;
+            }
+
+            // Qualified, because this runs inside joins and subqueries where a
+            // bare `store_id` is ambiguous.
+            $query->where($query->getModel()->getTable().'.store_id', $storeId);
+        });
+
+        static::creating(function (Model $model) {
+            $model->store_id ??= StoreContext::forWrites();
+        });
+    }
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
+}

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -193,7 +193,9 @@ The stores created for the other teams have **no channel**, so no hostname resol
 
 `teams`, `team_user`, `team_invitations` and `stores` are excluded: their `team_id` is the membership graph itself, Team-grained by definition.
 
-**3. Ship the tenant scope.** One global scope with two modes, rather than two scoping systems that must agree:
+**3. Ship the tenant scope.** — 🟡 *storefront mode and the 404 landed on the catalogue models; the remaining models and the panel mode follow*
+
+One global scope with two modes, rather than two scoping systems that must agree:
 
 | Context | Scope |
 | --- | --- |
@@ -203,6 +205,12 @@ The stores created for the other teams have **no channel**, so no hostname resol
 Panels keep `->tenant(Team::class, …)`. Switching them to `Store` tenancy would break every non-commerce resource, which is legitimately `Team`-grained; adding a store filter per resource is the original failure — scoping at the caller, remembered 105 times.
 
 **This step closes [#939](https://github.com/liberusoftware/ecommerce-laravel/issues/939), [#950](https://github.com/liberusoftware/ecommerce-laravel/issues/950) and [#952](https://github.com/liberusoftware/ecommerce-laravel/issues/952) at once.**
+
+**What landed first.** `IsStoreScoped` on `Product`, `ProductCategory` and `ProductCollection` — the catalogue, which is what all three issues name first and what the sitemap publishes. With it, the 404: an unconfigured hostname is an unscoped one, so refusing it is half the control rather than a separate rule. `/health` is the one exemption — a Kubernetes probe arrives on the pod's own address rather than a configured hostname, reads no tenant data, and 404ing it restarts healthy pods.
+
+**Writes stamp too, or the read scope is a bug.** A product created in a panel resolves no host, so nothing would set its `store_id` and it would vanish from the storefront that sells it. `StoreContext::forWrites()` uses the resolved store, and off a storefront falls back to *the only store when there is exactly one* — not a guess but the whole truth on a single-store deployment. With several stores and no resolved host the row is left unstamped rather than attributed to whichever sorts first.
+
+**The rest of the models follow.** Orders, customers, reviews, carts and the other ten tables carry `store_id` already; each needs its read paths checked before the scope goes on, and the panel mode — `whereIn` the tenant's stores — is a refinement rather than a control, since panels are already Team-scoped by Filament tenancy.
 
 **4. Rebuild the sitemap per channel.** One sitemap per resolved storefront, listing only that store's products. Rewritten rather than moved — the fix rebuilds it anyway, and it stays in the host as pure cross-module aggregation.
 

--- a/tests/Feature/StoreScopeTest.php
+++ b/tests/Feature/StoreScopeTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Channel;
+use App\Models\ChannelDomain;
+use App\Models\Product;
+use App\Models\Store;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Wave 1.5, step 3: a storefront serves its own store's catalogue and nobody
+ * else's.
+ *
+ * #939, #950 and #952 are one root cause with three surfaces — the Blade
+ * storefront, the GraphQL endpoint, the REST API. Each was going to be fixed at
+ * its own call site, and scoping at the caller is the original failure: it has
+ * to be remembered every time, and it was not. This scopes once, in the model.
+ */
+class StoreScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function storefront(string $host): Store
+    {
+        $store = Store::factory()->create();
+        $channel = Channel::factory()->create(['store_id' => $store->id]);
+        ChannelDomain::factory()->primary()->create(['channel_id' => $channel->id, 'host' => $host]);
+
+        return $store;
+    }
+
+    public function test_a_storefront_does_not_publish_another_stores_products(): void
+    {
+        $mine = $this->storefront('mine.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+
+        $ours = Product::factory()->create(['store_id' => $mine->id, 'name' => 'Mine For Sale']);
+        $competitor = Product::factory()->create(['store_id' => $theirs->id, 'name' => 'Theirs For Sale']);
+
+        $response = $this->get('http://mine.example.com/sitemap.xml')->assertOk();
+
+        $response->assertSee(route('products.show', $ours, absolute: false), escape: false);
+        $response->assertDontSee(route('products.show', $competitor, absolute: false), escape: false);
+    }
+
+    /**
+     * The sitemap is the harm that outlives its own fix: a request-time leak
+     * stops the moment it is patched, but URLs handed to a crawler stay in the
+     * index until it comes back.
+     */
+    public function test_the_sitemap_lists_only_the_resolved_stores_products(): void
+    {
+        $mine = $this->storefront('mine.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+
+        Product::factory()->count(2)->create(['store_id' => $mine->id]);
+        Product::factory()->count(3)->create(['store_id' => $theirs->id]);
+
+        $body = $this->get('http://mine.example.com/sitemap.xml')->assertOk()->getContent();
+
+        // Two products plus the home page.
+        $this->assertSame(3, substr_count($body, '<loc>'));
+    }
+
+    /**
+     * No default-merchant fallback. An unconfigured hostname is an unscoped one,
+     * which is the leak with extra steps.
+     */
+    public function test_an_unresolved_host_is_a_404(): void
+    {
+        $this->storefront('mine.example.com');
+
+        $this->get('http://somebody-elses.example.com/sitemap.xml')->assertNotFound();
+    }
+
+    /**
+     * Probes arrive on the pod's own address rather than a configured hostname,
+     * and 404ing them restarts healthy pods.
+     */
+    public function test_the_health_probe_answers_on_an_unresolved_host(): void
+    {
+        $this->get('http://10.0.0.7/health')->assertOk()->assertJsonPath('status', 'ok');
+    }
+
+    /**
+     * Off a resolved host the scope is inert — otherwise every console command
+     * and queued job would see an empty catalogue.
+     */
+    public function test_the_scope_is_inert_without_a_resolved_host(): void
+    {
+        $mine = $this->storefront('mine.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+
+        Product::factory()->create(['store_id' => $mine->id]);
+        Product::factory()->create(['store_id' => $theirs->id]);
+
+        $this->assertSame(2, Product::query()->count());
+    }
+
+    /**
+     * A product created where no host is resolved — a panel, a seeder — still
+     * has to appear on the storefront that sells it. With one store that is not
+     * a guess, it is the whole truth.
+     */
+    public function test_a_row_created_off_a_storefront_is_stamped_with_the_only_store(): void
+    {
+        $only = Store::query()->firstOrFail();
+
+        $product = Product::factory()->create();
+
+        $this->assertSame($only->id, (int) $product->store_id);
+    }
+
+    public function test_a_row_is_left_unstamped_when_there_is_more_than_one_store(): void
+    {
+        Store::factory()->create();
+
+        $product = Product::factory()->create(['store_id' => null]);
+
+        $this->assertNull(
+            $product->store_id,
+            'A row was attributed to a store nothing pointed at, which is how default(1) started.',
+        );
+    }
+}


### PR DESCRIPTION
Wave 1.5, step 3, on the catalogue models. This is the control #939, #950 and #952 all describe the absence of.

All three are **one root cause with three surfaces** — the Blade storefront, the GraphQL endpoint, the REST API — and each was going to be fixed at its own call site. Scoping at the caller is the original failure: it has to be remembered every time, and it was not. `IsStoreScoped` scopes once, in the model. `withoutGlobalScope('store')` is the way out where a query genuinely spans stores, and it has to be written down, which is the point.

Applied to `Product`, `ProductCategory` and `ProductCollection` — the catalogue, which is what all three issues name first and what the sitemap publishes to search engines.

## The 404 ships with it, not after it

An unconfigured hostname is an **unscoped** one, so refusing it is half the same control rather than a separate rule. No default-merchant fallback — single-merchant deployments configure their one channel's domain, and the initial-channel migration already did that for every environment.

`/health` is the one exemption. It is a Kubernetes liveness and readiness probe, probes arrive on the pod's own address rather than any configured hostname, and it reads no tenant data — it reports whether the database answers. 404ing it would restart healthy pods.

## Writes stamp, or the read scope is a bug

A product created in a panel resolves no host, so nothing would set its `store_id` and it would **vanish from the storefront that sells it**. `StoreContext::forWrites()` uses the resolved store, and off a storefront falls back to *the only store when there is exactly one* — not a guess, but the whole truth on a single-store deployment.

With several stores and no resolved host, the row is left unstamped rather than attributed to whichever store sorts first. That distinction is the whole lesson of `default(1)`.

Off a resolved host the read scope is inert, so console commands and queued jobs see the catalogue they always saw. Panels are unaffected and already Team-scoped by Filament tenancy; narrowing them to the tenant's stores is a refinement for later, not a control.

## Tests

`tests/Feature/StoreScopeTest.php`, driven over HTTP with real `Host` headers:

- a storefront's sitemap carries its own product URL and not a competitor's;
- the sitemap lists exactly the resolved store's products — the harm that outlives its own fix, since URLs handed to a crawler stay indexed until it returns;
- an unresolved host is a 404;
- `/health` still answers `ok` on an unresolved host;
- the scope is inert with no resolved host, so a console context still sees everything;
- a row created off a storefront is stamped with the only store;
- a row is left unstamped when there is more than one store.

## CI

Tests, Lint, Security, Install and Docker all green on `38fafd7`. 1305 tests, 3233 assertions — nothing in the existing suite broke.

## Next

The remaining thirteen `store_id` tables — orders, customers, reviews, carts and the rest — each need their read paths checked before the scope goes on. Then the panel mode, and the per-channel sitemap rewrite (step 4).