### PR TITLE
feat: scope orders and customers, and exempt the two paths a host cannot answer

### DIFF
--- a/app/Http/Controllers/StripeWebhookController.php
+++ b/app/Http/Controllers/StripeWebhookController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Order;
 use App\Notifications\OrderConfirmationNotification;
 use App\Notifications\OrderRefundedNotification;
+use App\Services\StoreContext;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Notification;
@@ -33,12 +34,20 @@ class StripeWebhookController extends Controller
 
         $charge = $event->data->object;
 
-        match ($event->type) {
-            'charge.succeeded' => $this->markPaid($charge),
-            'charge.failed' => $this->markFailed($charge),
-            'charge.refunded' => $this->reconcileRefund($charge),
-            default => null, // acknowledge and ignore everything else
-        };
+        // Across every store, deliberately. Stripe posts to one configured
+        // endpoint, so this request's host resolves to whichever store happens to
+        // own that hostname — not to the store the charge belongs to. Scoped, a
+        // payment confirmation for any other store would find no order, take the
+        // `null` branch, and return 200: money captured, order left pending, and
+        // nothing anywhere saying so. The charge id is the authority here.
+        StoreContext::acrossAllStores(function () use ($event, $charge) {
+            match ($event->type) {
+                'charge.succeeded' => $this->markPaid($charge),
+                'charge.failed' => $this->markFailed($charge),
+                'charge.refunded' => $this->reconcileRefund($charge),
+                default => null, // acknowledge and ignore everything else
+            };
+        });
 
         return response()->json(['received' => true]);
     }

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\IsStoreScoped;
 use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -9,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 class Customer extends Model
 {
     use HasFactory;
+    use IsStoreScoped;
     use IsTenantModel;
 
     protected $table = 'customers';

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Exceptions\InvalidOrderTransitionException;
 use App\Jobs\DispatchOutboundWebhook;
+use App\Traits\IsStoreScoped;
 use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -12,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Order extends Model
 {
     use HasFactory;
+    use IsStoreScoped;
     use IsTenantModel;
 
     public const STATUS_PENDING = 'pending';

--- a/app/Services/GdprErasureService.php
+++ b/app/Services/GdprErasureService.php
@@ -27,9 +27,17 @@ class GdprErasureService
 
     private const REDACTED = 'REDACTED';
 
+    /**
+     * Erasure spans every store, whatever host the request arrived on.
+     *
+     * This is reachable over HTTP from a storefront, and a storefront resolves a
+     * store. Scoped, an erasure would silently miss the person's rows at every
+     * other merchant and still report success — a breach that looks like a
+     * completed request.
+     */
     public function erase(User $user): void
     {
-        DB::transaction(function () use ($user) {
+        StoreContext::acrossAllStores(fn () => DB::transaction(function () use ($user) {
             $customer = $user->customer;
 
             $this->scrubOrders($user, $customer?->id);
@@ -73,7 +81,7 @@ class GdprErasureService
                 'two_factor_secret' => null,
                 'two_factor_recovery_codes' => null,
             ])->save();
-        });
+        }));
     }
 
     private function scrubOrders(User $user, ?int $customerId): void

