### PR TITLE
fix: cover the GraphQL surface named by #950, and bound its unbounded lists

### DIFF
--- a/app/GraphQL/StorefrontSchema.php
+++ b/app/GraphQL/StorefrontSchema.php
@@ -23,6 +23,17 @@ use GraphQL\Type\Schema;
  */
 class StorefrontSchema
 {
+    /**
+     * The ceiling on any list field that takes no pagination arguments.
+     *
+     * Depth and complexity limits bound the *shape* of a query, not the number
+     * of rows a field returns: `collections { products { id } }` is depth 3 and
+     * complexity well under the limit, and used to return the whole catalogue
+     * once per collection. `throttle:api` caps request count, not per-request
+     * cost, so nothing else bounded these.
+     */
+    private const MAX_LIST = 100;
+
     public function build(): Schema
     {
         $product = $this->productType();
@@ -51,7 +62,13 @@ class StorefrontSchema
                 ],
                 'collections' => [
                     'type' => Type::nonNull(Type::listOf(Type::nonNull($collection))),
-                    'resolve' => fn () => ProductCollection::query()->orderBy('name')->get(),
+                    // Products are eager-loaded rather than resolved per collection:
+                    // `Collection.products` was one query per collection.
+                    'resolve' => fn () => ProductCollection::query()
+                        ->with(['products' => fn ($q) => $q->orderBy('products.id')->limit(self::MAX_LIST)])
+                        ->orderBy('name')
+                        ->limit(self::MAX_LIST)
+                        ->get(),
                 ],
                 'me' => [
                     'type' => $user,
@@ -60,7 +77,7 @@ class StorefrontSchema
                 'orders' => [
                     'type' => Type::nonNull(Type::listOf(Type::nonNull($order))),
                     'resolve' => fn ($root, array $args, array $context) => ($u = $context['user'] ?? null)
-                        ? Order::where('user_id', $u->id)->latest('id')->get()
+                        ? Order::where('user_id', $u->id)->latest('id')->limit(self::MAX_LIST)->get()
                         : [],
                 ],
             ],
@@ -151,7 +168,11 @@ class StorefrontSchema
                 'slug' => Type::string(),
                 'products' => [
                     'type' => Type::nonNull(Type::listOf(Type::nonNull($product))),
-                    'resolve' => fn (ProductCollection $c) => $c->products()->get(),
+                    // Eager-loaded and already bounded by the `collections` query.
+                    // Loading here would be the N+1 back again.
+                    'resolve' => fn (ProductCollection $c) => $c->relationLoaded('products')
+                        ? $c->products
+                        : $c->products()->orderBy('products.id')->limit(self::MAX_LIST)->get(),
                 ],
             ],
         ]);

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -212,6 +212,10 @@ Panels keep `->tenant(Team::class, …)`. Switching them to `Store` tenancy woul
 
 **The rest of the models follow.** Orders, customers, reviews, carts and the other ten tables carry `store_id` already; each needs its read paths checked before the scope goes on, and the panel mode — `whereIn` the tenant's stores — is a refinement rather than a control, since panels are already Team-scoped by Filament tenancy.
 
