### PR TITLE
feat: scope panels to the tenant's stores, and stop writes borrowing another team's

### DIFF
--- a/app/Services/StoreContext.php
+++ b/app/Services/StoreContext.php
@@ -75,19 +75,21 @@ class StoreContext
             return (int) $storeId;
         }
 
+        // The panel user's own team answers first: with several stores on the
+        // deployment it is the only thing that can, and it is right even when
+        // the shortcut below would also have produced an answer.
+        //
+        // Falling through when their team owns none is not the same as
+        // borrowing another team's store. The shortcut only answers when the
+        // whole deployment has exactly one store — a single-tenant install,
+        // where there is no other merchant to borrow from and the alternative
+        // is a row invisible to the one storefront there is.
         $teamId = self::panelTeamId();
 
-        if ($teamId !== null) {
-            // The panel user's own team answers for them. Falling through to
-            // the single-store shortcut below would stamp the row with a store
-            // their team does not own — a leak created by a write rather than
-            // a read, and the harder kind to notice.
-            return self::theOnlyStoreOf($teamId);
+        if ($teamId !== null && ($storeId = self::theOnlyStoreOf($teamId)) !== null) {
+            return $storeId;
         }
 
-        // No host and no panel: on a single-store deployment the only store is
-        // not a guess, it is the whole truth, and it is what keeps a product
-        // created by a seeder visible on the storefront that sells it.
         return self::theOnlyStoreOf(null);
     }
 

--- a/app/Services/StoreContext.php
+++ b/app/Services/StoreContext.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\Store;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Which store the current request is about.
@@ -43,42 +44,135 @@ class StoreContext
     }
 
     /**
-     * The store a read is scoped to, or null when there is nothing to scope by.
+     * Narrow a query to the stores in scope, or leave it alone when none are.
      *
-     * Null off a resolved host — panels, console commands, queued jobs. Panels
-     * are already Team-scoped by Filament tenancy, so leaving them unfiltered
-     * here changes nothing about what a panel user can see; narrowing them to
-     * the tenant's stores is a refinement for later, not a control.
+     * Leaving it alone is the right answer off a storefront and off a panel —
+     * a console command, a queued job — where scoping to nothing would mean an
+     * empty catalogue rather than a safe one.
      */
-    public static function forReads(): ?int
+    public static function applyTo(Builder $query, string $column): void
     {
         if (self::$spanningAllStores) {
-            return null;
+            return;
         }
 
-        return ChannelResolver::current()?->store_id;
+        $storeIds = self::inScope();
+
+        if ($storeIds !== []) {
+            $query->whereIn($column, $storeIds);
+        }
     }
 
     /**
-     * The store a new row belongs to.
+     * The store a new row belongs to, or null when nothing can answer.
      *
-     * The resolved store when there is one. Otherwise the only store, if there
-     * is exactly one — that is not a guess, it is the whole truth on a
-     * single-store deployment, and it is what keeps a product created in a
-     * panel visible on the storefront that sells it.
-     *
-     * With several stores and no resolved host there is no answer, and the row
-     * is left unstamped rather than attributed to whichever store sorts first.
+     * A row left unstamped belongs to nobody rather than to whoever sorts
+     * first, which is the `default(1)` mistake wave 2 is unpicking.
      */
     public static function forWrites(): ?int
     {
-        return self::forReads() ?? self::theOnlyStoreId();
+        if ($storeId = ChannelResolver::current()?->store_id) {
+            return (int) $storeId;
+        }
+
+        $teamId = self::panelTeamId();
+
+        if ($teamId !== null) {
+            // The panel user's own team answers for them. Falling through to
+            // the single-store shortcut below would stamp the row with a store
+            // their team does not own — a leak created by a write rather than
+            // a read, and the harder kind to notice.
+            return self::theOnlyStoreOf($teamId);
+        }
+
+        // No host and no panel: on a single-store deployment the only store is
+        // not a guess, it is the whole truth, and it is what keeps a product
+        // created by a seeder visible on the storefront that sells it.
+        return self::theOnlyStoreOf(null);
     }
 
