### PR TITLE
feat: derive TrustHosts from the channel domains, and switch it on

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -10,6 +10,7 @@ use App\Http\Middleware\ResolveChannel;
 use App\Http\Middleware\SecurityHeaders;
 use App\Http\Middleware\TeamsPermission;
 use App\Http\Middleware\TrimStrings;
+use App\Http\Middleware\TrustHosts;
 use App\Http\Middleware\TrustProxies;
 use App\Http\Middleware\ValidateSignature;
 use App\Http\Middleware\VerifyCsrfToken;
@@ -40,7 +41,10 @@ class Kernel extends HttpKernel
      * @var array<int, class-string|string>
      */
     protected $middleware = [
-        // \App\Http\Middleware\TrustHosts::class,
+        // First, because everything after it reads the host it validates.
+        // Inert in local and under tests — Laravel only specifies trusted hosts
+        // outside them.
+        TrustHosts::class,
         TrustProxies::class,
         HandleCors::class,
         PreventRequestsDuringMaintenance::class,

--- a/app/Http/Middleware/TrustHosts.php
+++ b/app/Http/Middleware/TrustHosts.php
@@ -2,19 +2,95 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\ChannelDomain;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\Middleware\TrustHosts as Middleware;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
+/**
+ * Which hostnames this deployment answers on.
+ *
+ * Tenancy is resolved from the `Host` header, which is what makes the header
+ * security-relevant here rather than merely untidy: it selects the store, and
+ * every absolute URL the application generates from it — password resets,
+ * canonicals, webhook callbacks — carries whatever it said.
+ *
+ * The list is the channel domains, which is the same table `ChannelResolver`
+ * reads. A second hand-maintained list of the same hostnames drifts, and both
+ * directions of drift are outages: a live storefront answering 400, or a host
+ * trusted that resolves to nothing.
+ */
 class TrustHosts extends Middleware
 {
     /**
-     * Get the host patterns that should be trusted.
+     * Cleared by `ChannelDomain` on write. Public because the model that
+     * invalidates it should name the thing it invalidates.
+     */
+    public const CACHE_KEY = 'trusted-hosts';
+
+    /**
+     * `/health` is exempt, for the same reason it is exempt from the
+     * unresolved-host 404: a Kubernetes probe arrives on the pod's own address
+     * rather than on any configured hostname, and refusing it restarts healthy
+     * pods. It generates no URLs and reads no tenant data, so there is nothing
+     * for a forged header to reach.
      *
+     * `$next` is untyped to match the parent, which declares it untyped.
+     * Narrowing it to `Closure` is a fatal at class load, not a warning at the
+     * call — and a global middleware that cannot be loaded takes down every
+     * request there is.
+     */
+    public function handle(Request $request, $next)
+    {
+        if ($request->is('health')) {
+            return $next($request);
+        }
+
+        return parent::handle($request, $next);
+    }
+
+    /**
      * @return array<int, string|null>
      */
     public function hosts(): array
     {
-        return [
-            $this->allSubdomainsOfApplicationUrl(),
-        ];
+        return array_merge(
+            // Kept alongside the channel domains rather than replaced by them.
+            // It is what answers in the window between deploying and running
+            // migrations, and on a deployment whose panel sits on a hostname no
+            // storefront resolves. It widens the trusted set without widening
+            // what resolves: `ResolveChannel` still 404s a host that belongs to
+            // no channel.
+            [$this->allSubdomainsOfApplicationUrl()],
+            $this->channelDomainPatterns(),
+        );
+    }
+
+    /**
+     * Every configured hostname, as an anchored literal.
+     *
+     * Symfony matches trusted hosts as patterns, so the hostname is quoted
+     * before it is anchored — an unescaped `.` matches any character, and
+     * `shop.example.com` would then trust `shopxexample.com`, which somebody
+     * can register.
+     *
+     * @return array<int, string>
+     */
+    private function channelDomainPatterns(): array
+    {
+        try {
+            return Cache::rememberForever(self::CACHE_KEY, fn () => ChannelDomain::query()
+                ->orderBy('host')
+                ->pluck('host')
+                ->map(fn (string $host) => '^'.preg_quote($host).'$')
+                ->all());
+        } catch (QueryException) {
+            // An unreachable or unmigrated database trusts what it did before
+            // there was a table to read, rather than trusting nothing. This
+            // runs in front of every request, and the alternative is a
+            // deployment that cannot serve the page that says it is broken.
+            return [];
+        }
     }
 }

--- a/app/Models/ChannelDomain.php
+++ b/app/Models/ChannelDomain.php
@@ -2,9 +2,11 @@
 
 namespace App\Models;
 
+use App\Http\Middleware\TrustHosts;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Cache;
 
 /**
  * One hostname a Channel answers on. Hostname only — no scheme, no port.
@@ -16,6 +18,19 @@ class ChannelDomain extends Model
     protected $fillable = ['channel_id', 'host', 'is_primary'];
 
     protected $casts = ['is_primary' => 'boolean'];
+
+    /**
+     * The trusted-host list is this table, cached. Clearing it here rather than
+     * at the call sites that add domains is the same rule the store scope
+     * follows: a cache invalidated by whoever remembers is a cache that goes
+     * stale, and stale here means a merchant adds a domain and their storefront
+     * answers 400 until something else happens to clear it.
+     */
+    protected static function booted(): void
+    {
+        static::saved(fn () => Cache::forget(TrustHosts::CACHE_KEY));
+        static::deleted(fn () => Cache::forget(TrustHosts::CACHE_KEY));
+    }
 
     public function channel(): BelongsTo
     {

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -170,7 +170,7 @@ Three decisions collided:
 
 ### The wave, in order
 
-**1. Create the schema and resolve merchants.** — 🟡 *schema, models, resolver and middleware landed; enforcement and `TrustHosts` still to come*
+**1. Create the schema and resolve merchants.** — ✅ *schema, models, resolver, middleware, the 404, and `TrustHosts` reading the same table*
 
 - `stores`, `channels`, `channel_domains` — many hostnames per channel, one flagged **primary** for canonicals. A storefront realistically answers on the apex, `www`, a custom merchant domain and a platform subdomain on day one; a single `domain` column pushes apex/`www` handling into web-server config the application cannot see, so the canonical the app generates and the host the request arrived on can disagree.
 - `Channel` gains a **theme reference**, defaulting to `theme-ecommerce`. One storefront, theme selected per resolved channel; per-merchant themes are later children with `parent: ecommerce`.
@@ -182,6 +182,20 @@ Three decisions collided:
 **The 404 did not land, on purpose.** A control that refuses unconfigured hosts, shipped into environments where no host is configured yet, takes every storefront down at once — and before the tenant scope exists it guards nothing anyway. Data first, control second, which is the same order wave 2 uses for the backfill. It flips in the same change as step 3.
 
 That initial-channel migration is not the fallback this wave rules out. A fallback answers for hosts nobody configured; this configures the host the deployment already answers on, which on a single-store deployment is the whole truth. It refuses to run if any store or channel already exists, so it can never claim hostnames from a deployment set up by hand.
+
+**`TrustHosts` now reads the channel domains, and is switched on.** It had been commented out of the global stack entirely, which trusts every `Host` header there is. Two lists of the same hostnames drift, and both directions of drift are outages — a live storefront answering 400, or a host trusted that resolves to nothing — so there is one list, and it is the table `ChannelResolver` already reads.
+
+Three things it does not do, each on purpose:
+
+| | |
+| --- | --- |
+| It does not drop `allSubdomainsOfApplicationUrl()` | That is what answers between deploying and running migrations, and on a deployment whose panel sits on a hostname no storefront resolves. It widens what is **trusted**, not what **resolves** — `ResolveChannel` still 404s a host belonging to no channel. |
+| It does not apply to `/health` | The same exemption the 404 has, for the same reason: a probe arrives on the pod's own address, and refusing it restarts healthy pods. It generates no URLs and reads no tenant data, so a forged header reaches nothing. |
+| It does not fail closed on a broken database | The read is wrapped, and an unreachable or unmigrated database trusts what it did before there was a table to read. This runs in front of every request, and failing closed means a deployment that cannot serve the page saying it is broken. |
+
+Hostnames are quoted before they are anchored. Symfony matches trusted hosts as patterns, and an unescaped `.` matches any character — `shop.example.com` unquoted trusts `shopxexample.com`, which somebody can register, point here, and collect password-reset links from.
+
+The list is cached and cleared by `ChannelDomain` itself on save and delete, rather than by whoever remembers to. **Mass deletes bypass it**, as they bypass every model event: `ChannelDomain::query()->delete()` leaves the removed hostname trusted until the cache is cleared some other way. Nothing in the application does that today; it is worth knowing before something does.
 
 **2. Backfill `store_id` alone.** — ✅ **done**
 

--- a/tests/Feature/TrustedHostsTest.php
+++ b/tests/Feature/TrustedHostsTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\TrustHosts;
+use App\Models\Channel;
+use App\Models\ChannelDomain;
+use App\Models\Store;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+/**
+ * Wave 1.5, step 1: the trusted-host list is the channel domains.
+ *
+ * Tenancy is resolved from the `Host` header, which is what makes the header
+ * security-relevant rather than merely untidy — it selects the store, and every
+ * absolute URL generated from it carries whatever it said. A second
+ * hand-maintained list of the same hostnames drifts, and both directions of
+ * drift are outages: a live storefront answering 400, or a host trusted that
+ * resolves to nothing.
+ *
+ * Laravel only *applies* trusted hosts outside local and tests, so what is
+ * exercised here is the list itself and the cache in front of it.
+ */
+class TrustedHostsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function domain(string $host): ChannelDomain
+    {
+        $store = Store::factory()->create();
+        $channel = Channel::factory()->create(['store_id' => $store->id]);
+
+        return ChannelDomain::factory()->create(['channel_id' => $channel->id, 'host' => $host]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function patterns(): array
+    {
+        return array_values(array_filter(app(TrustHosts::class)->hosts()));
+    }
+
+    private function isTrusted(string $host): bool
+    {
+        foreach ($this->patterns() as $pattern) {
+            if (preg_match('{'.$pattern.'}i', $host) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function test_a_configured_channel_domain_is_trusted(): void
+    {
+        $this->domain('shop.example.com');
+
+        $this->assertTrue($this->isTrusted('shop.example.com'));
+    }
+
+    public function test_a_hostname_nobody_configured_is_not_trusted(): void
+    {
+        $this->domain('shop.example.com');
+
+        $this->assertFalse($this->isTrusted('attacker.example.net'));
+    }
+
+    /**
+     * The dot is the whole reason these are quoted. Unescaped it matches any
+     * character, so `shop.example.com` would trust `shopxexample.com` — a
+     * hostname somebody can register, pointed at this deployment, generating
+     * password-reset links that leave with it.
+     */
+    public function test_a_dot_in_a_hostname_is_not_a_wildcard(): void
+    {
+        $this->domain('shop.example.com');
+
+        $this->assertFalse($this->isTrusted('shopxexample.com'));
+    }
+
+    /**
+     * Anchored at both ends: a trusted hostname must be the whole host, not a
+     * substring of somebody else's.
+     */
+    public function test_a_trusted_hostname_inside_a_longer_one_is_not_trusted(): void
+    {
+        $this->domain('shop.example.com');
+
+        $this->assertFalse($this->isTrusted('shop.example.com.attacker.net'));
+        $this->assertFalse($this->isTrusted('notshop.example.com'));
+    }
+
+    /**
+     * The list is cached in front of a table read that would otherwise run on
+     * every request. A merchant adding a domain whose storefront then answers
+     * 400 until something else clears the cache is the failure this prevents.
+     */
+    public function test_adding_a_domain_makes_it_trusted_immediately(): void
+    {
+        $this->domain('first.example.com');
+
+        // Warm the cache with a list that does not contain the new host.
+        $this->assertFalse($this->isTrusted('second.example.com'));
+
+        $this->domain('second.example.com');
+
+        $this->assertTrue($this->isTrusted('second.example.com'));
+    }
+
+    public function test_removing_a_domain_stops_it_being_trusted(): void
+    {
+        $domain = $this->domain('gone.example.com');
+
+        $this->assertTrue($this->isTrusted('gone.example.com'));
+
+        $domain->delete();
+
+        $this->assertFalse($this->isTrusted('gone.example.com'));
+    }
+
+    /**
+     * Renaming is a `saved` rather than a `created`, and the old hostname has
+     * to stop being trusted at the same moment the new one starts.
+     */
+    public function test_renaming_a_domain_moves_the_trust_with_it(): void
+    {
+        $domain = $this->domain('old.example.com');
+
+        $this->assertTrue($this->isTrusted('old.example.com'));
+
+        $domain->update(['host' => 'new.example.com']);
+
+        $this->assertTrue($this->isTrusted('new.example.com'));
+        $this->assertFalse($this->isTrusted('old.example.com'));
+    }
+
+    /**
+     * The application's own URL stays in the list rather than being replaced by
+     * the table. It is what answers in the window between deploying and running
+     * migrations, and on a deployment whose panel sits on a hostname no
+     * storefront resolves. It widens what is *trusted*, not what *resolves* —
+     * `ResolveChannel` still 404s a host belonging to no channel.
+     */
+    public function test_the_application_url_is_trusted_with_no_domains_configured(): void
+    {
+        ChannelDomain::query()->delete();
+        Cache::forget(TrustHosts::CACHE_KEY);
+
+        $this->assertTrue($this->isTrusted(parse_url(config('app.url'), PHP_URL_HOST)));
+    }
+}


### PR DESCRIPTION
Finishes wave 1.5, step 1 — the last piece, `TrustHosts`.

## The gap

`TrustHosts` was commented out of the global stack, which trusts every `Host` header there is. That header is not decoration here: it selects the store, and every absolute URL generated from it — password resets, canonicals, webhook callbacks — carries whatever it said.

The trusted list is now the `channel_domains` table, which is the same table `ChannelResolver` reads. A second hand-maintained list of the same hostnames drifts, and both directions of drift are outages: a live storefront answering 400, or a host trusted that resolves to nothing.

## Hostnames are quoted before they are anchored

Symfony matches trusted hosts as **patterns**. An unescaped `.` matches any character, so `shop.example.com` unquoted also trusts `shopxexample.com` — a hostname somebody can register, point here, and collect password-reset links from. Two of the tests are that specific case and the substring case.

## Three deliberate non-behaviours

| | |
| --- | --- |
| It does not drop `allSubdomainsOfApplicationUrl()` | That is what answers between deploying and running migrations, and on a deployment whose panel sits on a hostname no storefront resolves. It widens what is **trusted**, not what **resolves** — `ResolveChannel` still 404s a host belonging to no channel. |
| It does not apply to `/health` | The same exemption the unresolved-host 404 has, for the same reason: a probe arrives on the pod's own address, and refusing it restarts healthy pods. It generates no URLs and reads no tenant data. |
| It does not fail closed on a broken database | The read is wrapped. An unreachable or unmigrated database trusts what it did before there was a table to read — this runs in front of every request, and failing closed means a deployment that cannot serve the page saying it is broken. |

## Cache

The list is cached and cleared by `ChannelDomain` itself on save and delete, rather than by whoever remembers to — a merchant adds a domain and their storefront answers 400 until something else clears it, otherwise.

**Mass deletes bypass it**, as they bypass every model event: `ChannelDomain::query()->delete()` leaves the removed hostname trusted. Nothing in the application does that today; it is recorded in the plan before something does.

## One thing worth knowing for next time

`Illuminate\Http\Middleware\TrustHosts::handle()` declares `$next` **untyped**. Typing it `Closure` in the override is an LSP violation, and PHP raises that as a fatal **when the class loads**, not when the method runs. For a global middleware that means every request dies — and in CI it surfaced as `Premature end of PHP process` on whichever test first touched the class, which moved when the middleware was unregistered. That is what the moving crash site was telling us.

## Tests

`tests/Feature/TrustedHostsTest.php` — 8 tests: a configured domain is trusted; an unconfigured hostname is not; a dot is not a wildcard; a trusted hostname inside a longer one is not trusted (both prefix and suffix); adding a domain trusts it immediately; deleting one stops it; renaming moves the trust; and the application URL is trusted with no domains configured at all.

Laravel only *applies* trusted hosts outside local and tests, so what is exercised is the list itself and the cache in front of it.

All five workflows green on `221e95f` — **1342 passed (3290 assertions)**.
