### PR TITLE
feat: one read-only command that answers the #944 tenant-distribution checklist

### DIFF
--- a/app/Console/Commands/TenantDistribution.php
+++ b/app/Console/Commands/TenantDistribution.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The [#944](https://github.com/liberusoftware/ecommerce-laravel/issues/944)
+ * checklist, as one read-only command.
+ *
+ * The checklist gates wave 2's backfill and cannot be answered from the
+ * repository: a fresh checkout has no `.env` and no database. It can only be
+ * answered against each real environment, which meant an operator adapting
+ * roughly forty statements per environment by hand — and the numbers decide
+ * whether rows get attributed or quarantined, so a transcription slip is a
+ * mis-attributed merchant.
+ *
+ * So the queries are written once, here, and read the schema rather than a
+ * hand-kept list of tables. **It writes nothing.** Output is Markdown, because
+ * the answer is pasted onto the issue.
+ */
+class TenantDistribution extends Command
+{
+    protected $signature = 'tenants:distribution';
+
+    protected $description = 'Read-only: tenant counts, per-table distribution and cross-boundary mismatches for #944';
+
+    /**
+     * `team_id` on these is the membership graph itself rather than tenant data
+     * — the same exclusion `StoreBackfillTest` makes, for the same reason.
+     */
+    private const NOT_TENANT_DATA = ['teams', 'team_user', 'team_invitations'];
+
+    /**
+     * Foreign keys whose parent also carries `team_id`, so parent and child can
+     * be compared. A disagreement is not a suspicion: it is a row already
+     * sitting on the wrong side of a tenancy boundary.
+     *
+     * @var array<string, string>
+     */
+    private const OWNED_BY = [
+        'customer_id' => 'customers',
+        'order_id' => 'orders',
+        'product_id' => 'products',
+        'product_category_id' => 'product_categories',
+        'collection_id' => 'collections',
+        'coupon_id' => 'coupons',
+    ];
+
+    public function handle(): int
+    {
+        $this->line('# Tenant distribution — '.config('app.env').' — '.DB::connection()->getDatabaseName());
+        $this->line('');
+        $this->line('Produced by `php artisan tenants:distribution` (reads only).');
+        $this->line('');
+
+        $tables = $this->tenantTables();
+
+        $this->teams();
+        $this->distribution($tables);
+        $this->mismatches($tables);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * §1 — how many tenants actually exist.
+     *
+     * One non-personal team means the boundary has a single occupant today and
+     * the backfill is trivial. Several means the quarantine rule is carrying
+     * real weight.
+     */
+    private function teams(): void
+    {
+        $teams = DB::table('teams')->orderBy('id')->get(['id', 'name', 'personal_team', 'created_at']);
+
+        $this->line('## 1. Tenants');
+        $this->line('');
+        $this->line('teams: '.$teams->count().', personal: '.$teams->where('personal_team', true)->count());
+        $this->line('');
+        $this->markdownTable(['id', 'name', 'personal_team', 'created_at'], $teams->map(fn ($team) => [
+            $team->id, $team->name, $team->personal_team ? 'yes' : 'no', (string) $team->created_at,
+        ])->all());
+    }
+
+    /**
+     * §2 — distribution per table, nulls included as their own row.
+     *
+     * A null `team_id` belongs to nobody, which is a different state from
+     * belonging to team 1, and the two must not be summed.
+     *
+     * @param  list<string>  $tables
+     */
+    private function distribution(array $tables): void
+    {
+        $rows = [];
+
+        foreach ($tables as $table) {
+            $counts = DB::table($table)
+                ->select('team_id', DB::raw('COUNT(*) AS rows_count'))
+                ->groupBy('team_id')
+                ->orderBy('team_id')
+                ->get();
+
+            foreach ($counts as $count) {
+                $rows[] = [$table, $count->team_id ?? 'NULL', $count->rows_count];
+            }
+
+            if ($counts->isEmpty()) {
+                $rows[] = [$table, '—', 0];
+            }
+        }
+
+        $this->line('## 2. Rows per tenant, per table');
+        $this->line('');
+        $this->markdownTable(['table', 'team_id', 'rows'], $rows);
+    }
+
+    /**
+     * §3 — how much of this is already wrong.
+     *
+     * Two kinds of evidence, and both are conclusive rather than indicative:
+     *
+     * - a row whose parent record belongs to a different team;
+     * - a row on a team whose named user is neither a member of that team nor
+     *   its owner.
+     *
+     * The issue asks for these to be reported prominently rather than buried in
+     * a count, so a non-zero total says so in as many words.
+     *
+     * @param  list<string>  $tables
+     */
+    private function mismatches(array $tables): void
+    {
+        $rows = [];
+
+        foreach ($tables as $table) {
+            $columns = Schema::getColumnListing($table);
+
+            foreach (self::OWNED_BY as $column => $parent) {
+                if (! in_array($column, $columns, true) || ! $this->isTenantScoped($parent)) {
+                    continue;
+                }
+
+                $rows[] = [$table, "{$column} → {$parent}", DB::table($table)
+                    ->join($parent, "{$parent}.id", '=', "{$table}.{$column}")
+                    ->whereNotNull("{$table}.team_id")
+                    ->whereNotNull("{$parent}.team_id")
+                    ->whereColumn("{$table}.team_id", '!=', "{$parent}.team_id")
+                    ->count()];
+            }
+
+            if (in_array('user_id', $columns, true)) {
+                $rows[] = [$table, 'user_id not in team', $this->rowsWhoseUserIsNotInTheTeam($table)];
+            }
+        }
+
+        $total = array_sum(array_column($rows, 2));
+
+        $this->line('## 3. Rows already across a boundary');
+        $this->line('');
+        $this->line($total === 0
+            ? 'None found.'
+            : "**{$total} rows are already attributed across a tenancy boundary.** These are not ambiguous rows; they are wrong ones.");
+        $this->line('');
+        $this->markdownTable(['table', 'check', 'rows'], $rows);
+    }
+
+    private function rowsWhoseUserIsNotInTheTeam(string $table): int
+    {
+        return DB::table($table)
+            ->leftJoin('team_user', function ($join) use ($table) {
+                $join->on('team_user.user_id', '=', "{$table}.user_id")
+                    ->on('team_user.team_id', '=', "{$table}.team_id");
+            })
+            // A team's owner is not in its own pivot, so without this every row
+            // created by the merchant themselves would read as a breach.
+            ->leftJoin('teams as owned', function ($join) use ($table) {
+                $join->on('owned.id', '=', "{$table}.team_id")
+                    ->on('owned.user_id', '=', "{$table}.user_id");
+            })
+            ->whereNotNull("{$table}.team_id")
+            ->whereNotNull("{$table}.user_id")
+            ->whereNull('team_user.user_id')
+            ->whereNull('owned.id')
+            ->count();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function tenantTables(): array
+    {
+        $tables = [];
+
+        foreach (Schema::getTableListing() as $table) {
+            $table = str_contains($table, '.') ? explode('.', $table)[1] : $table;
+
+            if (! in_array($table, self::NOT_TENANT_DATA, true) && $this->isTenantScoped($table)) {
+                $tables[] = $table;
+            }
+        }
+
+        sort($tables);
+
+        return $tables;
+    }
+
+    private function isTenantScoped(string $table): bool
+    {
+        return Schema::hasTable($table) && Schema::hasColumn($table, 'team_id');
+    }
+
+    /**
+     * @param  list<string>  $headings
+     * @param  list<array<int, string|int|null>>  $rows
+     */
+    private function markdownTable(array $headings, array $rows): void
+    {
+        $this->line('| '.implode(' | ', $headings).' |');
+        $this->line('| '.implode(' | ', array_fill(0, count($headings), '---')).' |');
+
+        foreach ($rows as $row) {
+            $this->line('| '.implode(' | ', $row).' |');
+        }
+
+        $this->line('');
+    }
+}

--- a/tests/Feature/TenantDistributionCommandTest.php
+++ b/tests/Feature/TenantDistributionCommandTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * The command that answers [#944](https://github.com/liberusoftware/ecommerce-laravel/issues/944).
+ *
+ * Its output decides whether rows are attributed or quarantined in wave 2, so
+ * what is worth testing is not that it prints a table — it is that it counts a
+ * cross-boundary row as one and does not count a legitimate row as one. A
+ * checklist that cries wolf gets ignored; one that stays quiet gets believed.
+ *
+ * Written against `DB` rather than factories throughout, for the same reason the
+ * command is: several of these tables have no factory, and the point is what is
+ * in the database rather than what the models would have written.
+ */
+class TenantDistributionCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_reports_a_row_whose_parent_belongs_to_another_team(): void
+    {
+        [$mine, $theirs] = [$this->merchant(), $this->merchant()];
+
+        $product = Product::factory()->create(['team_id' => $theirs->id]);
+
+        // Owned by the first merchant, pointing at the second merchant's
+        // product. The user is the first merchant's owner, so the membership
+        // check stays quiet and the parent check is the only thing that fires.
+        $this->wishlist($mine, $product->id);
+
+        $this->artisan('tenants:distribution')
+            ->expectsOutputToContain('are already attributed across a tenancy boundary')
+            ->expectsOutputToContain('| wishlists | product_id → products | 1 |')
+            ->assertSuccessful();
+    }
+
+    public function test_a_row_created_by_the_team_owner_is_not_a_breach(): void
+    {
+        // A team's owner has no row in its own `team_user` pivot, so a naive
+        // membership check reads every row the merchant created themselves as a
+        // breach — which on a real deployment is most of them, and is the
+        // reason nobody would trust the output.
+        $team = $this->merchant();
+
+        $this->wishlist($team, Product::factory()->create(['team_id' => $team->id])->id);
+
+        $this->artisan('tenants:distribution')
+            ->expectsOutputToContain('None found.')
+            ->assertSuccessful();
+    }
+
+    public function test_it_counts_rows_belonging_to_nobody_separately(): void
+    {
+        $team = $this->merchant();
+
+        $this->customer($team->id);
+        $this->customer(null);
+
+        // Belonging to nobody is a different state from belonging to team 1,
+        // and summing the two is how wave 2 would attribute a row it has no
+        // evidence for.
+        $this->artisan('tenants:distribution')
+            ->expectsOutputToContain('| customers | NULL | 1 |')
+            ->expectsOutputToContain("| customers | {$team->id} | 1 |")
+            ->assertSuccessful();
+    }
+
+    private function merchant(): Team
+    {
+        return User::factory()->withPersonalTeam()->create()->ownedTeams()->first();
+    }
+
+    private function wishlist(Team $team, int $productId): void
+    {
+        DB::table('wishlists')->insert([
+            'user_id' => $team->user_id,
+            'product_id' => $productId,
+            'team_id' => $team->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function customer(?int $teamId): void
+    {
+        DB::table('customers')->insert([
+            'first_name' => 'A',
+            'last_name' => 'Merchant',
+            'email' => 'customer'.($teamId ?? 'none').'@example.com',
+            'phone_number' => 123456,
+            'address' => '1 Street',
+            'city' => 'Town',
+            'state' => 'County',
+            'postal_code' => 'AB1 2CD',
+            'team_id' => $teamId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
## What this is

[#944](https://github.com/liberusoftware/ecommerce-laravel/issues/944) as one read-only command:

```bash
php artisan tenants:distribution
```

The checklist gates wave 2's backfill and cannot be answered from the repository — a fresh checkout has no `.env` and no database. Answering it as written meant an operator adapting roughly forty statements per environment by hand, per table, with the join shapes left as *"example shape; adapt per table"*. The numbers decide whether a row gets **attributed or quarantined**, so a transcription slip is a mis-attributed merchant.

So the queries are written once, here, and read the schema (`Schema::getTableListing`) rather than a hand-kept list of tables — which also means the three tables that gained `team_id` in #990 are included without anybody remembering. Output is Markdown, because the answer is pasted onto the issue.

**It writes nothing.**

## The three sections

| | |
| --- | --- |
| **1. Tenants** | Count, personal count, and the list. One non-personal team means the boundary has a single occupant and the backfill is trivial; several means the quarantine rule is load-bearing |
| **2. Rows per tenant, per table** | Including `NULL` as its own row. Belonging to nobody is a different state from belonging to team 1, and summing them is how wave 2 would attribute a row it has no evidence for |
| **3. Rows already across a boundary** | Not ambiguous rows — wrong ones. Reported with a sentence rather than buried in a count, as the issue asks |

## Why the third check is two checks

- **A row whose parent belongs to a different team** — `customer_id`, `order_id`, `product_id`, `product_category_id`, `collection_id`, `coupon_id`, each used only where both tables carry `team_id`.
- **A row on a team whose named user is neither a member of it nor its owner.**

The owner half is load-bearing: **a team's owner has no row in its own `team_user` pivot**, so a plain membership check reads every row the merchant created themselves as a breach. On a real deployment that is most of them, and it is the reason nobody would trust the output. There is a test for exactly that.

## Tests

Three, written against `DB` rather than factories — several of these tables have no factory, and the point is what is in the database rather than what the models would have written:

- a wishlist on merchant A pointing at merchant B's product is reported;
- a row created by the team owner is **not**;
- a null `team_id` is counted separately from an attributed one.
