### PR TITLE
feat: finish the store-scope sweep, and add the ratchet that keeps it finished

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Traits\IsStoreScoped;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Article extends Model
 {
     use HasFactory;
+    use IsStoreScoped;
 
     public function team()
     {

--- a/app/Models/DownloadableProduct.php
+++ b/app/Models/DownloadableProduct.php
@@ -23,7 +23,7 @@ class DownloadableProduct extends Model
     protected $casts = [
         'expiration_time' => 'datetime',
         'download_limit' => 'integer',
-        'downloads_count' => 'integer'
+        'downloads_count' => 'integer',
     ];
 
     public function product(): BelongsTo
@@ -34,7 +34,7 @@ class DownloadableProduct extends Model
     public function isDownloadable(): bool
     {
         return $this->download_limit > $this->downloads_count
-            && (!$this->expiration_time || $this->expiration_time->isFuture());
+            && (! $this->expiration_time || $this->expiration_time->isFuture());
     }
 
     public function incrementDownloadCount(): void

--- a/app/Models/DownloadableProduct.php
+++ b/app/Models/DownloadableProduct.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\IsStoreScoped;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,7 +10,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class DownloadableProduct extends Model
 {
     use HasFactory;
-    
+    use IsStoreScoped;
+
     protected $fillable = [
         'product_id',
         'file_url',
@@ -31,7 +33,7 @@ class DownloadableProduct extends Model
 
     public function isDownloadable(): bool
     {
-        return $this->download_limit > $this->downloads_count 
+        return $this->download_limit > $this->downloads_count
             && (!$this->expiration_time || $this->expiration_time->isFuture());
     }
 

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Traits\IsStoreScoped;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Group extends Model
 {
     use HasFactory;
+    use IsStoreScoped;
 
     protected $table = 'groups';
 

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Traits\IsStoreScoped;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Invoice extends Model
 {
     use HasFactory;
+    use IsStoreScoped;
 
     protected $table = 'invoices';
 

--- a/app/Models/ProductRating.php
+++ b/app/Models/ProductRating.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Traits\IsStoreScoped;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class ProductRating extends Model
 {
     use HasFactory;
+    use IsStoreScoped;
 
     protected $table = 'product_rating';
 

--- a/app/Models/ProductReview.php
+++ b/app/Models/ProductReview.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Traits\IsStoreScoped;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class ProductReview extends Model
 {
     use HasFactory;
+    use IsStoreScoped;
 
     protected $table = 'product_reviews';
 

--- a/app/Models/Wishlist.php
+++ b/app/Models/Wishlist.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Traits\IsStoreScoped;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Wishlist extends Model
 {
     use HasFactory;
+    use IsStoreScoped;
 
     protected $fillable = ['user_id', 'product_id'];
 

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -227,7 +227,20 @@ Panels keep `->tenant(Team::class, …)`. Switching them to `Store` tenancy woul
 
 **`coupons.code` is globally unique**, so no two merchants can issue the same code today. The scope is right regardless; the index grain is wrong and belongs with wave 2's other grain corrections, not here.
 
-**The rest of the models follow.** Reviews, invoices, wishlists and the other eight tables carry `store_id` already; each needs its own read paths checked the same way. The panel mode — `whereIn` the tenant's stores — is a refinement rather than a control, since panels are already Team-scoped by Filament tenancy.
+**The sweep finished, and is now checked rather than trusted.** Articles, reviews, ratings, invoices, wishlists, groups and downloadable products took the scope; their read paths all run through storefront requests, so none needed an exemption.
+
+Two do not take it, and the reasons are recorded next to the rule rather than in a commit message:
+
+| Model | Why not |
+| --- | --- |
+| `PaymentMethod` | A shopper's saved payment method belongs to the **person**, not the merchant. The column is there because a blanket migration put one on every table with a `team_id`, not because the data is store-grained. Scoped, their card would vanish the moment they shopped on another storefront. |
+| `Channel` | Resolving a channel is what *produces* the scope. Scoping channels by the store a channel resolves is circular — nothing would resolve, so nothing would ever be in scope. |
+
+`images` has no model, so there is nothing to scope.
+
+**`StoreScopeCoverageTest` is the ratchet.** Scoping at the caller failed because it had to be remembered every time; a sweep across sixteen tables has that same shape one level up, and the model that gets missed is the leak. So it is asserted in both directions — a table with `store_id` whose model is unscoped fails, and a scoped model whose table has no `store_id` fails, that second one being #958 exactly: a query naming a column that is not there, breaking only on the paths nobody tested. The exemption list can shrink; adding to it means writing down why.
+
+**Still outstanding in this step:** the panel mode — `whereIn` the tenant's stores — which is a refinement rather than a control, since panels are already Team-scoped by Filament tenancy.
 
 **The surfaces are covered at the surface.** [#950](https://github.com/liberusoftware/ecommerce-laravel/issues/950) and [#952](https://github.com/liberusoftware/ecommerce-laravel/issues/952) name the anonymous GraphQL endpoint and the Blade storefront, not the models, and a scope nothing exercises through the reported surface is a scope the next refactor removes. `/api/graphql` is now driven the way a caller drives it — real `Host`, no token — across the listing, `search`, a known id, and the nested `collections { products }` read, which reaches `Product` through a pivot and so is the path a caller-side fix would have missed. A `collection_items` row pointing at another store's product is a mis-stamped row, not permission: the nested read returns nothing for it.
 

--- a/tests/Feature/StoreScopeCoverageTest.php
+++ b/tests/Feature/StoreScopeCoverageTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Channel;
+use App\Models\PaymentMethod;
+use App\Traits\IsStoreScoped;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+use Throwable;
+
+/**
+ * The ratchet for wave 1.5, step 3.
+ *
+ * Scoping at the caller failed because it had to be remembered every time. A
+ * sweep across sixteen tables has the same shape one level up: it has to be
+ * remembered for every model, and the one that gets missed is the leak. So the
+ * rule is checked rather than trusted.
+ *
+ * Both directions, because both have already gone wrong here:
+ *
+ * - a table with `store_id` whose model is unscoped is an open leak;
+ * - a model scoped against a table with no `store_id` is #958 — a query naming
+ *   a column that is not there, which fails at request time and only for the
+ *   paths nobody tested.
+ */
+class StoreScopeCoverageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Models that carry `store_id` and are deliberately not scoped by it.
+     *
+     * Entries may be removed; adding one means writing down why, which is the
+     * point. A list that can only shrink is the difference between an exemption
+     * and a hole.
+     */
+    private const NOT_SCOPED_BY_STORE = [
+        PaymentMethod::class => 'A shopper\'s saved payment method belongs to the person, not the merchant. '
+            .'The column is there because a blanket migration put it on every table with a `team_id`, '
+            .'not because the data is store-grained. Scoped, their card would disappear the moment they '
+            .'shopped on another storefront.',
+
+        Channel::class => 'Resolving a channel is what produces the scope. Scoping channels by the store '
+            .'the channel resolves is circular: nothing would resolve, so nothing would ever be in scope.',
+    ];
+
+    public function test_every_table_with_a_store_id_has_a_scoped_model_or_a_recorded_reason(): void
+    {
+        $unscoped = [];
+
+        foreach ($this->models() as $class => $table) {
+            if (! Schema::hasColumn($table, 'store_id')) {
+                continue;
+            }
+
+            if (array_key_exists($class, self::NOT_SCOPED_BY_STORE) || $this->isScoped($class)) {
+                continue;
+            }
+
+            $unscoped[] = "{$class} ({$table})";
+        }
+
+        sort($unscoped);
+
+        $this->assertSame([], $unscoped, implode("\n", [
+            'These models sit on a table with a `store_id` and are not scoped by it.',
+            'Either add App\Traits\IsStoreScoped, or record the reason in NOT_SCOPED_BY_STORE',
+            'the way payment_methods is recorded — with the reason, not just the name.',
+        ]));
+    }
+
+    public function test_no_model_is_scoped_against_a_table_that_has_no_store_id(): void
+    {
+        $missing = [];
+
+        foreach ($this->models() as $class => $table) {
+            if ($this->isScoped($class) && ! Schema::hasColumn($table, 'store_id')) {
+                $missing[] = "{$class} ({$table})";
+            }
+        }
+
+        sort($missing);
+
+        $this->assertSame(
+            [],
+            $missing,
+            'These models carry the store scope but their tables have no `store_id`. '
+                .'Every query they make names a column that is not there — the failure #958 was.',
+        );
+    }
+
+    /**
+     * Every model class under app/Models, mapped to its table.
+     *
+     * Resolved through the model rather than guessed from the class name: three
+     * of these tables are named nothing like their model (`collections`,
+     * `product_rating`, `groups`).
+     *
+     * @return array<class-string<Model>, string>
+     */
+    private function models(): array
+    {
+        $tables = [];
+
+        foreach (glob(app_path('Models/*.php')) as $file) {
+            $class = 'App\\Models\\'.basename($file, '.php');
+
+            if (! class_exists($class) || ! is_subclass_of($class, Model::class)) {
+                continue;
+            }
+
+            try {
+                $model = new $class;
+            } catch (Throwable) {
+                // A model that cannot be constructed without arguments is not
+                // something this rule can speak about.
+                continue;
+            }
+
+            $table = $model->getTable();
+
+            if (Schema::hasTable($table)) {
+                $tables[$class] = $table;
+            }
+        }
+
+        return $tables;
+    }
+
+    private function isScoped(string $class): bool
+    {
+        return in_array(IsStoreScoped::class, class_uses_recursive($class), true);
+    }
+}


### PR DESCRIPTION
The last seven store-grained models take `IsStoreScoped`: `Article`, `ProductReview`, `ProductRating`, `Invoice`, `Wishlist`, `Group`, `DownloadableProduct`. Their read paths all run through storefront requests, so unlike orders and customers none of them needs an exemption — checked before the scope went on.

## Two models do not take it

Recorded next to the rule rather than in a commit message nobody will find.

| Model | Why not |
| --- | --- |
| `PaymentMethod` | A shopper's saved payment method belongs to the **person**, not the merchant. The column is there because a blanket migration put one on every table with a `team_id`, not because the data is store-grained. Scoped, their card would vanish the moment they shopped on another storefront. |
| `Channel` | Resolving a channel is what *produces* the scope. Scoping channels by the store a channel resolves is circular — nothing would resolve, so nothing would ever be in scope. |

`images` has no model, so there is nothing to scope.

## The ratchet

Scoping at the caller failed because it had to be remembered every time. A sweep across sixteen tables has the same shape one level up: it has to be remembered for every model, and the one that gets missed is the leak. `StoreScopeCoverageTest` asserts it instead.

Both directions, because both have already gone wrong in this repo:

- a table with `store_id` whose model is unscoped is an open leak;
- a scoped model whose table has no `store_id` is **#958** — a query naming a column that is not there, which fails at request time and only on the paths nobody tested.

Tables are resolved through the model rather than guessed from the class name; three of them are named nothing like their model (`collections`, `product_rating`, `groups`).

The exemption list can shrink. Adding to it means writing down why.

## Remaining in step 3

The panel mode — `whereIn` the tenant's stores. A refinement rather than a control, since panels are already Team-scoped by Filament tenancy.