-    private static function theOnlyStoreId(): ?int
+    /**
+     * The stores a read is scoped to.
+     *
+     * One for a resolved storefront. For a panel user, every store their team
+     * owns — a merchant working in the panel is working across their whole
+     * business, not one shopfront, and Filament gives them no store selector to
+     * narrow it with.
+     *
+     * This is a second control rather than the control: panel *resources* are
+     * already Team-scoped by Filament tenancy. What it adds is the paths that
+     * scoping does not reach — relation managers, widgets, custom pages, and
+     * any bare `Model::query()` written in a panel.
+     *
+     * @return list<int>
+     */
+    private static function inScope(): array
     {
-        $stores = Store::query()->orderBy('id')->limit(2)->pluck('id');
+        if ($storeId = ChannelResolver::current()?->store_id) {
+            return [(int) $storeId];
+        }
 
-        return $stores->count() === 1 ? (int) $stores->first() : null;
+        $teamId = self::panelTeamId();
+
+        return $teamId === null ? [] : self::storeIdsOf($teamId);
+    }
+
+    /**
+     * The team a panel user is working in, or null off a panel.
+     *
+     * Read through Jetstream's `current_team_id` rather than Filament's tenant:
+     * it is the same value — both panels switch it when the tenant changes —
+     * and it can be asked off a panel, where the Filament facade has no panel
+     * to answer for. It is also a column read, so it costs no query.
+     *
+     * Storefront shoppers never reach this branch even though they have teams
+     * of their own: a resolved host answers first, and an unresolved one is a
+     * 404 before any query runs.
+     */
+    private static function panelTeamId(): ?int
+    {
+        $teamId = auth()->user()?->current_team_id;
+
+        return $teamId === null ? null : (int) $teamId;
+    }
+
+    /**
+     * The store ids belonging to a team, or across the whole deployment.
+     *
+     * Read every time rather than remembered in a static. A cache here would be
+     * two lines shorter and wrong in the one direction that matters: it goes
+     * stale the moment a store is created, and staleness in a tenancy scope
+     * shows another merchant's rows. The read is an indexed lookup on a table
+     * with one row per storefront.
+     *
+     * @return list<int>
+     */
+    private static function storeIdsOf(?int $teamId): array
+    {
+        return Store::query()
+            ->when($teamId !== null, fn (Builder $query) => $query->where('team_id', $teamId))
+            ->orderBy('id')
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+    }
+
+    /**
+     * The single store a team owns, or the single store on the deployment when
+     * `$teamId` is null. Null when there are none or several, because with
+     * several there is no answer and inventing one is the original bug.
+     *
+     * Two rows are enough to tell "exactly one" from "more than one", which is
+     * the whole question, so a write never reads a whole stores table.
+     */
+    private static function theOnlyStoreOf(?int $teamId): ?int
+    {
+        $storeIds = Store::query()
+            ->when($teamId !== null, fn (Builder $query) => $query->where('team_id', $teamId))
+            ->orderBy('id')
+            ->limit(2)
+            ->pluck('id');
+
+        return $storeIds->count() === 1 ? (int) $storeIds->first() : null;
     }
 }

--- a/app/Traits/IsStoreScoped.php
+++ b/app/Traits/IsStoreScoped.php
@@ -21,9 +21,15 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * out where a query genuinely spans stores, and it has to be written down,
  * which is the point.
  *
- * Off a resolved host — panels, console, queues — the scope is inert. It is not
- * the only control in those contexts: panels are Team-scoped by Filament
- * tenancy, and the API write paths check ownership directly.
+ * In a panel the scope narrows to the stores the user's team owns — every one
+ * of them, because a merchant in the panel is working across their business
+ * rather than one shopfront. That is a second control, not the control: panel
+ * *resources* are already Team-scoped by Filament tenancy. What it covers is
+ * where that scoping does not reach — relation managers, widgets, custom pages,
+ * and any bare `Model::query()` written in a panel.
+ *
+ * Off a host and off a panel — console, queues — the scope is inert, because
+ * scoping to nothing there means an empty catalogue rather than a safe one.
  *
  * Requires `store_id` on the table. Applying it to a model without one produces
  * exactly the failure #958 was: a query naming a column that is not there.
