### PR TITLE
test: check every version the README claims against composer.lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 ![](https://img.shields.io/badge/Filament-5-informational?style=flat&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0OCIgaGVpZ2h0PSI0OCIgeG1sbnM6dj0iaHR0cHM6Ly92ZWN0YS5pby9uYW5vIj48cGF0aCBkPSJNMCAwaDQ4djQ4SDBWMHoiIGZpbGw9IiNmNGIyNWUiLz48cGF0aCBkPSJNMjggN2wtMSA2LTMuNDM3LjgxM0wyMCAxNWwtMSAzaDZ2NWgtN2wtMyAxOEg4Yy41MTUtNS44NTMgMS40NTQtMTEuMzMgMy0xN0g4di01bDUtMSAuMjUtMy4yNUMxNCAxMSAxNCAxMSAxNS40MzggOC41NjMgMTkuNDI5IDYuMTI4IDIzLjQ0MiA2LjY4NyAyOCA3eiIgZmlsbD0iIzI4MjQxZSIvPjxwYXRoIGQ9Ik0zMCAxOGg0YzIuMjMzIDUuMzM0IDIuMjMzIDUuMzM0IDEuMTI1IDguNUwzNCAyOWMtLjE2OCAzLjIwOS0uMTY4IDMuMjA5IDAgNmwtMiAxIDEgM2gtNXYyaC0yYy44NzUtNy42MjUuODc1LTcuNjI1IDItMTFoMnYtMmgtMnYtMmwyLTF2LTQtM3oiIGZpbGw9IiMyYTIwMTIiLz48cGF0aCBkPSJNMzUuNTYzIDYuODEzQzM4IDcgMzggNyAzOSA4Yy4xODggMi40MzguMTg4IDIuNDM4IDAgNWwtMiAyYy0yLjYyNS0uMzc1LTIuNjI1LS4zNzUtNS0xLS42MjUtMi4zNzUtLjYyNS0yLjM3NS0xLTUgMi0yIDItMiA0LjU2My0yLjE4N3oiIGZpbGw9IiM0MDM5MzEiLz48cGF0aCBkPSJNMzAgMThoNGMyLjA1NSA1LjMxOSAyLjA1NSA1LjMxOSAxLjgxMyA4LjMxM0wzNSAyOGwtMyAxdi0ybC00IDF2LTJsMi0xdi00LTN6IiBmaWxsPSIjMzEyODFlIi8+PHBhdGggZD0iTTI5IDI3aDN2MmgydjJoLTJ2MmwtNC0xdi0yaDJsLTEtM3oiIGZpbGw9IiMxNTEzMTAiLz48cGF0aCBkPSJNMzAgMThoNHYzaC0ydjJsLTMgMSAxLTZ6IiBmaWxsPSIjNjA0YjMyIi8+PC9zdmc+&&color=fdae4b&link=https://filamentphp.com)
 ![](https://img.shields.io/badge/Livewire-4-informational?style=flat&logo=Livewire&color=fb70a9)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Open Source Love](https://img.shields.io/badge/Open%20Source-%E2%9D%A4-red.svg)](https://github.com/liberu-ecommerce/ecommerce-laravel)
-[![Latest Release](https://img.shields.io/github/v/release/liberu-ecommerce/ecommerce-laravel?include_prereleases)](https://github.com/liberu-ecommerce/ecommerce-laravel/releases)
+[![Open Source Love](https://img.shields.io/badge/Open%20Source-%E2%9D%A4-red.svg)](https://github.com/liberusoftware/ecommerce-laravel)
+[![Latest Release](https://img.shields.io/github/v/release/liberusoftware/ecommerce-laravel?include_prereleases)](https://github.com/liberusoftware/ecommerce-laravel/releases)
 
 ---
 
@@ -22,10 +22,10 @@
 [![LinkedIn](https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/liberugroup)
 [![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://www.github.com/liberusoftware)
 
-[![Install](https://github.com/liberu-ecommerce/ecommerce-laravel/actions/workflows/install.yml/badge.svg)](https://github.com/liberu-ecommerce/ecommerce-laravel/actions/workflows/install.yml)
-[![Tests](https://github.com/liberu-ecommerce/ecommerce-laravel/actions/workflows/tests.yml/badge.svg)](https://github.com/liberu-ecommerce/ecommerce-laravel/actions/workflows/tests.yml)
-[![Docker](https://github.com/liberu-ecommerce/ecommerce-laravel/actions/workflows/main.yml/badge.svg)](https://github.com/liberu-ecommerce/ecommerce-laravel/actions/workflows/main.yml)
-[![Codecov](https://codecov.io/gh/liberu-ecommerce/ecommerce-laravel/branch/main/graph/badge.svg)](https://codecov.io/gh/liberu-ecommerce/ecommerce-laravel)
+[![Install](https://github.com/liberusoftware/ecommerce-laravel/actions/workflows/install.yml/badge.svg)](https://github.com/liberusoftware/ecommerce-laravel/actions/workflows/install.yml)
+[![Tests](https://github.com/liberusoftware/ecommerce-laravel/actions/workflows/tests.yml/badge.svg)](https://github.com/liberusoftware/ecommerce-laravel/actions/workflows/tests.yml)
+[![Docker](https://github.com/liberusoftware/ecommerce-laravel/actions/workflows/main.yml/badge.svg)](https://github.com/liberusoftware/ecommerce-laravel/actions/workflows/main.yml)
+[![Codecov](https://codecov.io/gh/liberusoftware/ecommerce-laravel/branch/main/graph/badge.svg)](https://codecov.io/gh/liberusoftware/ecommerce-laravel)
 
 ---
 
@@ -86,7 +86,7 @@ Powered by **Filament 5**, the admin panel provides resources for managing:
 PHP 8.5+ · Composer · Node.js 20+ · MySQL, MariaDB or PostgreSQL · Docker (optional)
 
 ```bash
-git clone https://github.com/liberu-ecommerce/ecommerce-laravel.git
+git clone https://github.com/liberusoftware/ecommerce-laravel.git
 cd ecommerce-laravel
 chmod +x setup.sh
 ./setup.sh
@@ -124,7 +124,7 @@ Liberu Ecommerce is part of the wider **Liberu** open-source ecosystem. All proj
 | CMS | [liberu-cms/cms-laravel](https://github.com/liberu-cms/cms-laravel) | Content management features and modular page administration. |
 | Control Panel | [liberu-control-panel/control-panel-laravel](https://github.com/liberu-control-panel/control-panel-laravel) | Administration/control-panel components for managing services. |
 | CRM | [liberu-crm/crm-laravel](https://github.com/liberu-crm/crm-laravel) | Customer relationship management features and integrations. |
-| E-commerce | [liberu-ecommerce/ecommerce-laravel](https://github.com/liberu-ecommerce/ecommerce-laravel) | E-commerce storefront, product and order management (this repo). |
+| E-commerce | [liberusoftware/ecommerce-laravel](https://github.com/liberusoftware/ecommerce-laravel) | E-commerce storefront, product and order management (this repo). |
 | Genealogy | [liberu-genealogy/genealogy-laravel](https://github.com/liberu-genealogy/genealogy-laravel) | Family tree and genealogy features built on Laravel. |
 | Maintenance | [liberu-maintenance/maintenance-laravel](https://github.com/liberu-maintenance/maintenance-laravel) | Scheduling, tracking and reporting for maintenance tasks. |
 | Real Estate | [liberu-real-estate/real-estate-laravel](https://github.com/liberu-real-estate/real-estate-laravel) | Property listings and real-estate management features. |

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -53,7 +53,7 @@ Nothing can be extracted before this wave. A module ships **no `extra.laravel.pr
 | Create **`theme-ecommerce`** — `type: public`, `parent: default` | The storefront layout moves **once**, and every later extraction targets an existing theme instead of a moving one |
 | Declare **`supported_locales`** in `config/app.php` | The key is absent and `localization-core` reads it. One line, arriving with the localization adoption already committed to |
 | Add the **translation lint step** to `package-tests.yml` | A static catalogue check belongs with the enforcement layer, not with the first module that ships a catalogue |
-| Generate **badge versions from `composer.lock`** | `REPOSITORIES.md` §6.1 forbids hard-coding a version CI does not verify. The README hard-codes PHP 8.5, Laravel 13, Filament 5, Livewire 4 |
+| ~~Generate **badge versions from `composer.lock`**~~ — ✅ **verified instead, see below** | `REPOSITORIES.md` §6.1 forbids hard-coding a version CI does not verify. The README hard-codes PHP 8.5, Laravel 13, Filament 5, Livewire 4 |
 | `package-testbench` upstream contribution — **timeboxed** | The boundary-rule architecture tests belong upstream so every module gets them. Fall back to `commerce-testbench` if it stalls |
 | `spatie/laravel-permission` `^8.0` support upstream in `roles-permissions` | This repo is on `^8.3`, the reference app on `^7.0`. **Downgrading a security-relevant dependency to match a module is the wrong direction of travel** |
 | Vendor rename `liberu-eccommerce` → `liberusoftware` | Free today — 0 downloads, 0 dependents, no tags. It stops being free the moment anything depends on it. [ADR 0009](./adr/0009-vendor-rename-to-liberusoftware.md) |
@@ -129,6 +129,16 @@ Both from [`OPERATIONS.md`](./OPERATIONS.md#a-widget-or-resource-does-not-appear
 `MenuResource` being "registered twice" — recorded in the conformance snapshot — **is not a defect**. The plugin registers the same class that discovery finds, and `Panel::getResources()` returns `array_unique($this->resources)`.
 
 `app/Filament/Resources/CustomerSegmentResource` stays where it is for now. It is discovered by neither panel, but both panels are tenant-scoped and `customer_segments` has no `team_id`, so moving it reproduces [#958](https://github.com/liberusoftware/ecommerce-laravel/issues/958) on a third table. It follows the tenant scope in wave 1.5.
+
+### The README's versions — checked rather than generated
+
+The standard forbids hard-coding a version CI does not verify, and the README hard-codes four: PHP, Laravel, Filament and Livewire, in badges at the top and again in prose. Fifteen claims in all, spread over five sections — the badge, the strapline, the About paragraph, the feature list and the requirements line. A README is the first thing anyone reads and the last thing anyone updates, so a stale claim outlives the upgrade that invalidated it, and the reader debugs against the wrong framework.
+
+**Generating them was the plan's wording; verifying them is what the standard asks for, and it is the cheaper half.** A generator is a script, a commit step and a way for the two to disagree — machinery to spare a four-character edit that happens once per major upgrade. `ReadmeVersionsTest` reads every `Name version` and `Name-version` in the README and checks each against `composer.lock`, segment by segment, so `Laravel 13` and `Laravel 13.23` both pass and `1` is not accepted as a prefix of `13`. When it fails, the fix is to type the new number.
+
+It catches the prose too, which is where the drift actually happens: nobody forgets the badge at the top, and everybody forgets the sentence in the middle.
+
+The eight GitHub links pointing at `liberu-ecommerce/ecommerce-laravel` are corrected in the same change. They resolve — GitHub keeps a redirect after a rename — which is why nobody noticed, and a redirect is a courtesy rather than a guarantee.
 
 ### The first architecture test, ahead of the enforcement layer
 

--- a/tests/Feature/ReadmeVersionsTest.php
+++ b/tests/Feature/ReadmeVersionsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+/**
+ * Every version the README claims is a version `composer.lock` agrees with.
+ *
+ * [`REPOSITORIES.md` §6.1](https://github.com/liberusoftware/documentation/blob/main/architecture/REPOSITORIES.md)
+ * forbids hard-coding a version CI does not verify, and the README hard-codes
+ * four of them — in badges and again in prose. A README is the first thing
+ * anyone reads and the last thing anyone updates, so the claim outlives the
+ * dependency: the badge says Laravel 13 for as long as nobody remembers, which
+ * is how a reader ends up debugging against the wrong framework.
+ *
+ * The plan's wording is *generate the badges from `composer.lock`*. Verifying is
+ * what the standard actually asks for, and it is the cheaper half: a generator
+ * is a script, a commit step and a way for the two to disagree, to spare a
+ * four-character edit that happens once per major upgrade. When this fails, the
+ * fix is to type the new number.
+ */
+class ReadmeVersionsTest extends TestCase
+{
+    /**
+     * Where each claimed name gets its true version from.
+     *
+     * PHP comes from the `require` constraint rather than the lock's platform
+     * block, because the constraint is what the project supports; the lock only
+     * records what the machine that resolved it happened to run.
+     */
+    private const PACKAGES = [
+        'Laravel' => 'laravel/framework',
+        'Filament' => 'filament/filament',
+        'Livewire' => 'livewire/livewire',
+    ];
+
+    public function test_every_version_the_readme_claims_matches_composer_lock(): void
+    {
+        $readme = file_get_contents(base_path('README.md'));
+        $actual = $this->lockedVersions();
+
+        // Badges write `Laravel-13`, prose writes `Laravel 13`. Both are the
+        // same claim and both go stale the same way, so both are checked —
+        // matching only line 15 would leave the badge above it lying.
+        preg_match_all(
+            '/\b(PHP|Laravel|Filament|Livewire)[- ](\d+(?:\.\d+)*)/',
+            $readme,
+            $matches,
+            PREG_SET_ORDER,
+        );
+
+        $this->assertNotEmpty($matches, 'Found no version claims in the README — the pattern is wrong.');
+
+        $wrong = [];
+
+        foreach ($matches as [$claim, $name, $claimed]) {
+            if (! $this->isPrefixOf($claimed, $actual[$name])) {
+                $wrong[] = "{$claim} — composer.lock says {$name} {$actual[$name]}";
+            }
+        }
+
+        $wrong = array_values(array_unique($wrong));
+        sort($wrong);
+
+        $this->assertSame([], $wrong, implode("\n", [
+            'The README claims versions this project does not use:',
+            '',
+            ...$wrong,
+            '',
+            'Update the README. A version nobody verifies is a version that goes stale',
+            'the first time somebody upgrades and does not scroll up.',
+        ]));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function lockedVersions(): array
+    {
+        $lock = json_decode(file_get_contents(base_path('composer.lock')), true);
+        $composer = json_decode(file_get_contents(base_path('composer.json')), true);
+
+        $versions = ['PHP' => ltrim($composer['require']['php'], '^~>=< ')];
+
+        foreach ($lock['packages'] as $package) {
+            $name = array_search($package['name'], self::PACKAGES, true);
+
+            if ($name !== false) {
+                $versions[$name] = ltrim($package['version'], 'v');
+            }
+        }
+
+        $missing = array_diff(['PHP', ...array_keys(self::PACKAGES)], array_keys($versions));
+
+        $this->assertSame([], array_values($missing),
+            'These are not in composer.lock, so the README cannot be checked against it: '.implode(', ', $missing));
+
+        return $versions;
+    }
+
+    /**
+     * Segment by segment, not `str_starts_with` — `1` is a string prefix of
+     * `13.23.0` and is not a truthful claim about it.
+     */
+    private function isPrefixOf(string $claimed, string $actual): bool
+    {
+        $claimedParts = explode('.', $claimed);
+        $actualParts = explode('.', $actual);
+
+        return array_slice($actualParts, 0, count($claimedParts)) === $claimedParts;
+    }
+}


### PR DESCRIPTION
## What this is

Wave 0's "generate badge versions from `composer.lock`". [`REPOSITORIES.md` §6.1](https://github.com/liberusoftware/documentation/blob/main/architecture/REPOSITORIES.md) forbids hard-coding a version CI does not verify, and the README hard-codes four — across **fifteen claims**, in five places: the badges, the strapline, the About paragraph, the feature list and the requirements line.

## Verified, not generated

Generating was the plan's wording. Verifying is what the standard actually asks for, and it is the cheaper half: a generator is a script, a commit step, and a way for the two to disagree — machinery to spare a four-character edit that happens once per major upgrade. When this check fails, the fix is to type the new number.

`ReadmeVersionsTest` reads every `Name version` and `Name-version` in the README and compares it to `composer.lock` **segment by segment**, so:

- `Laravel 13` and `Laravel 13.23` both pass against `13.23.0`;
- `1` is **not** accepted as a prefix of `13`, which a `str_starts_with` would have allowed.

Both forms are checked because both go stale the same way, and matching only the strapline would leave the badge above it lying. PHP comes from the `require` constraint rather than the lock's platform block — the constraint is what the project supports; the platform block only records what the machine that resolved the lock happened to run.

It catches the prose, which is where drift actually happens: nobody forgets the badge at the top, everybody forgets the sentence in the middle.

## Also

The eight GitHub links pointing at `liberu-ecommerce/ecommerce-laravel` now point at `liberusoftware/ecommerce-laravel`. They resolve today — GitHub keeps a redirect after a rename, which is why nobody noticed — and a redirect is a courtesy rather than a guarantee.

Currently all fifteen claims are correct, so this locks the state rather than fixing a wrong one.
