### PR TITLE
chore: rename the vendor to liberusoftware, and correct ADR 0009

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "liberu-eccommerce/ecommerce-laravel",
+    "name": "liberusoftware/ecommerce-laravel",
     "type": "project",
-    "description": "The skeleton application for the Laravel framework.",
+    "description": "Liberu Ecommerce — an open-source e-commerce platform built on Laravel, Filament and Livewire.",
     "keywords": [
         "laravel",
         "framework"
@@ -74,6 +74,9 @@
         ],
         "lint:fix": [
             "@php vendor/bin/pint"
+        ],
+        "test": [
+            "@php artisan test"
         ]
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2bf66f90bb45c14fb599a163bd76e953",
+    "content-hash": "cbaec2d2d66e4a6229be8b5ede956e00",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -56,7 +56,7 @@ Nothing can be extracted before this wave. A module ships **no `extra.laravel.pr
 | ~~Generate **badge versions from `composer.lock`**~~ — ✅ **verified instead, see below** | `REPOSITORIES.md` §6.1 forbids hard-coding a version CI does not verify. The README hard-codes PHP 8.5, Laravel 13, Filament 5, Livewire 4 |
 | `package-testbench` upstream contribution — **timeboxed** | The boundary-rule architecture tests belong upstream so every module gets them. Fall back to `commerce-testbench` if it stalls |
 | `spatie/laravel-permission` `^8.0` support upstream in `roles-permissions` | This repo is on `^8.3`, the reference app on `^7.0`. **Downgrading a security-relevant dependency to match a module is the wrong direction of travel** |
-| Vendor rename `liberu-eccommerce` → `liberusoftware` | Free today — 0 downloads, 0 dependents, no tags. It stops being free the moment anything depends on it. [ADR 0009](./adr/0009-vendor-rename-to-liberusoftware.md) |
+| ~~Vendor rename `liberu-eccommerce` → `liberusoftware`~~ — ✅ **done, with one step left outside this repository** | Free today — 0 downloads, 0 dependents. It stops being free the moment anything depends on it. [ADR 0009](./adr/0009-vendor-rename-to-liberusoftware.md), which is also corrected: the package **does** have five published tags, and that is what leaves a Packagist step for a maintainer |
 
 ### Also in wave 0, because they are one-line and shipping today — ✅ **done**
 

--- a/docs/adr/0009-vendor-rename-to-liberusoftware.md
+++ b/docs/adr/0009-vendor-rename-to-liberusoftware.md
@@ -1,13 +1,21 @@
 # Vendor rename: `liberu-eccommerce` → `liberusoftware`
 
-**Status**: accepted
+**Status**: accepted — **landed 2026-08-09**
 
 `composer.json` declares `"name": "liberu-eccommerce/ecommerce-laravel"` — a vendor nobody else uses, containing a typo (`eccommerce`). Everything commerce publishes goes under **`liberusoftware`**, matching the other 40 packages, and the typo dies with the rename.
 
 ## Why the rename is free
 
-Packagist shows `liberu-eccommerce/ecommerce-laravel` with **0 downloads, 0 dependents and no tags**. There is nothing to break. A rename that costs nothing today costs a redirect and a deprecation notice once anything depends on it.
+Packagist shows `liberu-eccommerce/ecommerce-laravel` with **0 downloads and 0 dependents**. Nothing consumes it, so nothing breaks.
+
+**Correction to this ADR as first written:** it also claimed *no tags*. That was wrong — the package has **five published versions**: `v1.0.0`, `v1.0.1`, `v1.0.2`, `v1.0.3` and `v13.0.0`. The decision does not change, because tags are not what makes a rename expensive; dependents are, and there are none. But the two are not the same fact and the difference has a consequence, below.
+
+A rename that costs nothing today costs a redirect and a deprecation notice once anything depends on it.
 
 ## Consequences
 
 The host's own package name changes, which is invisible to an application nobody `require`s. Every commerce module is unaffected — none has been published yet.
+
+**One step is outside this repository.** Those five published versions mean the old Packagist package still exists and still points at this repository, so the next push updates a package whose `composer.json` no longer declares that name. Somebody with maintainer rights has to either rename the package on Packagist — which keeps the old name as an alias, the tidy outcome — or mark it abandoned in favour of `liberusoftware/ecommerce-laravel` and submit the new one. Until that happens, `liberusoftware/ecommerce-laravel` is a name this repository declares and Packagist does not know.
+
+The GitHub repository moved to the `liberusoftware` organisation some time ago and the old URL survives on a redirect, which is why none of this surfaced as an error.

--- a/tests/Feature/ComposerLockIsCurrentTest.php
+++ b/tests/Feature/ComposerLockIsCurrentTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+/**
+ * `composer.lock` agrees with `composer.json`.
+ *
+ * Composer stores a hash of the dependency-relevant part of `composer.json` in
+ * the lock, and warns on every `composer install` when the two disagree. The
+ * warning is easy to miss and easy to live with, so the disagreement survives
+ * until somebody runs `composer update` for an unrelated reason and finds a
+ * pending change they did not make.
+ *
+ * It matters more here than in most repositories: `composer.json` is regularly
+ * edited where Composer cannot be run — a rename, a script, a constraint — so
+ * the lock is updated by hand or not at all. This is the check that says which.
+ *
+ * The hash is Composer's own: the relevant keys, sorted, JSON-encoded, md5'd.
+ * If a future Composer changes that list, this fails against a lock Composer
+ * itself wrote, and the list below is what to update.
+ */
+class ComposerLockIsCurrentTest extends TestCase
+{
+    /**
+     * `Composer\Package\Locker::getContentHash`. Deliberately not everything in
+     * the file — `description`, `scripts` and `autoload` are absent because
+     * changing them cannot change what gets installed.
+     *
+     * @var list<string>
+     */
+    private const RELEVANT = [
+        'name', 'version', 'require', 'require-dev', 'conflict', 'replace',
+        'provide', 'minimum-stability', 'prefer-stable', 'repositories', 'extra',
+    ];
+
+    public function test_the_lock_was_written_for_this_composer_json(): void
+    {
+        $composer = json_decode(file_get_contents(base_path('composer.json')), true);
+        $lock = json_decode(file_get_contents(base_path('composer.lock')), true);
+
+        $this->assertNotNull($composer, 'composer.json is not valid JSON.');
+        $this->assertNotNull($lock, 'composer.lock is not valid JSON.');
+
+        $this->assertSame(
+            $this->contentHash($composer),
+            $lock['content-hash'] ?? null,
+            'composer.lock was written for a different composer.json. Run `composer update --lock`, '
+                .'which rewrites the hash without changing a single installed version.',
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $composer
+     */
+    private function contentHash(array $composer): string
+    {
+        $relevant = [];
+
+        foreach (array_intersect(self::RELEVANT, array_keys($composer)) as $key) {
+            $relevant[$key] = $composer[$key];
+        }
+
+        if (isset($composer['config']['platform'])) {
+            $relevant['config']['platform'] = $composer['config']['platform'];
+        }
+
+        ksort($relevant);
+
+        return md5(json_encode($relevant));
+    }
+}


### PR DESCRIPTION
## What this is

Wave 0's vendor rename — [ADR 0009](../blob/main/docs/adr/0009-vendor-rename-to-liberusoftware.md), accepted, and free only for as long as nothing depends on the old name.

```diff
-"name": "liberu-eccommerce/ecommerce-laravel"
+"name": "liberusoftware/ecommerce-laravel"
```

The typo (`eccommerce`) dies with it.

## The ADR was wrong about one of its three facts

It justified the rename as free on **0 downloads, 0 dependents, no tags**. Checked against Packagist before touching anything:

| Claim | Actual |
| --- | --- |
| 0 downloads | ✅ total 0, monthly 0, daily 0 |
| 0 dependents | ✅ 0 |
| no tags | ❌ **five published versions** — `v1.0.0`, `v1.0.1`, `v1.0.2`, `v1.0.3`, `v13.0.0` |

The decision stands: dependents are what make a rename expensive, and there are none. But tags and dependents are not the same fact, and the difference has a consequence — so the ADR now records the correction rather than leaving somebody to discover it.

**One step is outside this repository.** Those five versions mean the old Packagist package still exists and still points here, so the next push updates a package whose `composer.json` no longer declares that name. A maintainer has to either rename it on Packagist — which keeps the old name as an alias, the tidy outcome — or abandon it in favour of the new name and submit that. Until then, `liberusoftware/ecommerce-laravel` is a name this repository declares and Packagist does not know.

## Also in composer.json

- A `test` script (`@php artisan test`), part of wave 0's enforcement layer — the same command CI runs.
- The `description`, which was still Laravel's skeleton default: *"The skeleton application for the Laravel framework."*

## The lock, and a check for it

`name` is one of the keys Composer hashes into `composer.lock`'s `content-hash`, so renaming without touching the lock makes every `composer install` — in all four workflows — warn that the lock is out of date.

The hash is updated the way `composer update --lock` would. The algorithm was verified first by recomputing the **existing** hash from the **unmodified** `composer.json` and confirming it reproduced what Composer had written, before being trusted to produce the new one.

`ComposerLockIsCurrentTest` makes that a check rather than a habit. It matters here more than in most repositories: `composer.json` gets edited where Composer cannot be run — a rename, a script, a constraint — so the lock is updated by hand or not at all, and the install-time warning is easy to live with until somebody runs `composer update` for an unrelated reason and finds a pending change they did not make.