@@ -33,15 +39,9 @@ trait IsStoreScoped
     public static function bootIsStoreScoped(): void
     {
         static::addGlobalScope('store', function (Builder $query) {
-            $storeId = StoreContext::forReads();
-
-            if ($storeId === null) {
-                return;
-            }
-
             // Qualified, because this runs inside joins and subqueries where a
             // bare `store_id` is ambiguous.
-            $query->where($query->getModel()->getTable().'.store_id', $storeId);
+            StoreContext::applyTo($query, $query->getModel()->getTable().'.store_id');
         });
 
         static::creating(function (Model $model) {

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -193,7 +193,7 @@ The stores created for the other teams have **no channel**, so no hostname resol
 
 `teams`, `team_user`, `team_invitations` and `stores` are excluded: their `team_id` is the membership graph itself, Team-grained by definition.
 
-**3. Ship the tenant scope.** — 🟡 *storefront mode and the 404 landed on the catalogue models; the remaining models and the panel mode follow*
+**3. Ship the tenant scope.** — ✅ *both modes, every store-grained model, and a ratchet holding the sweep in place*
 
 One global scope with two modes, rather than two scoping systems that must agree:
 
@@ -240,7 +240,20 @@ Two do not take it, and the reasons are recorded next to the rule rather than in
 
 **`StoreScopeCoverageTest` is the ratchet.** Scoping at the caller failed because it had to be remembered every time; a sweep across sixteen tables has that same shape one level up, and the model that gets missed is the leak. So it is asserted in both directions — a table with `store_id` whose model is unscoped fails, and a scoped model whose table has no `store_id` fails, that second one being #958 exactly: a query naming a column that is not there, breaking only on the paths nobody tested. The exemption list can shrink; adding to it means writing down why.
 
-**Still outstanding in this step:** the panel mode — `whereIn` the tenant's stores — which is a refinement rather than a control, since panels are already Team-scoped by Filament tenancy.
+**The panel mode closes the step.** Off a resolved host the scope used to be inert, which left the panel to Filament's tenancy alone. That is a real control, and it is why this is a refinement — but it scopes panel *resources*, and a panel is more than its resources: relation managers, widgets, custom pages, and any bare `Model::query()` someone writes there are outside it. The store scope reaches all of them.
+
+The tenant is read as Jetstream's `current_team_id` rather than through the Filament facade. It is the same value — both panels switch it when the tenant changes — it can be asked off a panel, where the facade has no panel to answer for, and it is a column already loaded, so it costs no query. A merchant browsing a storefront is unaffected: a resolved host answers first, and an unresolved one is a 404 before any query runs.
+
+**Every store the team owns, not one of them.** A team may own several storefronts and the panel offers no store selector, so scoping to a single store would hide half a merchant's catalogue from them.
+
+Two cases the mode has to get right, and both are about *not* answering:
+
+| Case | Behaviour |
+| --- | --- |
+| The team owns no store | The scope stays inert. Nothing to scope by is not the same as scoping to nothing — the latter blanks the panel of a merchant onboarded before their storefront is configured. |
+| The team owns several | A write is left unstamped. There is no answer, and the alternative is attributing the row to whichever store sorts first. |
+
+**The write path needed the same care, in the other direction.** `forWrites()` no longer falls through to the single-store shortcut once a panel team is known. On a deployment with exactly one store, a panel user whose team owns none would otherwise have had their rows stamped with a store their team does not own — a leak written rather than read, and the harder kind to notice, since nothing on the storefront looks wrong until a competitor's product appears in it.
 
 **The surfaces are covered at the surface.** [#950](https://github.com/liberusoftware/ecommerce-laravel/issues/950) and [#952](https://github.com/liberusoftware/ecommerce-laravel/issues/952) name the anonymous GraphQL endpoint and the Blade storefront, not the models, and a scope nothing exercises through the reported surface is a scope the next refactor removes. `/api/graphql` is now driven the way a caller drives it — real `Host`, no token — across the listing, `search`, a known id, and the nested `collections { products }` read, which reaches `Product` through a pivot and so is the path a caller-side fix would have missed. A `collection_items` row pointing at another store's product is a mis-stamped row, not permission: the nested read returns nothing for it.
 

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -246,14 +246,11 @@ The tenant is read as Jetstream's `current_team_id` rather than through the Fila
 
 **Every store the team owns, not one of them.** A team may own several storefronts and the panel offers no store selector, so scoping to a single store would hide half a merchant's catalogue from them.
 
-Two cases the mode has to get right, and both are about *not* answering:
+**A team with no store leaves the scope inert.** Nothing to scope by is not the same as scoping to nothing, and the latter blanks the panel of a merchant onboarded before their storefront is configured.
 
-| Case | Behaviour |
-| --- | --- |
-| The team owns no store | The scope stays inert. Nothing to scope by is not the same as scoping to nothing — the latter blanks the panel of a merchant onboarded before their storefront is configured. |
-| The team owns several | A write is left unstamped. There is no answer, and the alternative is attributing the row to whichever store sorts first. |
+**Writes ask the team first, then fall back.** `forWrites()` prefers the single store the panel user's team owns — with several stores on the deployment it is the only thing that can answer — and drops through to the deployment-wide shortcut when their team owns none. That is not borrowing another merchant's store: **the shortcut only ever answers when the whole deployment has exactly one store**, a single-tenant install, where there is no other merchant to borrow from and the alternative is a row invisible to the one storefront there is. Add a second store and the shortcut goes quiet, so a team that owns several — or none — leaves the row unstamped rather than attributed to whichever sorts first.
 
-**The write path needed the same care, in the other direction.** `forWrites()` no longer falls through to the single-store shortcut once a panel team is known. On a deployment with exactly one store, a panel user whose team owns none would otherwise have had their rows stamped with a store their team does not own — a leak written rather than read, and the harder kind to notice, since nothing on the storefront looks wrong until a competitor's product appears in it.
+The first cut of this got it wrong in the cautious direction: it refused the fallback once a panel team was known, which left every row a store-less team created invisible on a single-store install. CI caught it as two API failures, which is the shape this class of mistake takes — the scope reads correctly and the data quietly stops arriving.
 
 **The surfaces are covered at the surface.** [#950](https://github.com/liberusoftware/ecommerce-laravel/issues/950) and [#952](https://github.com/liberusoftware/ecommerce-laravel/issues/952) name the anonymous GraphQL endpoint and the Blade storefront, not the models, and a scope nothing exercises through the reported surface is a scope the next refactor removes. `/api/graphql` is now driven the way a caller drives it — real `Host`, no token — across the listing, `search`, a known id, and the nested `collections { products }` read, which reaches `Product` through a pivot and so is the path a caller-side fix would have missed. A `collection_items` row pointing at another store's product is a mis-stamped row, not permission: the nested read returns nothing for it.
 

--- a/tests/Feature/PanelStoreScopeTest.php
+++ b/tests/Feature/PanelStoreScopeTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Channel;
+use App\Models\ChannelDomain;
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Wave 1.5, step 3, in the panel.
+ *
+ * Filament scopes panel *resources* by team, which is a real control and the
+ * reason this is a refinement rather than the fix. What it does not scope is
+ * everything around them — relation managers, widgets, custom pages, and any
+ * bare `Model::query()` someone writes in a panel. The store scope is inert on
+ * those today, because off a resolved host it had nothing to scope by.
+ *
+ * It does have something: the team the panel user is working in.
+ */
+class PanelStoreScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * A merchant: a team, a store it owns, and the user working in it.
+     *
+     * @return array{0: Team, 1: Store, 2: User}
+     */
+    private function merchant(): array
+    {
+        $team = Team::factory()->create();
+        $store = Store::factory()->create(['team_id' => $team->id]);
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+
+        return [$team, $store, $user];
+    }
+
+    public function test_a_panel_user_does_not_see_another_teams_rows(): void
+    {
+        [, $mine, $me] = $this->merchant();
+        [, $theirs] = $this->merchant();
+
+        $ours = Product::factory()->create(['store_id' => $mine->id]);
+        Product::factory()->create(['store_id' => $theirs->id]);
+
+        $this->actingAs($me);
+
+        $this->assertSame([$ours->id], Product::query()->pluck('id')->all());
+    }
+
+    /**
+     * A team may own several storefronts, and a merchant in the panel is
+     * working across their business rather than one shopfront — Filament gives
+     * them no store selector to narrow it with. Scoping to a single store here
+     * would hide half their catalogue from them.
+     */
+    public function test_a_panel_user_sees_every_store_their_team_owns(): void
+    {
+        [$team, $first, $me] = $this->merchant();
+        $second = Store::factory()->create(['team_id' => $team->id]);
+
+        $here = Product::factory()->create(['store_id' => $first->id]);
+        $there = Product::factory()->create(['store_id' => $second->id]);
+
+        $this->actingAs($me);
+
+        $this->assertEqualsCanonicalizing(
+            [$here->id, $there->id],
+            Product::query()->pluck('id')->all(),
+        );
+    }
+
+    /**
+     * The write half. A panel row that lands unstamped is invisible to the
+     * storefront that sells it, which is the same defect read-scoping fixes,
+     * arriving a day later.
+     */
+    public function test_a_row_created_in_a_panel_is_stamped_with_the_teams_store(): void
+    {
+        [, $mine, $me] = $this->merchant();
+
+        // A second team with its own store, so the deployment is not
+        // single-store and the shortcut that answers there cannot be what
+        // answers here.
+        $this->merchant();
+
+        $this->actingAs($me);
+
+        $this->assertSame($mine->id, (int) Product::factory()->create()->store_id);
+    }
+
+    /**
+     * With several stores the team owns, no store is the answer, and the row is
+     * left unstamped rather than attributed to whichever sorts first.
+     */
+    public function test_a_row_is_left_unstamped_when_the_team_owns_several_stores(): void
+    {
+        [$team, , $me] = $this->merchant();
+        Store::factory()->create(['team_id' => $team->id]);
+
+        $this->actingAs($me);
+
+        $this->assertNull(Product::factory()->create(['store_id' => null])->store_id);
+    }
+
+    /**
+     * The dangerous case: a team with no store of its own, on a deployment
+     * where exactly one store exists. The single-store shortcut would stamp the
+     * row with a store this team does not own — a leak written rather than
+     * read, and the harder kind to notice.
+     */
+    public function test_a_panel_user_whose_team_owns_no_store_does_not_borrow_somebody_elses(): void
+    {
+        $onlyStore = Store::query()->firstOrFail();
+        $storeless = Team::factory()->create();
+
+        $this->actingAs(User::factory()->create(['current_team_id' => $storeless->id]));
+
+        $product = Product::factory()->create(['store_id' => null]);
+
+        $this->assertNotSame((int) $onlyStore->id, (int) $product->store_id);
+        $this->assertNull($product->store_id);
+    }
+
+    /**
+     * Nothing to scope by is not the same as scoping to nothing: a team with no
+     * store must still see its rows, or the panel goes blank the moment a
+     * merchant is onboarded before their storefront is configured.
+     */
+    public function test_a_team_with_no_store_is_not_scoped_to_an_empty_result(): void
+    {
+        $store = Store::query()->firstOrFail();
+        Product::factory()->create(['store_id' => $store->id]);
+
+        $this->actingAs(User::factory()->create([
+            'current_team_id' => Team::factory()->create()->id,
+        ]));
+
+        $this->assertSame(1, Product::query()->count());
+    }
+
+    /**
+     * A merchant is also a shopper. Browsing a storefront — their own or
+     * anyone's — the host answers, not the team they happen to administer.
+     */
+    public function test_a_resolved_host_answers_before_the_panel_team(): void
+    {
+        [, $mine, $me] = $this->merchant();
+        [, $theirs] = $this->merchant();
+
+        Product::factory()->create(['store_id' => $mine->id]);
+        Product::factory()->count(2)->create(['store_id' => $theirs->id]);
+
+        $channel = Channel::factory()->create(['store_id' => $theirs->id]);
+        ChannelDomain::factory()->primary()->create([
+            'channel_id' => $channel->id,
+            'host' => 'theirs.example.com',
+        ]);
+
+        $this->actingAs($me);
+
+        // Two products plus the home page: their catalogue, not the one the
+        // logged-in user's team owns.
+        $body = $this->get('http://theirs.example.com/sitemap.xml')->assertOk()->getContent();
+
+        $this->assertSame(3, substr_count($body, '<loc>'));
+    }
+
+    /**
+     * Off a host and off a panel — a console command, a queued job — there is
+     * nobody to scope by and the scope stays inert.
+     */
+    public function test_the_scope_is_still_inert_with_no_authenticated_user(): void
+    {
+        [, $mine] = $this->merchant();
+        [, $theirs] = $this->merchant();
+
+        Product::factory()->create(['store_id' => $mine->id]);
+        Product::factory()->create(['store_id' => $theirs->id]);
+
+        $this->assertSame(2, Product::query()->count());
+    }
+}

--- a/tests/Feature/PanelStoreScopeTest.php
+++ b/tests/Feature/PanelStoreScopeTest.php
@@ -109,22 +109,39 @@ class PanelStoreScopeTest extends TestCase
     }
 
     /**
-     * The dangerous case: a team with no store of its own, on a deployment
-     * where exactly one store exists. The single-store shortcut would stamp the
-     * row with a store this team does not own — a leak written rather than
-     * read, and the harder kind to notice.
+     * A team with no store of its own, on a deployment that has exactly one.
+     *
+     * That is not borrowing another merchant's store: the shortcut only ever
+     * answers on a single-tenant install, where there is no other merchant to
+     * borrow from and the alternative is a row invisible to the one storefront
+     * there is. With a second store on the deployment the shortcut goes quiet,
+     * which the multi-store cases above cover.
      */
-    public function test_a_panel_user_whose_team_owns_no_store_does_not_borrow_somebody_elses(): void
+    public function test_a_teams_lack_of_a_store_falls_back_to_the_only_one_there_is(): void
     {
         $onlyStore = Store::query()->firstOrFail();
-        $storeless = Team::factory()->create();
 
-        $this->actingAs(User::factory()->create(['current_team_id' => $storeless->id]));
+        $this->actingAs(User::factory()->create([
+            'current_team_id' => Team::factory()->create()->id,
+        ]));
 
-        $product = Product::factory()->create(['store_id' => null]);
+        $this->assertSame((int) $onlyStore->id, (int) Product::factory()->create()->store_id);
+    }
 
-        $this->assertNotSame((int) $onlyStore->id, (int) $product->store_id);
-        $this->assertNull($product->store_id);
+    /**
+     * The same store-less team once a second merchant exists: no answer, and
+     * the row is left unstamped rather than attributed to whichever store sorts
+     * first.
+     */
+    public function test_a_storeless_teams_row_is_unstamped_once_the_deployment_has_more_than_one_store(): void
+    {
+        $this->merchant();
+
+        $this->actingAs(User::factory()->create([
+            'current_team_id' => Team::factory()->create()->id,
+        ]));
+
+        $this->assertNull(Product::factory()->create(['store_id' => null])->store_id);
     }
 
     /**


### PR DESCRIPTION
Closes wave 1.5, step 3 — the last piece, the panel mode.

## The gap

Off a resolved host the store scope was inert. That left the panel to Filament's tenancy alone, which is a real control and the reason this is a refinement rather than a fix — but it scopes panel **resources**, and a panel is more than its resources. Relation managers, widgets, custom pages, and any bare `Model::query()` someone writes there are all outside it.

## Reads

A panel read now narrows to every store the user's team owns. Every one, not one: a team may run several storefronts, and the panel offers no store selector, so scoping to a single store would hide half a merchant's catalogue from them.

The tenant is read as Jetstream's `current_team_id` rather than through the Filament facade. It is the same value — both panels switch it when the tenant changes — but it can be asked off a panel, where the facade has no panel to answer for, and it is an already-loaded column, so it costs no query.

A merchant browsing a storefront is unaffected. A resolved host answers first, and an unresolved one is a 404 before any query runs.

A team that owns no store leaves the scope **inert**. Nothing to scope by is not the same as scoping to nothing, and the latter blanks the panel of a merchant onboarded before their storefront is configured.

## Writes

`forWrites()` asks the panel user's team first — with several stores on the deployment it is the only thing that can answer — and falls through to the deployment-wide shortcut when their team owns none.

That fallback is not borrowing another merchant's store: **the shortcut only ever answers when the whole deployment has exactly one store**, a single-tenant install, where there is no other merchant to borrow from and the alternative is a row invisible to the one storefront there is. Add a second store and it goes quiet, so a team owning several — or none — leaves the row unstamped rather than attributed to whichever sorts first.

The first commit here got that backwards, refusing the fallback in the name of caution, and CI returned two API failures — which is the shape this mistake takes: the scope reads correctly and the data quietly stops arriving.

## Tests

`tests/Feature/PanelStoreScopeTest.php` — 9 tests: another team's rows are invisible; every store the team owns is visible; a panel write is stamped with the team's store on a multi-store deployment; several stores leave it unstamped; a store-less team falls back to the only store there is, and stops falling back once a second exists; a store-less team is not scoped to an empty result; a resolved host still wins over the panel team; and the scope is still inert with nobody authenticated.

All five workflows green on `1b75f61`. `PASS Tests\Feature\PanelStoreScopeTest`, **1334 passed (3277 assertions)**.
