### PR TITLE
feat: run the #944 report without vendor, from a checkout or a replica

### DIFF
--- a/app/Console/Commands/TenantDistribution.php
+++ b/app/Console/Commands/TenantDistribution.php
@@ -25,10 +25,18 @@ class TenantDistribution extends Command
     {
         $connection = DB::connection();
 
-        $this->line((new TenantDistributionReport($connection->getPdo()))->markdown(
+        $report = (new TenantDistributionReport($connection->getPdo()))->markdown(
             (string) config('app.env'),
             (string) $connection->getDatabaseName(),
-        ));
+        );
+
+        // Line by line rather than as one string: the console writes it the
+        // same either way, but a single write is a single output chunk, and
+        // anything reading this output a line at a time — a test expectation, a
+        // `grep` in a pipeline — sees one blob instead.
+        foreach (explode("\n", $report) as $line) {
+            $this->line($line);
+        }
 
         return self::SUCCESS;
     }

--- a/app/Console/Commands/TenantDistribution.php
+++ b/app/Console/Commands/TenantDistribution.php
@@ -2,24 +2,18 @@
 
 namespace App\Console\Commands;
 
+use App\Support\TenantDistributionReport;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 
 /**
  * The [#944](https://github.com/liberusoftware/ecommerce-laravel/issues/944)
- * checklist, as one read-only command.
+ * checklist, for a machine that has the application.
  *
- * The checklist gates wave 2's backfill and cannot be answered from the
- * repository: a fresh checkout has no `.env` and no database. It can only be
- * answered against each real environment, which meant an operator adapting
- * roughly forty statements per environment by hand — and the numbers decide
- * whether rows get attributed or quarantined, so a transcription slip is a
- * mis-attributed merchant.
- *
- * So the queries are written once, here, and read the schema rather than a
- * hand-kept list of tables. **It writes nothing.** Output is Markdown, because
- * the answer is pasted onto the issue.
+ * The report itself is `TenantDistributionReport`, which needs a `PDO` and
+ * nothing else — because the machine that can reach production is not always
+ * the one with a working `vendor/`. `tools/tenant-distribution.php` is the
+ * same report without Laravel. **Neither writes anything.**
  */
 class TenantDistribution extends Command
 {
@@ -27,205 +21,15 @@ class TenantDistribution extends Command
 
     protected $description = 'Read-only: tenant counts, per-table distribution and cross-boundary mismatches for #944';
 
-    /**
-     * `team_id` on these is the membership graph itself rather than tenant data
-     * — the same exclusion `StoreBackfillTest` makes, for the same reason.
-     */
-    private const NOT_TENANT_DATA = ['teams', 'team_user', 'team_invitations'];
-
-    /**
-     * Foreign keys whose parent also carries `team_id`, so parent and child can
-     * be compared. A disagreement is not a suspicion: it is a row already
-     * sitting on the wrong side of a tenancy boundary.
-     *
-     * @var array<string, string>
-     */
-    private const OWNED_BY = [
-        'customer_id' => 'customers',
-        'order_id' => 'orders',
-        'product_id' => 'products',
-        'product_category_id' => 'product_categories',
-        'collection_id' => 'collections',
-        'coupon_id' => 'coupons',
-    ];
-
     public function handle(): int
     {
-        $this->line('# Tenant distribution — '.config('app.env').' — '.DB::connection()->getDatabaseName());
-        $this->line('');
-        $this->line('Produced by `php artisan tenants:distribution` (reads only).');
-        $this->line('');
+        $connection = DB::connection();
 
-        $tables = $this->tenantTables();
-
-        $this->teams();
-        $this->distribution($tables);
-        $this->mismatches($tables);
+        $this->line((new TenantDistributionReport($connection->getPdo()))->markdown(
+            (string) config('app.env'),
+            (string) $connection->getDatabaseName(),
+        ));
 
         return self::SUCCESS;
-    }
-
-    /**
-     * §1 — how many tenants actually exist.
-     *
-     * One non-personal team means the boundary has a single occupant today and
-     * the backfill is trivial. Several means the quarantine rule is carrying
-     * real weight.
-     */
-    private function teams(): void
-    {
-        $teams = DB::table('teams')->orderBy('id')->get(['id', 'name', 'personal_team', 'created_at']);
-
-        $this->line('## 1. Tenants');
-        $this->line('');
-        $this->line('teams: '.$teams->count().', personal: '.$teams->where('personal_team', true)->count());
-        $this->line('');
-        $this->markdownTable(['id', 'name', 'personal_team', 'created_at'], $teams->map(fn ($team) => [
-            $team->id, $team->name, $team->personal_team ? 'yes' : 'no', (string) $team->created_at,
-        ])->all());
-    }
-
-    /**
-     * §2 — distribution per table, nulls included as their own row.
-     *
-     * A null `team_id` belongs to nobody, which is a different state from
-     * belonging to team 1, and the two must not be summed.
-     *
-     * @param  list<string>  $tables
-     */
-    private function distribution(array $tables): void
-    {
-        $rows = [];
-
-        foreach ($tables as $table) {
-            $counts = DB::table($table)
-                ->select('team_id', DB::raw('COUNT(*) AS rows_count'))
-                ->groupBy('team_id')
-                ->orderBy('team_id')
-                ->get();
-
-            foreach ($counts as $count) {
-                $rows[] = [$table, $count->team_id ?? 'NULL', $count->rows_count];
-            }
-
-            if ($counts->isEmpty()) {
-                $rows[] = [$table, '—', 0];
-            }
-        }
-
-        $this->line('## 2. Rows per tenant, per table');
-        $this->line('');
-        $this->markdownTable(['table', 'team_id', 'rows'], $rows);
-    }
-
-    /**
-     * §3 — how much of this is already wrong.
-     *
-     * Two kinds of evidence, and both are conclusive rather than indicative:
-     *
-     * - a row whose parent record belongs to a different team;
-     * - a row on a team whose named user is neither a member of that team nor
-     *   its owner.
-     *
-     * The issue asks for these to be reported prominently rather than buried in
-     * a count, so a non-zero total says so in as many words.
-     *
-     * @param  list<string>  $tables
-     */
-    private function mismatches(array $tables): void
-    {
-        $rows = [];
-
-        foreach ($tables as $table) {
-            $columns = Schema::getColumnListing($table);
-
-            foreach (self::OWNED_BY as $column => $parent) {
-                if (! in_array($column, $columns, true) || ! $this->isTenantScoped($parent)) {
-                    continue;
-                }
-
-                $rows[] = [$table, "{$column} → {$parent}", DB::table($table)
-                    ->join($parent, "{$parent}.id", '=', "{$table}.{$column}")
-                    ->whereNotNull("{$table}.team_id")
-                    ->whereNotNull("{$parent}.team_id")
-                    ->whereColumn("{$table}.team_id", '!=', "{$parent}.team_id")
-                    ->count()];
-            }
-
-            if (in_array('user_id', $columns, true)) {
-                $rows[] = [$table, 'user_id not in team', $this->rowsWhoseUserIsNotInTheTeam($table)];
-            }
-        }
-
-        $total = array_sum(array_column($rows, 2));
-
-        $this->line('## 3. Rows already across a boundary');
-        $this->line('');
-        $this->line($total === 0
-            ? 'None found.'
-            : "**{$total} rows are already attributed across a tenancy boundary.** These are not ambiguous rows; they are wrong ones.");
-        $this->line('');
-        $this->markdownTable(['table', 'check', 'rows'], $rows);
-    }
-
-    private function rowsWhoseUserIsNotInTheTeam(string $table): int
-    {
-        return DB::table($table)
-            ->leftJoin('team_user', function ($join) use ($table) {
-                $join->on('team_user.user_id', '=', "{$table}.user_id")
-                    ->on('team_user.team_id', '=', "{$table}.team_id");
-            })
-            // A team's owner is not in its own pivot, so without this every row
-            // created by the merchant themselves would read as a breach.
-            ->leftJoin('teams as owned', function ($join) use ($table) {
-                $join->on('owned.id', '=', "{$table}.team_id")
-                    ->on('owned.user_id', '=', "{$table}.user_id");
-            })
-            ->whereNotNull("{$table}.team_id")
-            ->whereNotNull("{$table}.user_id")
-            ->whereNull('team_user.user_id')
-            ->whereNull('owned.id')
-            ->count();
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function tenantTables(): array
-    {
-        $tables = [];
-
-        foreach (Schema::getTableListing() as $table) {
-            $table = str_contains($table, '.') ? explode('.', $table)[1] : $table;
-
-            if (! in_array($table, self::NOT_TENANT_DATA, true) && $this->isTenantScoped($table)) {
-                $tables[] = $table;
-            }
-        }
-
-        sort($tables);
-
-        return $tables;
-    }
-
-    private function isTenantScoped(string $table): bool
-    {
-        return Schema::hasTable($table) && Schema::hasColumn($table, 'team_id');
-    }
-
-    /**
-     * @param  list<string>  $headings
-     * @param  list<array<int, string|int|null>>  $rows
-     */
-    private function markdownTable(array $headings, array $rows): void
-    {
-        $this->line('| '.implode(' | ', $headings).' |');
-        $this->line('| '.implode(' | ', array_fill(0, count($headings), '---')).' |');
-
-        foreach ($rows as $row) {
-            $this->line('| '.implode(' | ', $row).' |');
-        }
-
-        $this->line('');
     }
 }

--- a/app/Support/TenantDistributionReport.php
+++ b/app/Support/TenantDistributionReport.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace App\Support;
+
+use PDO;
+
+/**
+ * The [#944](https://github.com/liberusoftware/ecommerce-laravel/issues/944)
+ * checklist, computed from a `PDO` and nothing else.
+ *
+ * **Framework-free on purpose.** The checklist has to run against production and
+ * staging, and the machine that can reach those databases is not always the one
+ * with a working `vendor/`. Everything here uses `PDO` and the schema, so
+ * `tools/tenant-distribution.php` can `require` this file directly with no
+ * autoloader, no Composer install and no deploy — while `php artisan
+ * tenants:distribution` runs the same code on a machine that does have the
+ * application.
+ *
+ * One implementation, two entry points. Two implementations would drift, and
+ * the one nobody ran would be the one somebody trusted.
+ *
+ * It reads the schema rather than a hard-coded list of tables, so a table that
+ * gains `team_id` is covered without anybody remembering. **It writes nothing.**
+ */
+class TenantDistributionReport
+{
+    /**
+     * `team_id` on these is the membership graph itself rather than tenant data.
+     */
+    private const NOT_TENANT_DATA = ['teams', 'team_user', 'team_invitations'];
+
+    /**
+     * Foreign keys whose parent also carries `team_id`, so the two can be
+     * compared. A disagreement is not a suspicion — it is a row already sitting
+     * on the wrong side of a tenancy boundary.
+     *
+     * @var array<string, string>
+     */
+    private const OWNED_BY = [
+        'customer_id' => 'customers',
+        'order_id' => 'orders',
+        'product_id' => 'products',
+        'product_category_id' => 'product_categories',
+        'collection_id' => 'collections',
+        'coupon_id' => 'coupons',
+    ];
+
+    public function __construct(private readonly PDO $pdo) {}
+
+    public function markdown(string $environment, string $database): string
+    {
+        $tables = $this->tenantTables();
+
+        return implode("\n", [
+            "# Tenant distribution — {$environment} — {$database}",
+            '',
+            'Produced by the #944 report (reads only).',
+            '',
+            $this->tenants(),
+            $this->distribution($tables),
+            $this->mismatches($tables),
+        ]);
+    }
+
+    /**
+     * §1 — how many tenants actually exist.
+     *
+     * One non-personal team means the boundary has a single occupant today and
+     * the backfill is trivial. Several means the quarantine rule is carrying
+     * real weight.
+     */
+    private function tenants(): string
+    {
+        $teams = $this->rows('SELECT id, name, personal_team, created_at FROM teams ORDER BY id');
+        $personal = count(array_filter($teams, fn ($team) => (int) $team['personal_team'] === 1));
+
+        return implode("\n", [
+            '## 1. Tenants',
+            '',
+            'teams: '.count($teams).', personal: '.$personal,
+            '',
+            $this->table(['id', 'name', 'personal_team', 'created_at'], array_map(fn ($team) => [
+                $team['id'], $team['name'], ((int) $team['personal_team'] === 1) ? 'yes' : 'no', (string) $team['created_at'],
+            ], $teams)),
+        ]);
+    }
+
+    /**
+     * §2 — distribution per table, nulls as their own row.
+     *
+     * Belonging to nobody is a different state from belonging to team 1, and
+     * the two must not be summed.
+     *
+     * @param  list<string>  $tables
+     */
+    private function distribution(array $tables): string
+    {
+        $rows = [];
+
+        foreach ($tables as $table) {
+            $counts = $this->rows(
+                "SELECT team_id, COUNT(*) AS rows_count FROM {$this->quote($table)} GROUP BY team_id ORDER BY team_id"
+            );
+
+            foreach ($counts as $count) {
+                $rows[] = [$table, $count['team_id'] ?? 'NULL', $count['rows_count']];
+            }
+
+            if ($counts === []) {
+                $rows[] = [$table, '—', 0];
+            }
+        }
+
+        return implode("\n", ['## 2. Rows per tenant, per table', '', $this->table(['table', 'team_id', 'rows'], $rows)]);
+    }
+
+    /**
+     * §3 — how much of this is already wrong.
+     *
+     * Two kinds of evidence, both conclusive rather than indicative: a row whose
+     * parent belongs to a different team, and a row on a team whose named user
+     * is neither a member of it nor its owner.
+     *
+     * @param  list<string>  $tables
+     */
+    private function mismatches(array $tables): string
+    {
+        $rows = [];
+
+        foreach ($tables as $table) {
+            $columns = $this->columns($table);
+
+            foreach (self::OWNED_BY as $column => $parent) {
+                if (! in_array($column, $columns, true) || ! $this->isTenantScoped($parent)) {
+                    continue;
+                }
+
+                $rows[] = [$table, "{$column} → {$parent}", $this->count(
+                    'SELECT COUNT(*) FROM '.$this->quote($table).' c '.
+                    'JOIN '.$this->quote($parent).' p ON p.id = c.'.$column.' '.
+                    'WHERE c.team_id IS NOT NULL AND p.team_id IS NOT NULL AND c.team_id <> p.team_id'
+                )];
+            }
+
+            if (in_array('user_id', $columns, true)) {
+                $rows[] = [$table, 'user_id not in team', $this->count(
+                    'SELECT COUNT(*) FROM '.$this->quote($table).' c '.
+                    'LEFT JOIN team_user tu ON tu.user_id = c.user_id AND tu.team_id = c.team_id '.
+                    // A team's owner has no row in its own pivot, so without
+                    // this every row the merchant created themselves reads as a
+                    // breach — on a real deployment, most of them.
+                    'LEFT JOIN teams owned ON owned.id = c.team_id AND owned.user_id = c.user_id '.
+                    'WHERE c.team_id IS NOT NULL AND c.user_id IS NOT NULL '.
+                    'AND tu.user_id IS NULL AND owned.id IS NULL'
+                )];
+            }
+        }
+
+        $total = array_sum(array_column($rows, 2));
+
+        return implode("\n", [
+            '## 3. Rows already across a boundary',
+            '',
+            match (true) {
+                $total === 0 => 'None found.',
+                $total === 1 => '**One row is already attributed across a tenancy boundary.** It is not an ambiguous row; it is a wrong one.',
+                default => "**{$total} rows are already attributed across a tenancy boundary.** These are not ambiguous rows; they are wrong ones.",
+            },
+            '',
+            $this->table(['table', 'check', 'rows'], $rows),
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function tenantTables(): array
+    {
+        $tables = array_filter(
+            $this->tables(),
+            fn (string $table) => ! in_array($table, self::NOT_TENANT_DATA, true) && $this->isTenantScoped($table),
+        );
+
+        sort($tables);
+
+        return array_values($tables);
+    }
+
+    private function isTenantScoped(string $table): bool
+    {
+        return in_array('team_id', $this->columns($table), true);
+    }
+
+    /**
+     * Schema introspection, which is the one thing PDO does not standardise.
+     *
+     * @return list<string>
+     */
+    private function tables(): array
+    {
+        $sql = $this->driver() === 'sqlite'
+            ? "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+            : 'SELECT table_name AS name FROM information_schema.tables WHERE table_schema = DATABASE()';
+
+        return array_map(fn ($row) => (string) array_values($row)[0], $this->rows($sql));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function columns(string $table): array
+    {
+        if ($this->driver() === 'sqlite') {
+            return array_map(fn ($row) => (string) $row['name'], $this->rows('PRAGMA table_info('.$this->quote($table).')'));
+        }
+
+        $statement = $this->pdo->prepare(
+            'SELECT column_name AS name FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ?'
+        );
+        $statement->execute([$table]);
+
+        return array_map(fn ($row) => (string) array_values($row)[0], $statement->fetchAll(PDO::FETCH_ASSOC));
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function rows(string $sql): array
+    {
+        return $this->pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    private function count(string $sql): int
+    {
+        return (int) $this->pdo->query($sql)->fetchColumn();
+    }
+
+    private function driver(): string
+    {
+        return $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+    }
+
+    /**
+     * Table names come from the schema rather than from input, so this is
+     * quoting for correctness — a table called `order` — not for safety.
+     *
+     * MySQL quotes identifiers with backticks unless `ANSI_QUOTES` is set, and
+     * a deployment's SQL mode is not this report's business to change.
+     */
+    private function quote(string $identifier): string
+    {
+        return $this->driver() === 'mysql'
+            ? '`'.str_replace('`', '``', $identifier).'`'
+            : '"'.str_replace('"', '""', $identifier).'"';
+    }
+
+    /**
+     * @param  list<string>  $headings
+     * @param  list<array<int, string|int|null>>  $rows
+     */
+    private function table(array $headings, array $rows): string
+    {
+        $lines = [
+            '| '.implode(' | ', $headings).' |',
+            '| '.implode(' | ', array_fill(0, count($headings), '---')).' |',
+        ];
+
+        foreach ($rows as $row) {
+            $lines[] = '| '.implode(' | ', $row).' |';
+        }
+
+        return implode("\n", $lines)."\n";
+    }
+}

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -18,7 +18,30 @@ Every command registered by the application, taken from `app/Console/Commands/`.
 | `shipping:prune-quotes` | Deletes expired shipping quotes. `--days=1` sets how far past expiry to prune |
 | `vat:oss-report` | EU OSS VAT report. `--from=`, `--to=` (default: current quarter to today), `--csv` |
 | `vat:ec-sales-list` | EC Sales List. Same three options |
+| `tenants:distribution` | Read-only tenant counts, per-table distribution and cross-boundary mismatches — the [#944](https://github.com/liberusoftware/ecommerce-laravel/issues/944) checklist. See below |
 | `module {action} {name?}` | Module scaffolding. **Does nothing useful** — see below |
+
+### The tenant-distribution report, and running it without `vendor/`
+
+`tenants:distribution` answers the [#944](https://github.com/liberusoftware/ecommerce-laravel/issues/944) checklist, which gates wave 2's backfill: how many tenants exist, how rows are distributed across them per table, and how many rows are **already** attributed across a tenancy boundary. It writes nothing.
+
+It has to be run against each real environment — production, staging, any long-lived demo — because a development database answers with seeded data, which says nothing about how production's rows are attributed.
+
+The machine that can reach production is not always the one with a working `vendor/`, so the report also runs with no Composer install, no autoloader and no deploy:
+
+```bash
+php tools/tenant-distribution.php
+```
+
+That reads `DB_CONNECTION`, `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME` and `DB_PASSWORD` from `.env`, and any of them can be overridden by a real environment variable of the same name — which is how you point it at a read replica or a restored copy rather than at production itself:
+
+```bash
+DB_HOST=replica.internal php tools/tenant-distribution.php
+```
+
+Both entry points call `App\Support\TenantDistributionReport`, which needs a `PDO` and nothing else. Two implementations would drift, and the one nobody ran would be the one somebody trusted.
+
+Paste the output onto #944, one comment per environment, without interpreting it — the rules for what the numbers mean are already fixed.
 
 ### Scheduled
 

--- a/tests/Feature/TenantDistributionCommandTest.php
+++ b/tests/Feature/TenantDistributionCommandTest.php
@@ -37,7 +37,7 @@ class TenantDistributionCommandTest extends TestCase
         $this->wishlist($mine, $product->id);
 
         $this->artisan('tenants:distribution')
-            ->expectsOutputToContain('are already attributed across a tenancy boundary')
+            ->expectsOutputToContain('One row is already attributed across a tenancy boundary')
             ->expectsOutputToContain('| wishlists | product_id → products | 1 |')
             ->assertSuccessful();
     }

--- a/tests/Feature/TenantDistributionScriptTest.php
+++ b/tests/Feature/TenantDistributionScriptTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+/**
+ * `tools/tenant-distribution.php` runs without the framework.
+ *
+ * That is the only thing worth testing about it, and it cannot be tested in
+ * process: the whole point of the file is that it works on a machine with no
+ * `vendor/`, and a test that called its code through the application would
+ * prove the opposite of what it claims. So it runs as a subprocess, against a
+ * throwaway SQLite file, with the connection passed as real environment
+ * variables — which is also the documented way to point it at a replica.
+ *
+ * The counting is `TenantDistributionReport`'s and is covered against the real
+ * schema by `TenantDistributionCommandTest`. What is covered here is the part
+ * only this file has: finding its own class without an autoloader, reading the
+ * connection, and building a DSN.
+ */
+class TenantDistributionScriptTest extends TestCase
+{
+    private string $database;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->database = tempnam(sys_get_temp_dir(), 'tenants').'.sqlite';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->database);
+
+        parent::tearDown();
+    }
+
+    public function test_it_reports_without_an_autoloader_or_an_application(): void
+    {
+        $this->seed_a_database_with_one_row_across_a_boundary();
+
+        $process = new Process(
+            [PHP_BINARY, base_path('tools/tenant-distribution.php')],
+            base_path(),
+            [
+                'APP_ENV' => 'probe',
+                'DB_CONNECTION' => 'sqlite',
+                'DB_DATABASE' => $this->database,
+            ],
+        );
+
+        $process->run();
+
+        $this->assertSame(0, $process->getExitCode(), $process->getErrorOutput());
+
+        $output = $process->getOutput();
+
+        $this->assertStringContainsString('teams: 2, personal: 1', $output);
+        $this->assertStringContainsString('One row is already attributed across a tenancy boundary', $output);
+        $this->assertStringContainsString('| wishlists | product_id → products | 1 |', $output);
+
+        // The null row is counted apart from the attributed ones, which is the
+        // distinction wave 2's backfill turns on.
+        $this->assertStringContainsString('| wishlists | NULL | 1 |', $output);
+    }
+
+    public function test_it_says_what_to_look_at_when_it_cannot_connect(): void
+    {
+        $process = new Process(
+            [PHP_BINARY, base_path('tools/tenant-distribution.php')],
+            base_path(),
+            ['DB_CONNECTION' => 'sqlite', 'DB_DATABASE' => '/nonexistent/directory/db.sqlite'],
+        );
+
+        $process->run();
+
+        // An operator running this against production has no stack trace to
+        // read and nobody to ask, so the failure names the keys it read.
+        $this->assertSame(1, $process->getExitCode());
+        $this->assertStringContainsString('Could not connect', $process->getErrorOutput());
+        $this->assertStringContainsString('DB_DATABASE', $process->getErrorOutput());
+    }
+
+    private function seed_a_database_with_one_row_across_a_boundary(): void
+    {
+        $pdo = new \PDO('sqlite:'.$this->database, null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+
+        $pdo->exec('CREATE TABLE teams (id INTEGER PRIMARY KEY, user_id INT, name TEXT, personal_team INT, created_at TEXT)');
+        $pdo->exec('CREATE TABLE team_user (id INTEGER PRIMARY KEY, team_id INT, user_id INT)');
+        $pdo->exec('CREATE TABLE products (id INTEGER PRIMARY KEY, team_id INT)');
+        $pdo->exec('CREATE TABLE wishlists (id INTEGER PRIMARY KEY, user_id INT, product_id INT, team_id INT)');
+
+        $pdo->exec('INSERT INTO teams VALUES (1, 10, "Acme", 1, "2026-01-01"), (2, 20, "Other", 0, "2026-01-02")');
+        $pdo->exec('INSERT INTO products VALUES (1, 2)');
+
+        // Owned by team 1, pointing at team 2's product. The user owns team 1,
+        // so the membership check stays quiet and this is the only breach.
+        $pdo->exec('INSERT INTO wishlists VALUES (1, 10, 1, 1)');
+        $pdo->exec('INSERT INTO wishlists VALUES (2, 10, NULL, NULL)');
+    }
+}

--- a/tools/tenant-distribution.php
+++ b/tools/tenant-distribution.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * The #944 tenant-distribution checklist, without Laravel.
+ *
+ *     php tools/tenant-distribution.php
+ *
+ * Runs from a checkout with **no `vendor/`, no Composer install and no
+ * deploy** — it needs PHP with PDO and a database it can reach, which is the
+ * difference between an operator running this today and it waiting on a
+ * release. `php artisan tenants:distribution` is the same report on a machine
+ * that does have the application; both call the same class, because two
+ * implementations would drift and the one nobody ran would be the one somebody
+ * trusted.
+ *
+ * Connection details come from `.env` in the repository root, and any of them
+ * can be overridden by a real environment variable of the same name — which is
+ * how you point it at a read replica, or at a restored copy rather than at
+ * production itself:
+ *
+ *     DB_HOST=replica.internal php tools/tenant-distribution.php
+ *
+ * **It writes nothing.** Only SELECTs, and the connection can be a read-only
+ * user.
+ *
+ * @see TenantDistributionReport
+ */
+require __DIR__.'/../app/Support/TenantDistributionReport.php';
+
+use App\Support\TenantDistributionReport;
+
+$root = dirname(__DIR__);
+
+/**
+ * Enough `.env` parsing for connection details, and no more. A real
+ * environment variable wins, so the file is the default rather than the law.
+ */
+$config = static function (string $key, string $default = '') use ($root): string {
+    $fromEnvironment = getenv($key);
+
+    if ($fromEnvironment !== false && $fromEnvironment !== '') {
+        return $fromEnvironment;
+    }
+
+    static $file;
+
+    if ($file === null) {
+        $file = [];
+
+        foreach (@file($root.'/.env', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+            if (str_starts_with(trim($line), '#') || ! str_contains($line, '=')) {
+                continue;
+            }
+
+            [$name, $value] = explode('=', $line, 2);
+            $file[trim($name)] = trim(trim($value), "\"'");
+        }
+    }
+
+    return $file[$key] ?? $default;
+};
+
+$driver = $config('DB_CONNECTION', 'mysql');
+$database = $config('DB_DATABASE');
+
+$dsn = match ($driver) {
+    'sqlite' => 'sqlite:'.($database === ':memory:' ? $database : (str_starts_with($database, '/') ? $database : $root.'/'.$database)),
+    'pgsql' => "pgsql:host={$config('DB_HOST', '127.0.0.1')};port={$config('DB_PORT', '5432')};dbname={$database}",
+    default => "mysql:host={$config('DB_HOST', '127.0.0.1')};port={$config('DB_PORT', '3306')};dbname={$database};charset=utf8mb4",
+};
+
+try {
+    $pdo = new PDO($dsn, $config('DB_USERNAME'), $config('DB_PASSWORD'), [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    ]);
+} catch (PDOException $exception) {
+    fwrite(STDERR, implode("\n", [
+        'Could not connect: '.$exception->getMessage(),
+        '',
+        "Read {$root}/.env for DB_CONNECTION, DB_HOST, DB_PORT, DB_DATABASE, DB_USERNAME and DB_PASSWORD.",
+        'Any of them can be overridden by an environment variable of the same name.',
+        '',
+    ])."\n");
+
+    exit(1);
+}
+
+echo (new TenantDistributionReport($pdo))->markdown(
+    $config('APP_ENV', 'unknown'),
+    $database === '' ? 'unknown' : $database,
+), "\n";


### PR DESCRIPTION
## The problem with #992

The #944 report shipped as an artisan command. That put a Composer install and a deploy between an operator and a question that **gates wave 2's backfill** — and the machine that can reach the production database is not always the one with a working `vendor/`. Running it on this checkout proves the point:

```
Warning: require(.../vendor/autoload.php): Failed to open stream: No such file or directory
```

## What changed

The report moves to `App\Support\TenantDistributionReport`, which takes a **`PDO` and nothing else** — schema introspection included, branching on the driver for the one thing PDO does not standardise. Two entry points call it:

| | |
| --- | --- |
| `php artisan tenants:distribution` | For a machine that has the application |
| `php tools/tenant-distribution.php` | **No `vendor/`, no autoloader, no Composer install, no deploy.** It `require`s the class file directly and builds its own connection |

One implementation, two entry points. Two implementations would drift, and the one nobody ran would be the one somebody trusted.

## Pointing it somewhere safe

The standalone script reads `DB_CONNECTION`, `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD` from `.env`, and **a real environment variable of the same name wins** — so the file is the default rather than the law:

```bash
DB_HOST=replica.internal php tools/tenant-distribution.php
```

That is how it gets pointed at a read replica or a restored copy instead of at production itself. It issues only `SELECT`s, so the credentials can be a read-only user.

## Detail worth keeping

- **Identifiers are quoted per driver.** MySQL uses backticks unless `ANSI_QUOTES` is set, and a deployment's SQL mode is not this report's business to change.
- **The connection failure is a message, not a stack trace.** An operator running this against production has nothing to read and nobody to ask, so it names the keys it read and where they come from.
- **The command emits the report line by line.** One `line()` of a multi-line string is a single output chunk, so anything reading it a line at a time — a test expectation, a `grep` in a pipeline — gets one blob. CI caught that as two failing expectations against output that plainly contained both.
- Singular when it is one row. The sentence an operator is most likely to paste should not read *"1 rows"*.

## Tests

The script runs as a **subprocess** against a throwaway SQLite file, with the connection passed as real environment variables — the documented replica path, exercised. It cannot be tested in process: the whole claim is that it works without the framework, and a test that reached the code through the application would prove the opposite.

The failure path is tested too, because a connection error is the most likely thing an operator will actually see.

Docs: `OPERATIONS.md` gains the command, and a section on running the report without `vendor/`.