--- a/app/Services/GdprExportService.php
+++ b/app/Services/GdprExportService.php
@@ -29,7 +29,20 @@ use App\Models\User;
  */
 class GdprExportService
 {
+    /**
+     * The export spans every store, whatever host the request arrived on.
+     *
+     * Subject access is about a person, not about a storefront. Scoped to the
+     * host the request happened to land on, this would return one merchant's
+     * slice and present it as the whole record — a wrong answer rather than a
+     * partial one.
+     */
     public function export(User $user): array
+    {
+        return StoreContext::acrossAllStores(fn () => $this->everything($user));
+    }
+
+    private function everything(User $user): array
     {
         $customer = $user->customer;
 

--- a/app/Services/StoreContext.php
+++ b/app/Services/StoreContext.php
@@ -14,6 +14,34 @@ use App\Models\Store;
  */
 class StoreContext
 {
+    private static bool $spanningAllStores = false;
+
+    /**
+     * Run a callback with the store scope suspended.
+     *
+     * Some work is about a person rather than about a storefront, and narrowing
+     * it to whichever host the request happened to arrive on makes it silently
+     * incomplete. A subject-access export that returns one store's orders is a
+     * wrong answer, not a partial one; an erasure that misses rows is a breach.
+     *
+     * Suspending it here rather than adding `withoutGlobalScope('store')` at
+     * each query is deliberate: these paths read through relations
+     * (`$user->customer`, `$user->wishlist()`) that no call-site opt-out
+     * reaches, and every model added to the scope later would need remembering
+     * again. That is the failure this whole trait exists to stop.
+     */
+    public static function acrossAllStores(callable $callback): mixed
+    {
+        $previous = self::$spanningAllStores;
+        self::$spanningAllStores = true;
+
+        try {
+            return $callback();
+        } finally {
+            self::$spanningAllStores = $previous;
+        }
+    }
+
     /**
      * The store a read is scoped to, or null when there is nothing to scope by.
      *
@@ -24,6 +52,10 @@ class StoreContext
      */
     public static function forReads(): ?int
     {
+        if (self::$spanningAllStores) {
+            return null;
+        }
+
         return ChannelResolver::current()?->store_id;
     }
 

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -210,7 +210,18 @@ Panels keep `->tenant(Team::class, …)`. Switching them to `Store` tenancy woul
 
 **Writes stamp too, or the read scope is a bug.** A product created in a panel resolves no host, so nothing would set its `store_id` and it would vanish from the storefront that sells it. `StoreContext::forWrites()` uses the resolved store, and off a storefront falls back to *the only store when there is exactly one* — not a guess but the whole truth on a single-store deployment. With several stores and no resolved host the row is left unstamped rather than attributed to whichever sorts first.
 
-**The rest of the models follow.** Orders, customers, reviews, carts and the other ten tables carry `store_id` already; each needs its read paths checked before the scope goes on, and the panel mode — `whereIn` the tenant's stores — is a refinement rather than a control, since panels are already Team-scoped by Filament tenancy.
+**Orders and customers followed, with two exemptions.** Checking their read paths first is what the step called for, and it found two places where the request's host says nothing about which store the work is *about*:
+
+| Path | Why the host is the wrong answer |
+| --- | --- |
+| Inbound payment webhooks | Stripe posts to one configured endpoint. That hostname resolves to whichever store owns it, never to the store the charge belongs to. Scoped, a confirmation for any other store finds no order, takes the `null` branch and returns 200 — money captured, order left pending, nothing anywhere saying so. |
+| Subject access and erasure | Both are about a person, not a storefront, and both are reachable over HTTP from a storefront that resolves a store. A scoped export returns one merchant's slice and presents it as the whole record; a scoped erasure misses rows and still reports success. |
+
+`StoreContext::acrossAllStores()` suspends the scope for the duration of a callback, rather than `withoutGlobalScope('store')` at each query. These paths read through relations — `$user->customer`, `$user->wishlist()` — that no call-site opt-out reaches, and every model added to the scope later would need remembering again at each of them. **That is the failure the scope exists to stop, and an exemption written the other way would reintroduce it inside the fix.**
+
+`store_id` is not fillable on any scoped model. The trait's `creating` hook is its only writer, so no request can post its way into another store.
+
+**The rest of the models follow.** Reviews, carts, invoices and the other ten tables carry `store_id` already; each needs its own read paths checked the same way. The panel mode — `whereIn` the tenant's stores — is a refinement rather than a control, since panels are already Team-scoped by Filament tenancy.
 
 **The surfaces are covered at the surface.** [#950](https://github.com/liberusoftware/ecommerce-laravel/issues/950) and [#952](https://github.com/liberusoftware/ecommerce-laravel/issues/952) name the anonymous GraphQL endpoint and the Blade storefront, not the models, and a scope nothing exercises through the reported surface is a scope the next refactor removes. `/api/graphql` is now driven the way a caller drives it — real `Host`, no token — across the listing, `search`, a known id, and the nested `collections { products }` read, which reaches `Product` through a pivot and so is the path a caller-side fix would have missed. A `collection_items` row pointing at another store's product is a mis-stamped row, not permission: the nested read returns nothing for it.
 

--- a/tests/Feature/OrderStoreScopeTest.php
+++ b/tests/Feature/OrderStoreScopeTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Channel;
+use App\Models\ChannelDomain;
+use App\Models\Order;
+use App\Models\Store;
+use App\Models\User;
+use App\Services\StoreContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Testing\TestResponse;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Wave 1.5, step 3 on the order and customer tables.
+ *
+ * The plan's rule: order history scopes to the resolved store. The data is the
+ * shopper's, but the surface belongs to the merchant — otherwise merchant A's
+ * support staff, looking at a customer's account, see what that person bought
+ * from a competitor.
+ *
+ * Two paths are deliberately exempt, and the exemptions are the substance of
+ * this change rather than a footnote to it. Both are cases where the request's
+ * host says nothing about which store the work is *about*.
+ */
+class OrderStoreScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $stripeSecret = 'whsec_test_secret';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Notification::fake();
+        config(['services.stripe.webhook.secret' => $this->stripeSecret]);
+    }
+
+    private function storefront(string $host): Store
+    {
+        $store = Store::factory()->create();
+        $channel = Channel::factory()->create(['store_id' => $store->id]);
+        ChannelDomain::factory()->primary()->create(['channel_id' => $channel->id, 'host' => $host]);
+
+        return $store;
+    }
+
+    /**
+     * `store_id` is written after the fact rather than passed in, because it is
+     * deliberately not fillable on any scoped model: the trait's `creating` hook
+     * is its only writer, so no request can post its way into another store.
+     */
+    private function orderAt(Store $store, User $user, array $overrides = []): Order
+    {
+        $order = Order::create(array_merge([
+            'user_id' => $user->id,
+            'customer_email' => $user->email,
+            'payment_method' => 'stripe',
+            'total_amount' => 100,
+            'status' => Order::STATUS_PAID,
+        ], $overrides));
+
+        $order->forceFill(['store_id' => $store->id])->save();
+
+        return $order;
+    }
+
+    public function test_order_history_shows_only_the_resolved_stores_orders(): void
+    {
+        $mine = $this->storefront('mine.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+        $shopper = User::factory()->create();
+
+        $here = $this->orderAt($mine, $shopper);
+        $elsewhere = $this->orderAt($theirs, $shopper);
+
+        Sanctum::actingAs($shopper);
+        $ids = collect($this->getJson('http://mine.example.com/api/orders')->json('data'))->pluck('id');
+
+        $this->assertTrue($ids->contains($here->id));
+        $this->assertFalse(
+            $ids->contains($elsewhere->id),
+            "Merchant A's storefront listed what this shopper bought from merchant B.",
+        );
+    }
+
+    public function test_an_order_placed_at_another_store_is_not_readable_by_id(): void
+    {
+        $this->storefront('mine.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+        $shopper = User::factory()->create();
+
+        $elsewhere = $this->orderAt($theirs, $shopper);
+
+        Sanctum::actingAs($shopper);
+
+        $this->getJson('http://mine.example.com/api/orders/'.$elsewhere->id)->assertNotFound();
+    }
+
+    // --- The exemptions ---------------------------------------------------
+
+    /**
+     * Stripe posts to one configured endpoint, so the webhook's host resolves to
+     * whichever store owns that hostname — not to the store the charge belongs
+     * to. Scoped, a confirmation for any other store would find no order, take
+     * the null branch, and return 200: money captured, order left pending, and
+     * nothing anywhere saying so.
+     */
+    public function test_a_payment_webhook_reaches_an_order_belonging_to_another_store(): void
+    {
+        $this->storefront('payments.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+        $shopper = User::factory()->create();
+
+        $order = $this->orderAt($theirs, $shopper, [
+            'status' => Order::STATUS_PENDING,
+            'transaction_id' => 'ch_cross_store',
+        ]);
+
+        $this->postStripe('payments.example.com', [
+            'type' => 'charge.succeeded',
+            'data' => ['object' => ['id' => 'ch_cross_store', 'object' => 'charge', 'amount' => 10000, 'amount_refunded' => 0]],
+        ])->assertOk();
+
+        $this->assertSame(
+            Order::STATUS_PAID,
+            $order->fresh()->status,
+            'A captured payment left its order pending because the webhook arrived on another store\'s hostname.',
+        );
+    }
+
+    /**
+     * Subject access is about a person, not a storefront. Scoped to whichever
+     * host the request landed on, an export returns one merchant's slice and
+     * presents it as the whole record — a wrong answer, not a partial one.
+     */
+    public function test_a_data_export_spans_every_store(): void
+    {
+        $mine = $this->storefront('mine.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+        $shopper = User::factory()->create();
+
+        $here = $this->orderAt($mine, $shopper);
+        $elsewhere = $this->orderAt($theirs, $shopper);
+
+        $export = $this->actingAs($shopper)
+            ->get('http://mine.example.com/account/data-export')
+            ->assertOk()
+            ->json();
+
+        $ids = collect($export['orders'] ?? [])->pluck('id');
+
+        $this->assertTrue($ids->contains($here->id));
+        $this->assertTrue(
+            $ids->contains($elsewhere->id),
+            'The export omitted orders from another store and still called itself complete.',
+        );
+    }
+
+    /**
+     * An erasure that misses rows is a breach that looks like a completed
+     * request. It must not depend on which storefront the person happened to be
+     * logged into when they asked.
+     */
+    public function test_an_erasure_spans_every_store(): void
+    {
+        $mine = $this->storefront('mine.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+        $shopper = User::factory()->create(['password' => bcrypt('password')]);
+
+        $here = $this->orderAt($mine, $shopper);
+        $elsewhere = $this->orderAt($theirs, $shopper);
+
+        $this->actingAs($shopper)
+            ->delete('http://mine.example.com/account', ['password' => 'password'])
+            ->assertRedirect();
+
+        // Orders are kept for accounting and scrubbed in place, so the check is
+        // on the personal data rather than on the row's absence.
+        $scrubbed = StoreContext::acrossAllStores(
+            fn () => Order::whereIn('id', [$here->id, $elsewhere->id])->pluck('customer_email', 'id'),
+        );
+
+        $this->assertNotSame($shopper->email, $scrubbed[$elsewhere->id], 'An order at another store kept the erased email.');
+        $this->assertSame($scrubbed[$here->id], $scrubbed[$elsewhere->id], 'The two stores were erased differently.');
+    }
+
+    /**
+     * The suspension is scoped to the callback. Leaking it would turn one
+     * exempt path into an application-wide hole that nothing would notice.
+     */
+    public function test_the_exemption_does_not_outlive_its_callback(): void
+    {
+        $mine = $this->storefront('mine.example.com');
+        $theirs = $this->storefront('theirs.example.com');
+        $shopper = User::factory()->create();
+
+        $this->orderAt($mine, $shopper);
+        $this->orderAt($theirs, $shopper);
+
+        Sanctum::actingAs($shopper);
+
+        StoreContext::acrossAllStores(fn () => Order::query()->count());
+
+        $this->assertCount(1, $this->getJson('http://mine.example.com/api/orders')->json('data'));
+    }
+
+    private function postStripe(string $host, array $event): TestResponse
+    {
+        $payload = json_encode(array_merge(['id' => 'evt_1', 'object' => 'event', 'created' => time()], $event));
+        $ts = time();
+        $signature = 't='.$ts.',v1='.hash_hmac('sha256', $ts.'.'.$payload, $this->stripeSecret);
+
+        return $this->call(
+            'POST',
+            "http://{$host}/stripe/webhook",
+            [], [], [],
+            ['HTTP_STRIPE_SIGNATURE' => $signature],
+            $payload,
+        );
+    }
+}

--- a/tests/Feature/OrderStoreScopeTest.php
+++ b/tests/Feature/OrderStoreScopeTest.php
@@ -176,7 +176,7 @@ class OrderStoreScopeTest extends TestCase
 
         $this->actingAs($shopper)
             ->delete('http://mine.example.com/account', ['password' => 'password'])
-            ->assertRedirect();
+            ->assertOk();
 
         // Orders are kept for accounting and scrubbed in place, so the check is
         // on the personal data rather than on the row's absence.


### PR DESCRIPTION
`IsStoreScoped` on `Order` and `Customer`. Order history scopes to the resolved store — the data is the shopper's, but the surface belongs to the merchant, or merchant A's support staff see what a customer bought from a competitor.

## The exemptions are the substance

Checking the read paths before putting the scope on is what this step calls for, and it found two places where the request's host says nothing about which store the work is *about* — where scoping would have **been** the bug.

**Inbound payment webhooks.** Stripe posts to one configured endpoint. That hostname resolves to whichever store owns it, never to the store the charge belongs to. Scoped, a `charge.succeeded` for any other store finds no order, takes the `null` branch and returns 200 — money captured, order left pending, and nothing anywhere saying so.

**Subject access and erasure.** Both are about a person rather than a storefront, and both are reachable over HTTP from a storefront that resolves a store. A scoped export returns one merchant's slice and presents it as the whole record — a wrong answer, not a partial one. A scoped erasure misses rows and still reports success, which is a breach that looks like a completed request.

## Why a suspension rather than per-query opt-outs

`StoreContext::acrossAllStores()` suspends the scope for the duration of a callback. `withoutGlobalScope('store')` at each query would not reach these paths: they read through relations — `$user->customer`, `$user->wishlist()` — that no call-site opt-out touches, and every model added to the scope later would need remembering again at each of them.

That is the failure the scope exists to stop. An exemption written the other way reintroduces it inside the fix.

## `store_id` stays unfillable

It is in no `$fillable` on any scoped model. The trait's `creating` hook is its only writer, so no request can post its way into another store.

## Tests

`tests/Feature/OrderStoreScopeTest.php` — history scoped to the resolved store; another store's order not readable by id; a webhook reaching an order at a different store than its own hostname; export spanning; erasure spanning; and the suspension not outliving its callback, since a leaked one would be an application-wide hole nothing would notice.

## Not in this

The remaining eleven `store_id` tables, the panel mode, and `TrustHosts` from channel domains.