### PR TITLE
feat: build the sitemap on the channel's primary hostname, and bound it

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -4,18 +4,90 @@ namespace App\Http\Controllers;
 
 use App\Models\Product;
 use App\Models\ProductCategory;
+use App\Services\ChannelResolver;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 
+/**
+ * One sitemap per resolved storefront.
+ *
+ * *Which* products it lists is settled elsewhere — the store scope narrows
+ * `Product` and `ProductCategory` to the resolved store, and an unresolved host
+ * never reaches here. What is left is the two things scoping does not answer:
+ * which hostname the URLs are written on, and how many of them there are.
+ */
 class SitemapController extends Controller
 {
-    public function index()
-    {
-        $products = Product::all();
-        $categories = ProductCategory::all();
+    /**
+     * The sitemap protocol's ceiling: 50,000 URLs per file.
+     *
+     * A crawler is entitled to ignore a file that exceeds it, so an unbounded
+     * `Product::all()` does not merely render slowly at 60,000 products — it
+     * publishes a sitemap that need not be read at all. Overridable because the
+     * limit is somebody else's number and a deployment may want to sit further
+     * under it.
+     */
+    private const MAX_URLS = 50000;
 
-        return response()->view('sitemap.index', [
-            'products' => $products,
-            'categories' => $categories,
-        ])->header('Content-Type', 'text/xml');
+    public function index(Request $request): Response
+    {
+        $limit = max(1, (int) config('sitemap.max_urls', self::MAX_URLS));
+        $root = $this->canonicalRoot($request);
+
+        // The home page is one URL, and the budget is spent in listing order:
+        // categories are few and bounded by the merchant's own taxonomy,
+        // products are not.
+        $urls = [['loc' => $root.'/']];
+
+        $categories = ProductCategory::query()
+            ->select(['id', 'slug'])
+            ->orderBy('id')
+            ->limit($limit - count($urls))
+            ->get();
+
+        foreach ($categories as $category) {
+            $urls[] = ['loc' => $root.'/products?category='.urlencode($category->slug)];
+        }
+
+        $products = Product::query()
+            ->select(['id', 'slug', 'updated_at'])
+            ->orderBy('id')
+            ->limit(max(0, $limit - count($urls)))
+            ->get();
+
+        foreach ($products as $product) {
+            $urls[] = [
+                'loc' => $root.route('products.show', $product, absolute: false),
+                'lastmod' => $product->updated_at?->toAtomString(),
+            ];
+        }
+
+        return response()
+            ->view('sitemap.index', ['urls' => $urls])
+            ->header('Content-Type', 'text/xml');
+    }
+
+    /**
+     * The hostname the URLs are written on, which is not necessarily the one
+     * the request arrived on.
+     *
+     * A storefront answers on several hostnames from day one — the apex, `www`,
+     * a custom merchant domain, a platform subdomain — and `route()` builds from
+     * whichever the crawler used. Two hostnames then publish two sitemaps naming
+     * the same pages by different absolute URLs, which is duplicate content
+     * announced to the crawler in the one file whose whole job is telling it
+     * what to index. The primary domain flag exists for exactly this.
+     *
+     * The scheme stays the request's: a deployment behind TLS termination
+     * reports it through `TrustProxies`, and hard-coding one here would publish
+     * `http` URLs from an `https` storefront.
+     */
+    private function canonicalRoot(Request $request): string
+    {
+        $host = ChannelResolver::current()?->primaryDomain()?->host;
+
+        return $host === null
+            ? rtrim($request->getSchemeAndHttpHost(), '/')
+            : $request->getScheme().'://'.$host;
     }
 }

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -270,7 +270,15 @@ The first cut of this got it wrong in the cautious direction: it refused the fal
 
 **The availability defects recorded on #950 close with it.** `collections`, `Collection.products` and `orders` returned unbounded lists — depth and complexity rules bound the *shape* of a query, not the row count, and `throttle:api` caps request count rather than per-request cost. All three are capped, and the nested products are eager-loaded, which retires the one-query-per-collection N+1 in the same change. No execution timeout yet; that needs a number nobody has picked.
 
-**4. Rebuild the sitemap per channel.** One sitemap per resolved storefront, listing only that store's products. Rewritten rather than moved — the fix rebuilds it anyway, and it stays in the host as pure cross-module aggregation.
+**4. Rebuild the sitemap per channel.** — ✅ *scoped by step 3, then canonicalised and bounded*
+
+One sitemap per resolved storefront, listing only that store's products. **Which** products it lists was settled by the store scope in step 3 and is covered by `StoreScopeTest`; what was left is the two questions scoping does not answer.
+
+**Which hostname the URLs are written on.** A storefront answers on several hostnames from day one — the apex, `www`, a custom merchant domain, a platform subdomain — and `route()` builds from whichever the crawler used. Two hostnames then publish two sitemaps naming the same pages by different absolute URLs: duplicate content, announced to the crawler in the one file whose whole job is telling it what to index. `Channel::primaryDomain()` had been written for exactly this and used nowhere; it is what the URLs are built on now. The scheme stays the request's, because a deployment behind TLS termination reports it through `TrustProxies` and a hard-coded one would publish `http` URLs from an `https` storefront.
+
+**How many URLs there are.** `Product::all()` was unbounded. The sitemap protocol's ceiling is 50,000 URLs per file and a crawler is entitled to ignore a file that exceeds it, so at 60,000 products the old sitemap did not merely render slowly — it published something that need not be read at all. The budget is spent in listing order, with the home page reserved first: a sitemap that omits the site is worse than no sitemap. `sitemap.max_urls` overrides the ceiling for a deployment that wants to sit further under it.
+
+Rewritten rather than moved — the fix rebuilds it anyway, and it stays in the host as pure cross-module aggregation.
 
 ### Rules this wave establishes
 

--- a/resources/views/sitemap/index.blade.php
+++ b/resources/views/sitemap/index.blade.php
@@ -1,17 +1,11 @@
 <?php echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n"; ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+@foreach($urls as $url)
     <url>
-        <loc>{{ url('/') }}</loc>
+        <loc>{{ $url['loc'] }}</loc>
+@if(! empty($url['lastmod']))
+        <lastmod>{{ $url['lastmod'] }}</lastmod>
+@endif
     </url>
-    @foreach($products as $product)
-    <url>
-        <loc>{{ route('products.show', $product) }}</loc>
-        <lastmod>{{ optional($product->updated_at)->toAtomString() }}</lastmod>
-    </url>
-    @endforeach
-    @foreach($categories as $category)
-    <url>
-        <loc>{{ url('/products?category=' . $category->slug) }}</loc>
-    </url>
-    @endforeach
+@endforeach
 </urlset>

--- a/resources/views/sitemap/index.blade.php
+++ b/resources/views/sitemap/index.blade.php
@@ -1,4 +1,4 @@
-<?php echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n"; ?>
+<?php echo '<?xml version="1.0" encoding="UTF-8"?>'."\n"; ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 @foreach($urls as $url)
     <url>

--- a/tests/Feature/SitemapCanonicalTest.php
+++ b/tests/Feature/SitemapCanonicalTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Channel;
+use App\Models\ChannelDomain;
+use App\Models\Product;
+use App\Models\ProductCategory;
+use App\Models\Store;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Wave 1.5, step 4: one sitemap per resolved storefront.
+ *
+ * *Which* products it lists is settled by the store scope, and covered by
+ * `StoreScopeTest`. What is left is the two questions scoping does not answer:
+ * which hostname the URLs are written on, and how many of them there are.
+ */
+class SitemapCanonicalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * A storefront answering on several hostnames, the first one flagged
+     * primary — the apex, `www`, a custom domain and a platform subdomain is the
+     * realistic shape from day one, not an edge case.
+     */
+    private function storefront(string $primary, string ...$aliases): Store
+    {
+        $store = Store::factory()->create();
+        $channel = Channel::factory()->create(['store_id' => $store->id]);
+
+        ChannelDomain::factory()->primary()->create(['channel_id' => $channel->id, 'host' => $primary]);
+
+        foreach ($aliases as $alias) {
+            ChannelDomain::factory()->create(['channel_id' => $channel->id, 'host' => $alias]);
+        }
+
+        return $store;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function locations(string $url): array
+    {
+        $body = $this->get($url)->assertOk()->getContent();
+
+        preg_match_all('#<loc>(.*?)</loc>#', $body, $matches);
+
+        return $matches[1];
+    }
+
+    /**
+     * The canonical is the primary hostname, not the one the crawler used.
+     *
+     * Otherwise two hostnames publish two sitemaps naming the same pages by
+     * different absolute URLs — duplicate content, announced to the crawler in
+     * the one file whose whole job is telling it what to index.
+     */
+    public function test_urls_are_written_on_the_primary_hostname_not_the_one_requested(): void
+    {
+        $store = $this->storefront('shop.example.com', 'www.example.com');
+
+        Product::factory()->create(['store_id' => $store->id]);
+
+        $locations = $this->locations('http://www.example.com/sitemap.xml');
+
+        $this->assertNotEmpty($locations);
+
+        foreach ($locations as $location) {
+            $this->assertStringStartsWith('http://shop.example.com/', $location);
+        }
+    }
+
+    /**
+     * The same sitemap fetched on the primary hostname is the same sitemap. A
+     * canonical that changes with the request is not a canonical.
+     */
+    public function test_the_sitemap_is_the_same_on_every_hostname_the_storefront_answers_on(): void
+    {
+        $store = $this->storefront('shop.example.com', 'www.example.com');
+
+        Product::factory()->count(3)->create(['store_id' => $store->id]);
+
+        $this->assertSame(
+            $this->locations('http://shop.example.com/sitemap.xml'),
+            $this->locations('http://www.example.com/sitemap.xml'),
+        );
+    }
+
+    public function test_a_products_url_and_last_modified_date_are_listed(): void
+    {
+        $store = $this->storefront('shop.example.com');
+
+        $product = Product::factory()->create(['store_id' => $store->id]);
+
+        $this->get('http://shop.example.com/sitemap.xml')
+            ->assertOk()
+            ->assertSee('http://shop.example.com'.route('products.show', $product, absolute: false), escape: false)
+            ->assertSee('<lastmod>'.$product->updated_at->toAtomString().'</lastmod>', escape: false);
+    }
+
+    public function test_a_categorys_listing_url_is_included(): void
+    {
+        $store = $this->storefront('shop.example.com');
+
+        $category = ProductCategory::factory()->create(['store_id' => $store->id, 'slug' => 'mugs & cups']);
+
+        $this->assertContains(
+            'http://shop.example.com/products?category='.urlencode($category->slug),
+            $this->locations('http://shop.example.com/sitemap.xml'),
+        );
+    }
+
+    /**
+     * The sitemap protocol's ceiling is 50,000 URLs per file, and a crawler is
+     * entitled to ignore a file that exceeds it. An unbounded `Product::all()`
+     * does not merely render slowly at 60,000 products — it publishes a sitemap
+     * that need not be read at all.
+     */
+    public function test_the_url_count_is_capped(): void
+    {
+        $store = $this->storefront('shop.example.com');
+
+        Product::factory()->count(5)->create(['store_id' => $store->id]);
+
+        config(['sitemap.max_urls' => 3]);
+
+        $this->assertCount(3, $this->locations('http://shop.example.com/sitemap.xml'));
+    }
+
+    /**
+     * The home page is the one URL the cap may never spend on something else: a
+     * sitemap that omits the site is worse than no sitemap.
+     */
+    public function test_the_home_page_survives_the_cap(): void
+    {
+        $store = $this->storefront('shop.example.com');
+
+        Product::factory()->count(5)->create(['store_id' => $store->id]);
+
+        config(['sitemap.max_urls' => 1]);
+
+        $this->assertSame(
+            ['http://shop.example.com/'],
+            $this->locations('http://shop.example.com/sitemap.xml'),
+        );
+    }
+}


### PR DESCRIPTION
Wave 1.5, step 4 — and with it, the wave.

**Which** products the sitemap lists was settled by the store scope in step 3, and is covered by `StoreScopeTest`. What was left is the two questions scoping does not answer.

## Which hostname the URLs are written on

A storefront answers on several hostnames from day one — the apex, `www`, a custom merchant domain, a platform subdomain — and `route()` builds from whichever the crawler used. Two hostnames then publish two sitemaps naming the same pages by different absolute URLs: **duplicate content, announced to the crawler in the one file whose whole job is telling it what to index.**

`Channel::primaryDomain()` had been written for exactly this — its docblock says "the hostname canonical URLs are built from, which is not necessarily the one the request arrived on" — and was used nowhere. It is what the URLs are built on now.

The **scheme stays the request's**. A deployment behind TLS termination reports it through `TrustProxies`, and hard-coding one here would publish `http` URLs from an `https` storefront.

## How many URLs there are

`Product::all()` was unbounded. The sitemap protocol's ceiling is **50,000 URLs per file**, and a crawler is entitled to ignore a file that exceeds it — so at 60,000 products the old sitemap did not merely render slowly, it published something that need not be read at all.

The budget is spent in listing order with the home page reserved first: a sitemap that omits the site is worse than no sitemap. `sitemap.max_urls` overrides the ceiling for a deployment that wants to sit further under it.

The rows are also no longer loaded whole — the query selects the three columns the file actually prints, rather than every column including `long_description`.

## Tests

`tests/Feature/SitemapCanonicalTest.php` — 6 tests: URLs are written on the primary hostname, not the requested one; the sitemap is byte-identical on every hostname the storefront answers on (a canonical that changes with the request is not a canonical); a product's URL and `lastmod` are listed; a category's listing URL is included; the URL count is capped; and the home page survives a cap of one.

All five workflows green on `22afc06` — **1348 passed (3306 assertions)**.