+**The surfaces are covered at the surface.** [#950](https://github.com/liberusoftware/ecommerce-laravel/issues/950) and [#952](https://github.com/liberusoftware/ecommerce-laravel/issues/952) name the anonymous GraphQL endpoint and the Blade storefront, not the models, and a scope nothing exercises through the reported surface is a scope the next refactor removes. `/api/graphql` is now driven the way a caller drives it — real `Host`, no token — across the listing, `search`, a known id, and the nested `collections { products }` read, which reaches `Product` through a pivot and so is the path a caller-side fix would have missed. A `collection_items` row pointing at another store's product is a mis-stamped row, not permission: the nested read returns nothing for it.
+
+**The availability defects recorded on #950 close with it.** `collections`, `Collection.products` and `orders` returned unbounded lists — depth and complexity rules bound the *shape* of a query, not the row count, and `throttle:api` caps request count rather than per-request cost. All three are capped, and the nested products are eager-loaded, which retires the one-query-per-collection N+1 in the same change. No execution timeout yet; that needs a number nobody has picked.
+
 **4. Rebuild the sitemap per channel.** One sitemap per resolved storefront, listing only that store's products. Rewritten rather than moved — the fix rebuilds it anyway, and it stays in the host as pure cross-module aggregation.
 
 ### Rules this wave establishes

--- a/tests/Feature/GraphQLStoreIsolationTest.php
+++ b/tests/Feature/GraphQLStoreIsolationTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Channel;
+use App\Models\ChannelDomain;
+use App\Models\Product;
+use App\Models\ProductCollection;
+use App\Models\Store;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * #950: the anonymous GraphQL endpoint served every merchant's catalogue.
+ *
+ * The scope that fixes it lives on the models, not here — but the models are not
+ * where the issue was reported, and a scope nobody exercises through the actual
+ * surface is a scope that gets removed by the next refactor. These drive
+ * `/api/graphql` the way a caller does, on a real `Host`, with no token.
+ *
+ * The nested read matters most: `collections { products }` reaches Product
+ * through a pivot rather than through the `products` query, so it is the path a
+ * caller-side fix would have missed.
+ */
+class GraphQLStoreIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function storefront(string $host): Store
+    {
+        $store = Store::factory()->create();
+        $channel = Channel::factory()->create(['store_id' => $store->id]);
+        ChannelDomain::factory()->primary()->create(['channel_id' => $channel->id, 'host' => $host]);
+
+        return $store;
+    }
+
+    private function gql(string $host, string $query): array
+    {
+        return $this->postJson("http://{$host}/api/graphql", ['query' => $query])->json();
+    }
+
+    private function collectionOf(Store $store, string $name, Product ...$products): ProductCollection
+    {
+        $collection = ProductCollection::factory()->create(['store_id' => $store->id, 'name' => $name]);
+
+        // attach() writes the pivot without reading the related model, which is
+        // what lets the mis-stamped-pivot case below be set up at all.
+        $collection->products()->attach(collect($products)->pluck('id')->all(), ['quantity' => 1]);
+
+        return $collection;
+    }
+
+    public function test_the_products_query_returns_only_the_resolved_stores_catalogue(): void
+    {
+        $mine = $this->storefront('mine.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+
+        Product::factory()->create(['store_id' => $mine->id, 'name' => 'Mine For Sale']);
+        Product::factory()->create(['store_id' => $theirs->id, 'name' => 'Theirs For Sale']);
+
+        $data = $this->gql('mine.example.com', '{ products { data { name } total } }')['data']['products'];
+
+        $this->assertSame(['Mine For Sale'], array_column($data['data'], 'name'));
+        $this->assertSame(1, $data['total']);
+    }
+
+    /**
+     * `search` is the field an attacker reaches for: it is the difference between
+     * having to page through a competitor's catalogue and asking for a product by
+     * name. The scope has to apply before the filter, not instead of it.
+     */
+    public function test_a_search_cannot_reach_across_stores(): void
+    {
+        $mine = $this->storefront('mine.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+
+        Product::factory()->create(['store_id' => $mine->id, 'name' => 'Widget Blue']);
+        Product::factory()->create(['store_id' => $theirs->id, 'name' => 'Widget Red']);
+
+        $data = $this->gql('mine.example.com', '{ products(search: "Widget") { data { name } total } }')['data']['products'];
+
+        $this->assertSame(['Widget Blue'], array_column($data['data'], 'name'));
+    }
+
+    /**
+     * A known id is the other half of the same reach: the listing hiding a row
+     * means nothing if fetching it by id still works.
+     */
+    public function test_a_product_from_another_store_is_not_readable_by_id(): void
+    {
+        $this->storefront('mine.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+
+        $competitor = Product::factory()->create(['store_id' => $theirs->id]);
+
+        $data = $this->gql('mine.example.com', '{ product(id: '.$competitor->id.') { id name } }');
+
+        $this->assertNull($data['data']['product']);
+    }
+
+    public function test_collections_and_their_nested_products_are_scoped(): void
+    {
+        $mine = $this->storefront('mine.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+
+        $ours = Product::factory()->create(['store_id' => $mine->id, 'name' => 'Mine For Sale']);
+        $competitor = Product::factory()->create(['store_id' => $theirs->id, 'name' => 'Theirs For Sale']);
+
+        $this->collectionOf($mine, 'Mine Featured', $ours);
+        $this->collectionOf($theirs, 'Theirs Featured', $competitor);
+
+        $collections = $this->gql(
+            'mine.example.com',
+            '{ collections { name products { name } } }',
+        )['data']['collections'];
+
+        $this->assertSame(['Mine Featured'], array_column($collections, 'name'));
+        $this->assertSame(['Mine For Sale'], array_column($collections[0]['products'], 'name'));
+    }
+
+    /**
+     * The pivot is not a way around the scope. A row in `collection_items`
+     * pointing at another store's product is a mis-stamped row, not permission.
+     */
+    public function test_a_pivot_row_pointing_at_another_stores_product_does_not_expose_it(): void
+    {
+        $mine = $this->storefront('mine.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+
+        $competitor = Product::factory()->create(['store_id' => $theirs->id, 'name' => 'Theirs For Sale']);
+        $this->collectionOf($mine, 'Mine Featured', $competitor);
+
+        $collections = $this->gql(
+            'mine.example.com',
+            '{ collections { name products { name } } }',
+        )['data']['collections'];
+
+        $this->assertSame([], $collections[0]['products']);
+    }
+
+    /**
+     * An unconfigured hostname resolves to no store, and a request that cannot be
+     * scoped is refused rather than served unscoped.
+     */
+    public function test_an_unresolved_host_gets_no_catalogue_at_all(): void
+    {
+        $mine = $this->storefront('mine.example.com');
+        Product::factory()->create(['store_id' => $mine->id]);
+
+        $this->postJson('http://somebody-elses.example.com/api/graphql', [
+            'query' => '{ products { total } }',
+        ])->assertNotFound();
+    }
+
+    /**
+     * `collections { products }` is depth 3 and inside the complexity limit, so
+     * neither rule bounded it — it returned the whole catalogue once per
+     * collection, in one query per collection.
+     */
+    public function test_the_nested_collection_read_is_bounded_and_not_an_n_plus_1(): void
+    {
+        $mine = $this->storefront('mine.example.com');
+
+        $products = Product::factory()->count(3)->create(['store_id' => $mine->id])->all();
+        foreach (range(1, 3) as $i) {
+            $this->collectionOf($mine, "Collection {$i}", ...$products);
+        }
+
+        $queries = 0;
+        DB::listen(function () use (&$queries) {
+            $queries++;
+        });
+
+        $collections = $this->gql('mine.example.com', '{ collections { name products { name } } }')['data']['collections'];
+
+        $this->assertCount(3, $collections);
+        $this->assertCount(3, $collections[0]['products']);
+
+        // One for the collections, one for all their products. Per-collection
+        // loading would make this grow with the number of collections.
+        $this->assertLessThan(
+            10,
+            $queries,
+            'The nested read is issuing a query per collection again.',
+        );
+    }
+}


### PR DESCRIPTION
The store scope landed on the models in #981. #950 and #952 report **surfaces**, not models — and a scope nothing exercises through the reported surface is a scope the next refactor removes.

## The isolation half

`tests/Feature/GraphQLStoreIsolationTest.php` drives `/api/graphql` the way a caller drives it: a real `Host` header, no token.

- the `products` listing
- `search` — the field that turns "page through a competitor's catalogue" into "ask for it by name"
- `product(id:)` — a listing that hides a row means nothing if fetching it by id still works
- `collections { products }` — reaches `Product` through the `collection_items` pivot rather than through the `products` query, so it is the path a caller-side fix would have missed
- a pivot row pointing at another store's product: a mis-stamped row, not permission. The nested read returns nothing for it.
- an unresolved host gets no catalogue at all

## The availability half

#950 recorded three defects in its own body, under "Related availability defects on the same route". They close here.

`collections`, `Collection.products` and `orders` returned **unbounded** lists. `QueryDepth(10)` and `QueryComplexity(200)` bound the *shape* of a query, not the number of rows a field returns — `collections { products { id } }` is depth 3 — and `throttle:api` caps request *count*, not per-request cost. So nothing bounded them. All three now cap at 100.

`Collection.products` was also **one query per collection**. Products are eager-loaded on the `collections` query with a per-parent limit, so the nested read is two queries regardless of how many collections come back; the resolver uses the loaded relation rather than loading again. The test asserts the query count instead of trusting the shape.

No execution **timeout** — that needs a number nobody has picked.

## What this does not close

The remaining thirteen `store_id` tables, the panel mode, and step 4's per-channel sitemap rewrite.