### PR TITLE
feat: write team_id instead of defaulting it, and retire the backfill wave

### DIFF
--- a/app/Services/StoreContext.php
+++ b/app/Services/StoreContext.php
@@ -94,6 +94,36 @@ class StoreContext
     }
 
     /**
+     * The team a new row belongs to, or null when nothing can answer.
+     *
+     * Derived from the store rather than asked separately, because a store
+     * belongs to exactly one team and two independent answers can disagree —
+     * which on a tenant key means a row a merchant can see in the panel and not
+     * on their storefront, or the reverse.
+     *
+     * Off a storefront and off a panel this is null, and the row is left
+     * unstamped. That is the whole correction: a tenant key with a `default(1)`
+     * turns "nobody said" into "team 1", silently, and every row created by the
+     * API, a controller, a seeder or a factory took that default.
+     */
+    public static function teamForWrites(): ?int
+    {
+        $storeId = self::forWrites();
+
+        if ($storeId !== null) {
+            $teamId = Store::query()->whereKey($storeId)->value('team_id');
+
+            if ($teamId !== null) {
+                return (int) $teamId;
+            }
+        }
+
+        // A panel user whose team owns no store yet: the panel is the only
+        // thing that can answer, and it is right — the row is theirs.
+        return self::panelTeamId();
+    }
+
+    /**
      * The stores a read is scoped to.
      *
      * One for a resolved storefront. For a panel user, every store their team

--- a/app/Traits/IsTenantModel.php
+++ b/app/Traits/IsTenantModel.php
@@ -1,12 +1,52 @@
-<?php 
+<?php
 
 namespace App\Traits;
 
 use App\Models\Team;
+use App\Services\StoreContext;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-trait IsTenantModel 
+/**
+ * Marks a model as belonging to a `Team`, and — from now on — writes it.
+ *
+ * The trait used to be a `team()` relation and nothing else. **No application
+ * code wrote `team_id`**: the only writers were Filament's tenancy and a
+ * `default(1)` on the column, so every row created by the API, a controller, a
+ * seeder or a factory silently became team 1. The default did not fill a gap,
+ * it hid one — and a tenant key that turns "nobody said" into "team 1" produces
+ * rows nobody can later distinguish from rows that really are team 1's.
+ *
+ * The migration plan answered that with a backfill wave, because on a
+ * deployment with real rows the damage is already done and the only question
+ * left is which rows can be positively attributed. **This application has no
+ * such deployment** — every database is built from the migrations — so the
+ * correction belongs where the rows are created rather than in a migration that
+ * tries to guess afterwards.
+ *
+ * So: the default is gone from the schema, and the write is here. A row that
+ * nothing can attribute is left unstamped, which is a state an operator can see
+ * and fix, unlike a row that quietly claims to be team 1's.
+ *
+ * `team_id` is deliberately absent from `$fillable` on every model that uses
+ * this. The hook is its only writer here, so no request can post its way into
+ * another merchant's tenancy.
+ *
+ * @see IsStoreScoped for the storefront-facing half — `store_id` is
+ * the grain commerce reads on, and this key is derived from it.
+ */
+trait IsTenantModel
 {
+    public static function bootIsTenantModel(): void
+    {
+        static::creating(function (Model $model) {
+            // `??=`, so Filament's own tenancy hook wins where it runs. In a
+            // panel the tenant the user is looking at is the authority; this is
+            // for every path that has no panel — the API, a controller, a
+            // seeder, a queued job.
+            $model->team_id ??= StoreContext::teamForWrites();
+        });
+    }
 
     public function team(): BelongsTo
     {

--- a/database/migrations/2024_10_10_100000_add_team_to_resources.php
+++ b/database/migrations/2024_10_10_100000_add_team_to_resources.php
@@ -6,11 +6,10 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-
     protected $tables = [
         'product_categories', 'products', 'payment_methods', 'customers', 'wishlists', 'orders',
         'coupons', 'groups', 'product_reviews', 'downloadable_products', 'images', 'cart_items',
-        'collections'
+        'collections',
     ];
 
     /**
@@ -19,11 +18,10 @@ return new class extends Migration
     public function up(): void
     {
 
-
         foreach ($this->tables as $table) {
-            if (!Schema::hasColumn($table, 'team_id')) {
+            if (! Schema::hasColumn($table, 'team_id')) {
                 Schema::table($table, function (Blueprint $table) {
-                    $table->foreignId('team_id')->nullable()->constrained()->onDelete('cascade')->default(1);
+                    $table->foreignId('team_id')->nullable()->constrained()->onDelete('cascade');
                 });
             }
         }

--- a/database/migrations/2026_07_15_000000_add_team_to_remaining_resources.php
+++ b/database/migrations/2026_07_15_000000_add_team_to_remaining_resources.php
@@ -19,7 +19,7 @@ return new class extends Migration
         foreach ($this->tables as $table) {
             if (Schema::hasTable($table) && ! Schema::hasColumn($table, 'team_id')) {
                 Schema::table($table, function (Blueprint $table) {
-                    $table->foreignId('team_id')->nullable()->constrained()->onDelete('cascade')->default(1);
+                    $table->foreignId('team_id')->nullable()->constrained()->onDelete('cascade');
                 });
             }
         }

--- a/database/migrations/2026_08_09_000000_add_team_id_to_panel_scoped_tables.php
+++ b/database/migrations/2026_08_09_000000_add_team_id_to_panel_scoped_tables.php
@@ -15,14 +15,12 @@ use Illuminate\Support\Facades\Schema;
  * actually queries, and a panel query is the difference between a dormant wrong
  * claim and a live one.
  *
- * **No `default(1)`, unlike the two migrations that added `team_id` before it.**
- * A default on a tenant key is what made every row created outside Filament
- * silently team 1, which is the ambiguity wave 2 exists to unpick — adding three
- * more tables to it to save one operator query would be paying the same cost
- * twice. Existing rows keep a null `team_id` and are therefore invisible in a
- * tenant-scoped panel until somebody attributes them. That is the plan's
- * asymmetry applied literally: hiding a row from its owner is recoverable,
- * handing it to the wrong merchant is not.
+ * **No `default(1)`.** A default on a tenant key is what made every row created
+ * outside Filament silently team 1. The two migrations that added `team_id`
+ * before this one carried that default; they no longer do, and `IsTenantModel`
+ * writes the key instead. Rows that nothing can attribute keep a null
+ * `team_id`, which is a state an operator can see and fix — unlike a row that
+ * quietly claims to be team 1's.
  */
 return new class extends Migration
 {

--- a/database/migrations/2026_08_09_000001_add_team_id_to_the_remaining_tenant_models.php
+++ b/database/migrations/2026_08_09_000001_add_team_id_to_the_remaining_tenant_models.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The last eight models that declare tenancy and had nowhere to store it.
+ *
+ * These were left without a column on purpose while `IsTenantModel` was a
+ * `team()` relation and nothing else: nothing read them through a panel or a
+ * scope, and eight columns nothing writes and nothing filters are eight columns
+ * of decoration.
+ *
+ * **The trait now writes the key**, so that reasoning expires. A model that
+ * declares tenancy and cannot store it is no longer a dormant wrong claim — it
+ * is an insert that fails on a column that is not there, which is #958 with the
+ * blame moved one file over. Claim and schema have to agree in whichever
+ * direction is true, and now the claim is the true one.
+ *
+ * These are the **roots**: merchant-owned, with no tenant-owned parent to
+ * inherit an owner from. The twenty models whose owner *is* their parent's lost
+ * the trait instead, and are deliberately absent here — copying `team_id` onto
+ * every child table is the blanket migration this plan has spent a wave
+ * unpicking.
+ *
+ * Nullable and with **no default**, like every tenant key here now. Null means
+ * nobody could say, which is a true statement about a row created by a console
+ * command; a default answers on the row's behalf, and that is the fault the
+ * whole correction is about.
+ */
+return new class extends Migration
+{
+    private const TABLES = [
+        'ab_tests',
+        'cart_recovery_campaigns',
+        'customer_groups',
+        'customer_segments',
+        'inventory_locations',
+        'recommendation_rules',
+        'seo_settings',
+        'taxonomy_categories',
+    ];
+
+    public function up(): void
+    {
+        foreach (self::TABLES as $table) {
+            if (! Schema::hasTable($table) || Schema::hasColumn($table, 'team_id')) {
+                continue;
+            }
+
+            Schema::table($table, function (Blueprint $blueprint) {
+                $blueprint->foreignId('team_id')->nullable()->constrained()->cascadeOnDelete();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (self::TABLES as $table) {
+            if (! Schema::hasTable($table) || ! Schema::hasColumn($table, 'team_id')) {
+                continue;
+            }
+
+            Schema::table($table, function (Blueprint $blueprint) {
+                $blueprint->dropForeign(['team_id']);
+                $blueprint->dropColumn('team_id');
+            });
+        }
+    }
+};

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -225,7 +225,7 @@ The list is cached and cleared by `ChannelDomain` itself on save and delete, rat
 
 **2. Backfill `store_id` alone.** — ✅ **done**
 
-On a today-single-store deployment this is a constant, so it needs no rehearsal — which is exactly why it can be separated from wave 2 without breaking that wave's rehearse-once discipline.
+On a today-single-store deployment this is a constant, so it needs no rehearsal — which is exactly why it could be separated from wave 2 while that wave still had a rehearse-once discipline to break.
 
 It was **derived from `team_id`** rather than written as a constant. The 16 tables that carry `team_id` gained a nullable `store_id`, filled from the row's own team; every team without a store got one first. On a single-team deployment the two approaches agree, and on a deployment that already has several teams the constant would have handed one merchant's rows to another. Rows with a null `team_id` keep a null `store_id` — they belong to nobody rather than to whoever sorts first.
 
@@ -356,40 +356,38 @@ Nothing read `->team` on any of the twenty; the only readers in the tree are `St
 
 ---
 
-## Wave 2 — the backfill wave
+## Wave 2 — ~~the backfill wave~~ the wave that stopped being a backfill
 
-**Gated on** [the tenant-distribution query checklist](https://github.com/liberusoftware/ecommerce-laravel/issues/944), which needs a human at a real database and cannot be run from this repository. That gate is an argument for running the checklist **now**, not a reason to reorder the waves.
+**The premise is gone.** This wave was three data migrations, one rehearsal against a production-shaped copy, a quarantine rule, and a gate on [#944](https://github.com/liberusoftware/ecommerce-laravel/issues/944) — a query checklist somebody had to run against each real environment.
 
-Three backfills — `store_id` already landed in wave 1.5 — shipped as **one sequenced data migration with a single rehearsal against a production-shaped copy**:
+All of that existed for one reason: **rows that already exist and cannot be attributed.** Every `team_id = 1` row was unverified because the column carried `default(1)` and no application code wrote it, so a row created by the API, a controller, a seeder or a factory became team 1 without anybody deciding that — and afterwards nothing could tell those rows from rows that really were team 1's. Quarantine, rehearsal and the checklist are all answers to *"which of these existing rows can we prove anything about?"*
 
-| Order | Backfill | Note |
-| --- | --- | --- |
-| 1 | `team_id` | Every `team_id = 1` row is **unverified** (below) |
-| 2 | The reviews `Customer` backfill | Touches the same customer graph as 3 |
-| 3 | The cart `'api'` session sentinel | Guest rows keep their identifier; **nothing is truncated** |
+**There are no such rows.** The application is pre-production: every database is built from the migrations, and nothing has to be migrated *from*. So the question is not which rows to attribute, it is why the schema allowed an unattributed row in the first place.
 
-Four independent migrations shipped with their own modules would discover any deadlock or half-application in production instead of in rehearsal.
+### What replaced it
 
-### The `team_id` rule
+| Was | Is |
+| --- | --- |
+| Backfill `team_id`, quarantine what cannot be attributed | **`default(1)` deleted from the migrations, and `IsTenantModel` writes the key on create** — derived from the store, which belongs to exactly one team. A row nothing can attribute is left null, which an operator can see and fix |
+| Run #944 against each environment before migrating | Nothing to run it against. The report itself stays — it is how a database gets checked rather than assumed — but it gates nothing |
+| One sequenced data migration, rehearsed once | Migrations edited where they are wrong. There is no deployment to upgrade, so a correction belongs in the migration that created the fault |
 
-**No application code writes `team_id`.** The only writers are Filament's tenancy and the migration's `default(1)`, so any row created by the API, a frontend controller, a seeder or a factory silently became team 1.
+`team_id` stays **nullable**, and that is not the old default in disguise. Null means *nobody said*, which is a true statement about a row created by a console command with no store and no panel; the fault was never nullability, it was a default that answered the question on the row's behalf.
 
-- **Treat every `team_id = 1` row as unverified.** Attribute it positively from other evidence — a creating user, an order's customer, a parent record's team.
-- **Quarantine what cannot be attributed. Do not assign it.** Under a real tenancy boundary a wrong attribution is a cross-merchant leak that the global scope will then enforce and hide. Quarantine is recoverable; a confident wrong assignment is not.
-- **After backfill, `team_id` becomes non-nullable and `default(1)` is dropped.** A default on a tenant key means a forgotten assignment silently becomes team 1 instead of failing loudly — the mechanism that created this ambiguity. With no code path writing it outside Filament, keeping the default guarantees the same drift resumes the moment the migration lands.
+### What genuinely remains, and is not a backfill
 
-### The reviews merge
+Two items from this wave were never really about attributing existing rows, and they survive as ordinary work:
 
-The most expensive of the four, and the only one that is a merge rather than a fill. [ADR 0008](./adr/0008-reviews-and-ratings-merge.md). Two details are load-bearing:
+- **The reviews and ratings merge** — [ADR 0008](./adr/0008-reviews-and-ratings-merge.md). Two duplicate stacks, one of which must win. **Port the `approved` column** onto `product_reviews`: `ReviewController` creates reviews `approved = false`, exposes an approve endpoint, and the public listing filters `where('approved', true)`, so dropping it turns a moderated listing into an unmoderated one. The `Customer` backfill it carried is now schema work rather than a data migration.
+- **The cart `'api'` session sentinel**, which is a code fix in the cart's identity handling.
 
-- **Port the `approved` column** onto `product_reviews`. `ReviewController` creates reviews `approved = false`, exposes an approve endpoint, and the public listing filters `where('approved', true)`. Dropping it turns that listing from moderated to unmoderated the moment the merge lands.
-- **Backfill a `Customer`** for every user with reviews but no `Customer` record. Both stacks are in the GDPR export and erasure paths; dropping unmappable reviews deletes user-authored personal data to simplify a migration.
+And the grain corrections this plan has been collecting, which are now edits to the migrations that got the grain wrong rather than corrections layered on top:
 
-Because it runs through GDPR paths, it is **rehearsed against production-shaped data rather than run directly** — which is the same rehearsal this whole wave gets.
+- **`coupons.code` is globally unique**, so no two merchants can issue the same code. `discounts.code` has the same fault.
 
-### Why this wave precedes any tier-1 extraction
+### Why this no longer gates wave 3
 
-Every module extracted over mis-attributed rows inherits the problem into its own migrations and tests. Doing it once against tables the host still owns is far cheaper than doing it across N packages.
+It gated tier-1 extraction because *"every module extracted over mis-attributed rows inherits the problem into its own migrations and tests"*. With no mis-attributed rows, there is nothing to inherit. **Wave 3 is unblocked.**
 
 ---
 
@@ -432,7 +430,7 @@ What each wave costs to undo, stated up front so nobody has to guess mid-inciden
 | **0** — enforcement, installer, theme | **Yes, cheaply.** Config, CI and deletions of dead code. The riskiest item is deleting `app/Modules/`, which serves zero modules | Revert the commit |
 | **1** — `ecommerce-core` | **Yes, before its first tag.** Demotion is deleting an unreleased repository and restoring the path package | See §2 |
 | **1.5** — schema, resolver, **the scope** | **The scope is reversible; the schema is additive.** Turning the scope off restores the previous (leaking) behaviour instantly | Feature-flag the scope for the first deployment |
-| **2** — backfills | **Partially.** Quarantine is recoverable by design; a wrong positive attribution is not, which is why quarantine is the default | Single rehearsal, then a reversible migration per step |
+| **2** — schema corrections | **Yes.** It stopped being a data wave: there is no production data to get wrong, so what is left is migrations and code | Revert the commit and rebuild the database |
 | **3+** — extractions | **Yes before the first tag, no after.** After a tag, demotion breaks every consumer and the honest move is deprecation | See §2 |
 
 Two asymmetries drive the whole plan:

--- a/tests/Feature/StoreBackfillTest.php
+++ b/tests/Feature/StoreBackfillTest.php
@@ -45,7 +45,19 @@ class StoreBackfillTest extends TestCase
      * Per-storefront navigation is a product change, not a backfill, and it sits
      * with wave 2's other grain corrections next to `coupons.code`.
      */
-    private const NOT_STORE_GRAINED_YET = ['discounts', 'menus', 'menu_items'];
+    private const NOT_STORE_GRAINED_YET = [
+        'discounts', 'menus', 'menu_items',
+
+        // The eight roots, which took `team_id` when `IsTenantModel` started
+        // writing the key. Team-grained today and read by nothing on a
+        // storefront, so a store scope on them would be a control over a path
+        // nobody walks. Several have an obvious store grain waiting —
+        // `seo_settings` and `inventory_locations` most of all — and each gets
+        // it when something reads it per storefront, which is the same rule the
+        // rest of this wave followed.
+        'ab_tests', 'cart_recovery_campaigns', 'customer_groups', 'customer_segments',
+        'inventory_locations', 'recommendation_rules', 'seo_settings', 'taxonomy_categories',
+    ];
 
     public function test_every_team_scoped_table_has_a_store_id(): void
     {

--- a/tests/Feature/TeamIdIsWrittenTest.php
+++ b/tests/Feature/TeamIdIsWrittenTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Channel;
+use App\Models\ChannelDomain;
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\ChannelResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * `team_id` is written when a row is created, and left alone when nothing can
+ * say whose it is.
+ *
+ * The migration plan's wave 2 existed because **no application code wrote
+ * `team_id`**: the column carried `default(1)`, so every row created by the
+ * API, a controller, a seeder or a factory became team 1 without anybody
+ * deciding that — and afterwards nothing could tell those rows apart from rows
+ * that really were team 1's. The plan answered with a backfill and a quarantine
+ * rule, which is the only thing you *can* do once the rows exist.
+ *
+ * They do not exist. Every database here is built from the migrations, so the
+ * correction belongs at the point of writing rather than in a migration that
+ * guesses afterwards. The default is gone from the schema and the write is in
+ * `IsTenantModel`.
+ *
+ * Both directions matter. A key that is never written is the bug being fixed; a
+ * key written with a guess is the bug being reintroduced under a different name.
+ */
+class TeamIdIsWrittenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_row_created_on_a_storefront_belongs_to_that_storefronts_team(): void
+    {
+        $team = Team::factory()->create();
+        $store = Store::factory()->create(['team_id' => $team->id]);
+        $this->storefront($store, 'shop.example.com');
+
+        $product = $this->onHost('shop.example.com', fn () => Product::factory()->create());
+
+        // Derived from the store rather than asked separately: a store belongs
+        // to exactly one team, and two independent answers can disagree — which
+        // on a tenant key means a row visible in the panel and not on the
+        // storefront that sells it, or the reverse.
+        $this->assertSame($team->id, $product->team_id);
+        $this->assertSame($store->id, $product->store_id);
+    }
+
+    public function test_a_row_created_in_a_panel_belongs_to_the_panel_users_team(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $team = $user->ownedTeams()->first();
+
+        $this->actingAs($user);
+
+        // No host, so no store — a merchant onboarded before their storefront
+        // is configured. The panel is the only thing that can answer, and it is
+        // right: the row is theirs.
+        $product = Product::factory()->create();
+
+        $this->assertSame($team->id, $product->team_id);
+    }
+
+    public function test_a_row_nothing_can_attribute_is_left_unstamped(): void
+    {
+        // No host, no panel user — a console command, a queued job, a seeder.
+        $product = Product::factory()->create();
+
+        // Null, not team 1. An unstamped row is a state an operator can see and
+        // fix; a row that quietly claims to be team 1's is not.
+        $this->assertNull($product->team_id);
+    }
+
+    public function test_an_explicit_team_is_not_overwritten(): void
+    {
+        $team = Team::factory()->create();
+        $store = Store::factory()->create(['team_id' => $team->id]);
+        $this->storefront($store, 'shop.example.com');
+
+        $other = Team::factory()->create();
+
+        $product = $this->onHost('shop.example.com', fn () => Product::factory()->create(['team_id' => $other->id]));
+
+        // The hook fills a gap; it does not overrule a caller who has said.
+        // Filament's own tenancy hook is one such caller, and in a panel the
+        // tenant the user is looking at is the authority.
+        $this->assertSame($other->id, $product->team_id);
+    }
+
+    public function test_no_tenant_key_carries_a_default(): void
+    {
+        $columns = ['products' => 'team_id', 'orders' => 'team_id', 'customers' => 'team_id'];
+
+        foreach ($columns as $table => $column) {
+            // A default on a tenant key turns "nobody said" into a merchant's
+            // id. That is the mechanism wave 2 was written to unpick, and it is
+            // cheaper to assert its absence than to unpick it twice.
+            $this->assertNull(
+                $this->defaultFor($table, $column),
+                "{$table}.{$column} has a default. A tenant key must not have one.",
+            );
+        }
+    }
+
+    private function storefront(Store $store, string $host): void
+    {
+        $channel = Channel::factory()->create(['store_id' => $store->id]);
+        ChannelDomain::factory()->primary()->create(['channel_id' => $channel->id, 'host' => $host]);
+    }
+
+    /**
+     * Run a callback as though the request had arrived on a host.
+     *
+     * Through the resolver and the request attribute the middleware uses, so
+     * this exercises the path a real request takes rather than a stub of it.
+     */
+    private function onHost(string $host, callable $callback): mixed
+    {
+        $channel = app(ChannelResolver::class)->resolve($host);
+
+        $this->assertNotNull($channel, "No channel resolves {$host} — the fixture is wrong.");
+
+        request()->attributes->set(ChannelResolver::ATTRIBUTE, $channel);
+
+        try {
+            return $callback();
+        } finally {
+            request()->attributes->remove(ChannelResolver::ATTRIBUTE);
+        }
+    }
+
+    private function defaultFor(string $table, string $column): ?string
+    {
+        foreach (DB::select('PRAGMA table_info('.$table.')') as $info) {
+            if ($info->name === $column) {
+                return $info->dflt_value;
+            }
+        }
+
+        $this->fail("{$table}.{$column} does not exist.");
+    }
+}

--- a/tests/Feature/TeamIdIsWrittenTest.php
+++ b/tests/Feature/TeamIdIsWrittenTest.php
@@ -57,6 +57,11 @@ class TeamIdIsWrittenTest extends TestCase
         $user = User::factory()->withPersonalTeam()->create();
         $team = $user->ownedTeams()->first();
 
+        // `withPersonalTeam()` creates the team but does not switch to it, and
+        // the tenant is read from `current_team_id` — the value both panels set
+        // when the tenant changes.
+        $user->switchTeam($team);
+
         $this->actingAs($user);
 
         // No host, so no store — a merchant onboarded before their storefront

--- a/tests/Feature/TenantModelSchemaTest.php
+++ b/tests/Feature/TenantModelSchemaTest.php
@@ -2,68 +2,47 @@
 
 namespace Tests\Feature;
 
-use App\Models\ABTest;
-use App\Models\CartRecoveryCampaign;
-use App\Models\CustomerGroup;
-use App\Models\CustomerSegment;
-use App\Models\InventoryLocation;
-use App\Models\RecommendationRule;
-use App\Models\SeoSetting;
-use App\Models\TaxonomyCategory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 /**
- * `App\Traits\IsTenantModel` is a `team()` BelongsTo relation and nothing else.
- * A model that uses it therefore promises a `team_id` column, and eight of the
- * seventeen that use it have no such column on their table — so the relation is
- * dead on arrival and a tenant scope added later would raise an unknown-column
- * error rather than isolating anything.
+ * Every model that declares tenancy has somewhere to store it. **The list of
+ * exceptions is empty**, and this is what keeps it that way.
  *
- * It was 31 of 37, and the list shrank twice for opposite reasons.
+ * It was 31 of 37, and it closed in three moves for three different reasons.
  *
- * `Discount`, `Menu` and `MenuItem` got the column, because a tenant-scoped
+ * `Discount`, `Menu` and `MenuItem` got the column because a tenant-scoped
  * Filament resource queries them — a live wrong claim rather than a dormant one
- * (#958). Twenty more lost the trait, because their owner is their parent's:
+ * (#958). Twenty models lost the trait, because their owner is their parent's:
  * `ProductVariant` belongs to a product, `GiftCardTransaction` to a gift card,
- * `InventoryLevel` to an inventory item. Copying `team_id` onto every child
- * table is the blanket migration that produced half of this, and a relation to
- * a column that will never exist is a claim, not a plan.
+ * `InventoryLevel` to an inventory item, and copying `team_id` onto every child
+ * table is the blanket migration this plan spent a wave unpicking. The last
+ * eight — the roots, with no tenant-owned parent to inherit from — got the
+ * column when `IsTenantModel` started *writing* the key, at which point a model
+ * that declares tenancy and cannot store it stopped being a dormant claim and
+ * became an insert that fails.
  *
- * What is left are the eight roots: no tenant-owned parent to inherit from, so
- * the column is the only way they could ever be tenanted.
- *
- * This test is a ratchet. The allow-list below can only shrink — a model may
- * not newly join it — and it is a list of names rather than a count, so
- * shrinking it means naming what changed.
+ * The ratchet stays because the pairing can break in both directions and both
+ * have happened here: a trait added to a model whose table has no column, and a
+ * column dropped from under a model that has the trait.
  */
 class TenantModelSchemaTest extends TestCase
 {
     use RefreshDatabase;
 
     /**
-     * The roots: merchant-owned, with no tenant-owned parent to inherit an
-     * owner from, and no table column to be owned by yet.
+     * Empty, and meant to stay that way.
      *
-     * Still not a to-do list. Nothing reads any of them through a panel or a
-     * scope, so adding eight columns today buys eight columns nothing writes
-     * and nothing filters. Each one gets its `team_id` when something needs to
-     * ask whose it is — which is how `discounts` and `menus` got theirs.
+     * An entry here is a model that says it belongs to a team and has nowhere
+     * to record which. Adding one means writing down why that is acceptable —
+     * and since the trait now writes the key on create, the honest answer is
+     * usually that the model should not have the trait.
      *
      * @var list<class-string<Model>>
      */
-    private const MISSING_TEAM_ID = [
-        ABTest::class,
-        CartRecoveryCampaign::class,
-        CustomerGroup::class,
-        CustomerSegment::class,
-        InventoryLocation::class,
-        RecommendationRule::class,
-        SeoSetting::class,
-        TaxonomyCategory::class,
-    ];
+    private const MISSING_TEAM_ID = [];
 
     public function test_tenant_models_have_a_team_id_column(): void
     {


### PR DESCRIPTION
## The premise changed

Wave 2 was three data migrations, a quarantine rule, one rehearsal against a production-shaped copy, and a gate on #944 — a query checklist somebody had to run against each real environment.

**All of it existed for one reason: rows that already exist and cannot be attributed.** `team_id` carried `default(1)` and no application code wrote it, so every row created by the API, a controller, a seeder or a factory became team 1 without anybody deciding that — and afterwards nothing could tell those rows from rows that really were team 1's. Quarantine, rehearsal and the checklist are all answers to *"which of these existing rows can we prove anything about?"*

**There are no such rows.** This application is pre-production; every database is built from the migrations. So the question is not which rows to attribute — it is why the schema ever allowed an unattributed row.

## The correction, at the fault

| | |
| --- | --- |
| `default(1)` | **Deleted** from the two migrations that carried it. There is no deployment to upgrade, so a correction belongs in the migration that created the fault |
| The write nobody did | `IsTenantModel` now writes `team_id` on create, **derived from the store** — a store belongs to exactly one team, and two independent answers can disagree, which on a tenant key means a row visible in the panel and not on the storefront that sells it |
| `??=` | Filament's own tenancy hook still wins in a panel: there, the tenant the user is looking at is the authority |
| Unattributable rows | Left **null**. An operator can see and fix a null; nothing can see a row that quietly claims to be team 1's |

`team_id` stays nullable, and that is not the default in disguise. Null means *nobody said*, which is a true statement about a row created by a console command with no store and no panel. The fault was never nullability — it was a default answering on the row's behalf.

## What CI made me finish

The trait writing the key broke **65 tests**, all one thing: the eight models that declare tenancy against tables with **no `team_id` column**. Leaving them without one was right while the trait was a relation and nothing else — nothing read them, and eight columns nothing writes are decoration. The moment the trait writes, a model that declares tenancy and cannot store it stops being a dormant wrong claim and becomes an insert that fails.

So they get the column, and `TenantModelSchemaTest`'s allow-list is now **empty** — the end state that started at 31 of 37 and closed in three moves for three different reasons: three got the column because a panel queried them (#958), twenty lost the trait because their owner is their parent's, and these last eight got theirs when the claim became true.

They are exempt from the `store_id` rule with the reason recorded: team-grained today, read by nothing on a storefront. `seo_settings` and `inventory_locations` have an obvious store grain waiting, and get it when something reads them per storefront — the same rule the rest of the wave followed.

## The plan

Wave 2 is rewritten rather than ticked. It says what it was, why the premise is gone, and what survives as ordinary work: the reviews/ratings merge (ADR 0008, with the `approved` column that keeps a moderated listing moderated), the cart `'api'` sentinel, and the grain corrections — `coupons.code` and `discounts.code` are globally unique, which is now an edit to the migration that got it wrong.

**It no longer gates wave 3.** It gated tier-1 extraction because a module extracted over mis-attributed rows inherits the problem; with no mis-attributed rows there is nothing to inherit.
