### PR TITLE
fix: a promo code belongs to the merchant who issued it, not the installation

### DIFF
--- a/app/Filament/Admin/Resources/Coupons/CouponResource.php
+++ b/app/Filament/Admin/Resources/Coupons/CouponResource.php
@@ -2,32 +2,30 @@
 
 namespace App\Filament\Admin\Resources\Coupons;
 
-use Filament\Schemas\Schema;
-use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\Select;
-use Filament\Forms\Components\DateTimePicker;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Filters\Filter;
-use Filament\Actions\EditAction;
-use Filament\Actions\DeleteAction;
-use Filament\Actions\DeleteBulkAction;
-use App\Filament\Admin\Resources\Coupons\Pages\ListCoupons;
 use App\Filament\Admin\Resources\Coupons\Pages\CreateCoupon;
 use App\Filament\Admin\Resources\Coupons\Pages\EditCoupon;
-use App\Filament\Admin\Resources\CouponResource\Pages;
+use App\Filament\Admin\Resources\Coupons\Pages\ListCoupons;
 use App\Models\Coupon;
-use Filament\Forms;
+use App\Services\StoreContext;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
-use Filament\Tables;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Validation\Rules\Unique;
 
 class CouponResource extends Resource
 {
     protected static ?string $model = Coupon::class;
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-ticket';
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-ticket';
 
     protected static ?int $navigationSort = 6;
 
@@ -37,7 +35,16 @@ class CouponResource extends Resource
             ->components([
                 TextInput::make('code')
                     ->required()
-                    ->unique(ignoreRecord: true)
+                    // Unique within the store this coupon will belong to, which
+                    // is the grain the index uses. A validation rule is a query
+                    // builder query, so no Eloquent scope reaches it — left
+                    // bare it tells a merchant their code is taken when what is
+                    // taken is a competitor's, and the database would have
+                    // accepted the row.
+                    ->unique(
+                        ignoreRecord: true,
+                        modifyRuleUsing: fn (Unique $rule) => $rule->where('store_id', StoreContext::forWrites()),
+                    )
                     ->maxLength(255),
                 Select::make('type')
                     ->required()
@@ -71,7 +78,15 @@ class CouponResource extends Resource
                 TextColumn::make('value'),
                 TextColumn::make('valid_from')->date(),
                 TextColumn::make('valid_until')->date(),
-                TextColumn::make('uses_count')->counts('orders'),
+                // Counted per row rather than with `counts('orders')`. The
+                // relation is constrained to the coupon's own store — codes are
+                // unique per store, so the code alone names several coupons —
+                // and `withCount` builds it from a blank model instance, whose
+                // store is null. That subquery returns a number, and a wrong
+                // number in a usage column is worse than a slow one.
+                TextColumn::make('uses_count')
+                    ->label('Uses')
+                    ->state(fn (Coupon $record): int => $record->orders()->count()),
                 TextColumn::make('max_uses'),
             ])
             ->filters([

--- a/app/Models/Coupon.php
+++ b/app/Models/Coupon.php
@@ -34,7 +34,16 @@ class Coupon extends Model
     public function orders()
     {
         // Orders link to coupons by code, not coupon_id (see orders.coupon_code column).
-        return $this->hasMany(Order::class, 'coupon_code', 'code');
+        //
+        // Codes are unique per store rather than per installation, so the code
+        // alone no longer names one coupon. Without the store this counts
+        // another merchant's orders, and `max_uses` — which is derived from
+        // this count — gets spent by somebody else's customers. (Which also
+        // means this relation must not be eager-loaded across coupons of
+        // different stores: one instance's store would filter them all.
+        // Nothing does today.)
+        return $this->hasMany(Order::class, 'coupon_code', 'code')
+            ->where('orders.store_id', $this->store_id);
     }
 
     public function isValid()

--- a/app/Services/CouponService.php
+++ b/app/Services/CouponService.php
@@ -13,7 +13,7 @@ class CouponService
     {
         $coupon = Coupon::where('code', $couponCode)->first();
 
-        if (!$coupon) {
+        if (! $coupon) {
             return [
                 'valid' => false,
                 'error' => 'Invalid coupon code.',
@@ -21,7 +21,7 @@ class CouponService
             ];
         }
 
-        if (!$coupon->isValid()) {
+        if (! $coupon->isValid()) {
             return [
                 'valid' => false,
                 'error' => 'This coupon has expired or reached its usage limit.',
@@ -79,7 +79,7 @@ class CouponService
      */
     public function canApplyCoupon(Coupon $coupon, float $subtotal): bool
     {
-        if (!$coupon->isValid()) {
+        if (! $coupon->isValid()) {
             return false;
         }
 
@@ -96,9 +96,17 @@ class CouponService
     public function getActiveCoupons()
     {
         $now = now();
+
         return Coupon::where('valid_from', '<=', $now)
             ->where('valid_until', '>=', $now)
-            ->leftJoin('orders', 'coupons.code', '=', 'orders.coupon_code')
+            // Joined on the store as well as the code: the global scope reaches
+            // `coupons` and not the table joined to it, so on code alone this
+            // counts every merchant's use of the same code against one
+            // merchant's `max_uses`.
+            ->leftJoin('orders', function ($join) {
+                $join->on('coupons.code', '=', 'orders.coupon_code')
+                    ->on('coupons.store_id', '=', 'orders.store_id');
+            })
             ->select('coupons.*')
             ->selectRaw('COUNT(orders.id) as usage_count')
             ->groupBy('coupons.id')

--- a/database/migrations/2024_10_10_000008_create_discounts_table.php
+++ b/database/migrations/2024_10_10_000008_create_discounts_table.php
@@ -11,7 +11,10 @@ return new class extends Migration
         Schema::create('discounts', function (Blueprint $table) {
             $table->id();
             $table->string('title');
-            $table->string('code')->nullable()->unique();
+            // Unique per team rather than per installation — see the coupons
+            // table for the same correction. The composite is added in
+            // 2026_08_09_000002, once `team_id` exists.
+            $table->string('code')->nullable();
             $table->text('description')->nullable();
             $table->enum('type', ['percentage', 'fixed_amount', 'free_shipping', 'buy_x_get_y']);
             $table->decimal('value', 10, 2);

--- a/database/migrations/2024_10_10_000010_create_coupons_table.php
+++ b/database/migrations/2024_10_10_000010_create_coupons_table.php
@@ -10,7 +10,14 @@ return new class extends Migration
     {
         Schema::create('coupons', function (Blueprint $table) {
             $table->id();
-            $table->string('code')->unique();
+            // Not unique here. A coupon is one merchant's money, and a globally
+            // unique code means the first merchant to issue SUMMER10 takes it
+            // from everyone else on the installation. The uniqueness that is
+            // actually wanted is per store, and `store_id` does not exist until
+            // 2026_08_08_000002 — so the composite lands there, in
+            // 2026_08_09_000002. Indexed, because the code is the lookup key
+            // and the orders join reads it.
+            $table->string('code')->index();
             $table->enum('type', ['percentage', 'fixed']);
             $table->decimal('value', 10, 2);
             $table->timestamp('valid_from')->nullable();

--- a/database/migrations/2026_08_09_000002_scope_promo_codes_to_the_merchant_that_issued_them.php
+++ b/database/migrations/2026_08_09_000002_scope_promo_codes_to_the_merchant_that_issued_them.php
@@ -1,0 +1,90 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * A promo code is unique to the merchant who issued it, not to the installation.
+ *
+ * `coupons.code` and `discounts.code` were globally unique, which reads like a
+ * correctness constraint and is really a land grab: the first merchant to issue
+ * `SUMMER10` takes that code from every other merchant on the installation, and
+ * they are told so by a database error on a form that had no way of knowing.
+ *
+ * The *reads* were fixed in wave 1.5 — `Coupon` is store-scoped, so a code
+ * entered on one storefront cannot find another merchant's coupon. The index
+ * grain was left behind, and this is it.
+ *
+ * **The grain differs because the models differ.** Coupons are store-scoped:
+ * two storefronts of the same merchant are two shops, and a code that works in
+ * one is not automatically live in the other. Discounts are team-scoped and
+ * deliberately not store-scoped yet (see `StoreBackfillTest`), so team is the
+ * finest grain their schema can express today. When a discount takes a
+ * `store_id`, this constraint moves with it.
+ *
+ * Null owners collide freely, because SQL treats NULLs as distinct in a unique
+ * index. That is the right behaviour and not an oversight: a row nothing could
+ * attribute is not sellable — nothing resolves a store for it — so two of them
+ * sharing a code costs nothing, and the alternative is a constraint that stops
+ * a seeder mid-run over rows no shopper can reach.
+ */
+return new class extends Migration
+{
+    /** The column each table's code is unique *within*. */
+    private const GRAIN = [
+        'coupons' => 'store_id',
+        'discounts' => 'team_id',
+    ];
+
+    public function up(): void
+    {
+        foreach (self::GRAIN as $table => $owner) {
+            if (! Schema::hasTable($table) || ! Schema::hasColumn($table, $owner)) {
+                continue;
+            }
+
+            $this->dropTheGlobalUnique($table);
+
+            Schema::table($table, function (Blueprint $blueprint) use ($owner) {
+                $blueprint->unique([$owner, 'code']);
+            });
+        }
+    }
+
+    /**
+     * The create migrations no longer declare it, so on a database built from
+     * scratch there is nothing here to drop. A database built before that edit
+     * still carries the index, and leaving it would keep the exact constraint
+     * this migration exists to remove — silently, since the composite would go
+     * on beside it and look like the job was done.
+     */
+    private function dropTheGlobalUnique(string $table): void
+    {
+        foreach (Schema::getIndexes($table) as $index) {
+            if ($index['unique'] && $index['columns'] === ['code']) {
+                Schema::table($table, function (Blueprint $blueprint) use ($index) {
+                    $blueprint->dropIndex($index['name']);
+                });
+            }
+        }
+    }
+
+    /**
+     * The global unique is not restored. Once two merchants hold the same code
+     * — the whole point of this migration — recreating it fails, and a `down()`
+     * that only works if nobody used the feature is worse than one that says so.
+     */
+    public function down(): void
+    {
+        foreach (self::GRAIN as $table => $owner) {
+            if (! Schema::hasTable($table) || ! Schema::hasColumn($table, $owner)) {
+                continue;
+            }
+
+            Schema::table($table, function (Blueprint $blueprint) use ($owner) {
+                $blueprint->dropUnique([$owner, 'code']);
+            });
+        }
+    }
+};

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -265,7 +265,7 @@ Panels keep `->tenant(Team::class, …)`. Switching them to `Store` tenancy woul
 
 `exists:products,id` in the cart's request rules still spans every merchant — **validation rules do not run through Eloquent, so no global scope reaches them.** The model lookup behind the rule does, which is what turns adding a foreign product into a 404 rather than a cart row pointing at something this storefront does not sell. Worth remembering wherever an `exists` rule is the only check.
 
-**`coupons.code` is globally unique**, so no two merchants can issue the same code today. The scope is right regardless; the index grain is wrong and belongs with wave 2's other grain corrections, not here.
+**`coupons.code` is globally unique**, so no two merchants can issue the same code today. The scope is right regardless; the index grain is wrong and belongs with wave 2's other grain corrections, not here. *(Corrected there — the code is unique per store now, and the queries that identified a coupon by code alone had to move with it.)*
 
 **The sweep finished, and is now checked rather than trusted.** Articles, reviews, ratings, invoices, wishlists, groups and downloadable products took the scope; their read paths all run through storefront requests, so none needed an exemption.
 
@@ -327,7 +327,7 @@ The cause is not the missing column. `$isScopedToTenant` is declared by Filament
 
 **The ratchet asks it the only way that works.** Not *is this resource tenant-scoped* — an unscoped resource may be deliberate — but *if it is not, did this class say so*, by checking that the property is declared on the resource itself. That is the only form that distinguishes a written-down exemption from somebody else's side effect, and it covers both panels, because the slot they share is one slot. Both panel tests now go over HTTP: the scope is registered when the panel boots, the panel boots in middleware, and `Livewire::test` skips all of it.
 
-Three tables took `team_id` and not `store_id`, against this wave's own rule, with the reason recorded next to the exemption: the menu builder's storefront component queries `Biostate\FilamentMenuBuilder\Models\Menu` **by class name**, not the model this application configures, so a store scope on `App\Models\Menu` would control the panel and leave the storefront reading exactly what it reads today. Per-storefront navigation is a product change and sits with wave 2's grain corrections, next to `coupons.code`.
+Three tables took `team_id` and not `store_id`, against this wave's own rule, with the reason recorded next to the exemption: the menu builder's storefront component queries `Biostate\FilamentMenuBuilder\Models\Menu` **by class name**, not the model this application configures, so a store scope on `App\Models\Menu` would control the panel and leave the storefront reading exactly what it reads today. Per-storefront navigation is a product change and sits with wave 2's grain corrections, alongside the `coupons.code` grain that has since been corrected.
 
 ### Rules this wave establishes
 
@@ -383,7 +383,13 @@ Two items from this wave were never really about attributing existing rows, and 
 
 And the grain corrections this plan has been collecting, which are now edits to the migrations that got the grain wrong rather than corrections layered on top:
 
-- **`coupons.code` is globally unique**, so no two merchants can issue the same code. `discounts.code` has the same fault.
+- ~~**`coupons.code` is globally unique**, so no two merchants can issue the same code. `discounts.code` has the same fault.~~ — ✅ **done**, and the uniqueness turned out to be the smaller half.
+
+  The `->unique()` is gone from both create migrations and `2026_08_09_000002` adds the composite: `(store_id, code)` on coupons, `(team_id, code)` on discounts. The grain differs because the models do — discounts are team-scoped and deliberately not store-scoped yet, so team is the finest grain their schema can express today, and the constraint moves when that does. Null owners collide freely, which is what SQL does with NULLs in a unique index and also what is wanted: a row nothing can attribute is not sellable, because nothing resolves a store for it.
+
+  **The half that was not about the index:** once two merchants hold `SUMMER10`, every query that identifies a coupon *by code alone* crosses the boundary — and `max_uses` is derived from exactly such a query. `Coupon::orders()` matched orders on `coupon_code` and nothing else, and `CouponService::getActiveCoupons()` joined `orders` on the same column; the store scope reaches `coupons` and not the table joined to it. Left alone, a competitor's customers would spend a merchant's coupon and withdraw it from their own storefront. Both now carry the store, and the two tests that would have caught it are the two that matter most in that file.
+
+  A global unique index is not a constraint that was merely too strict. It reads as correctness and behaves as a land grab: the first merchant to issue a code takes it from everyone else, and finds out through a database error on a form that could not have known.
 
 ### Why this no longer gates wave 3
 

--- a/tests/Feature/PromoCodeGrainTest.php
+++ b/tests/Feature/PromoCodeGrainTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Channel;
+use App\Models\ChannelDomain;
+use App\Models\Coupon;
+use App\Models\Discount;
+use App\Models\Store;
+use App\Models\Team;
+use App\Services\ChannelResolver;
+use App\Services\CouponService;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * A promo code belongs to the merchant who issued it.
+ *
+ * `coupons.code` and `discounts.code` were unique across the whole
+ * installation, so the first merchant to issue `SUMMER10` took that code from
+ * everybody else — enforced by a database error on a form with no way to
+ * explain it. Wave 1.5 fixed the *reads*: a code entered on one storefront
+ * cannot find another merchant's coupon. This is the index grain it left behind.
+ *
+ * Uniqueness is only half of it. Once two merchants hold the same code, every
+ * query that identifies a coupon *by code alone* reaches across the boundary —
+ * and `max_uses` is derived from exactly such a query.
+ */
+class PromoCodeGrainTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_two_merchants_can_issue_the_same_code(): void
+    {
+        $this->couponFor($this->store(), ['code' => 'SUMMER10']);
+        $this->couponFor($this->store(), ['code' => 'SUMMER10']);
+
+        $this->assertSame(2, Coupon::query()->where('code', 'SUMMER10')->count());
+    }
+
+    public function test_one_merchant_cannot_issue_the_same_code_twice(): void
+    {
+        $store = $this->store();
+
+        $this->couponFor($store, ['code' => 'SUMMER10']);
+
+        // Within one store the constraint is real and wanted: two live coupons
+        // with one code means the checkout picks whichever the database returns
+        // first, and the merchant cannot tell which discount they gave away.
+        $this->expectException(QueryException::class);
+
+        $this->couponFor($store, ['code' => 'SUMMER10']);
+    }
+
+    public function test_a_storefront_finds_its_own_coupon_and_not_the_other_merchants(): void
+    {
+        $mine = $this->store();
+        $theirs = $this->store();
+
+        $myCoupon = $this->couponFor($mine, ['code' => 'SUMMER10', 'value' => 10]);
+        $this->couponFor($theirs, ['code' => 'SUMMER10', 'value' => 90]);
+
+        $this->onHost($this->hostFor($mine), function () use ($myCoupon) {
+            $found = app(CouponService::class)->getCouponByCode('SUMMER10');
+
+            $this->assertNotNull($found, 'The storefront could not find its own coupon.');
+            $this->assertSame($myCoupon->id, $found->id, 'The storefront was given another merchant\'s coupon.');
+        });
+    }
+
+    public function test_usage_counts_only_the_orders_of_the_store_that_issued_the_coupon(): void
+    {
+        $mine = $this->store();
+        $theirs = $this->store();
+
+        $myCoupon = $this->couponFor($mine, ['code' => 'SUMMER10', 'max_uses' => 2]);
+
+        // One use of my coupon, and two of theirs — same code, different shop.
+        $this->seedOrders($mine, 'SUMMER10', 1);
+        $this->seedOrders($theirs, 'SUMMER10', 2);
+
+        $this->assertSame(1, $myCoupon->orders()->count(), 'Another merchant\'s orders were counted as mine.');
+        $this->assertTrue($myCoupon->isValid(), 'The coupon was spent by a customer who never shopped here.');
+    }
+
+    public function test_the_active_coupon_listing_counts_uses_per_store(): void
+    {
+        $mine = $this->store();
+        $theirs = $this->store();
+
+        $this->couponFor($mine, [
+            'code' => 'SUMMER10',
+            'max_uses' => 2,
+            'valid_from' => now()->subDay(),
+            'valid_until' => now()->addDay(),
+        ]);
+
+        $this->seedOrders($theirs, 'SUMMER10', 5);
+
+        // The listing joins orders to coupons by code, and the store scope
+        // reaches `coupons` but not the table joined to it.
+        $active = $this->onHost($this->hostFor($mine), fn () => app(CouponService::class)->getActiveCoupons());
+
+        $this->assertCount(1, $active, 'My coupon was withdrawn by another merchant\'s order volume.');
+    }
+
+    public function test_two_teams_can_issue_the_same_discount_code(): void
+    {
+        $this->discountFor(Team::factory()->create(), 'SPRING');
+        $this->discountFor(Team::factory()->create(), 'SPRING');
+
+        $this->assertSame(2, Discount::query()->where('code', 'SPRING')->count());
+    }
+
+    public function test_one_team_cannot_issue_the_same_discount_code_twice(): void
+    {
+        $team = Team::factory()->create();
+
+        $this->discountFor($team, 'SPRING');
+
+        $this->expectException(QueryException::class);
+
+        $this->discountFor($team, 'SPRING');
+    }
+
+    private function store(): Store
+    {
+        return Store::factory()->create(['team_id' => Team::factory()->create()->id]);
+    }
+
+    private function hostFor(Store $store): string
+    {
+        $channel = Channel::factory()->create(['store_id' => $store->id]);
+
+        return ChannelDomain::factory()->primary()->create(['channel_id' => $channel->id])->host;
+    }
+
+    /**
+     * `store_id` is not fillable — the trait's hook is its only writer — so a
+     * fixture that needs a specific store sets the attribute directly, which is
+     * what the hook itself does.
+     */
+    private function couponFor(Store $store, array $attributes): Coupon
+    {
+        $coupon = new Coupon(array_merge([
+            'type' => 'percentage',
+            'value' => 10,
+            'valid_from' => now()->subDay(),
+            'valid_until' => now()->addDay(),
+        ], $attributes));
+
+        $coupon->store_id = $store->id;
+        $coupon->save();
+
+        return $coupon;
+    }
+
+    private function discountFor(Team $team, string $code): Discount
+    {
+        $discount = new Discount([
+            'title' => 'Spring sale',
+            'code' => $code,
+            'type' => Discount::TYPE_PERCENTAGE,
+            'value' => 10,
+            'target_type' => Discount::TARGET_ORDER,
+        ]);
+
+        $discount->team_id = $team->id;
+        $discount->save();
+
+        return $discount;
+    }
+
+    /** Orders link to coupons by code, so the linkage is written the way the app writes it. */
+    private function seedOrders(Store $store, string $code, int $count): void
+    {
+        $customerId = DB::table('customers')->insertGetId([
+            'first_name' => 'Test',
+            'last_name' => 'Buyer',
+            'email' => 'buyer'.$store->id.'@example.com',
+            'phone_number' => 5551234,
+            'address' => '1 Main St',
+            'city' => 'Town',
+            'state' => 'CA',
+            'postal_code' => '00000',
+        ]);
+
+        for ($i = 0; $i < $count; $i++) {
+            DB::table('orders')->insert([
+                'customer_id' => $customerId,
+                'store_id' => $store->id,
+                'order_date' => now()->toDateString(),
+                'total_amount' => 100,
+                'payment_status' => 'paid',
+                'shipping_status' => 'pending',
+                'coupon_code' => $code,
+            ]);
+        }
+    }
+
+    /**
+     * Run a callback as though the request had arrived on a host — through the
+     * resolver and the request attribute the middleware uses, so this exercises
+     * the path a real request takes rather than a stub of it.
+     */
+    private function onHost(string $host, callable $callback): mixed
+    {
+        $channel = app(ChannelResolver::class)->resolve($host);
+
+        $this->assertNotNull($channel, "No channel resolves {$host} — the fixture is wrong.");
+
+        request()->attributes->set(ChannelResolver::ATTRIBUTE, $channel);
+
+        try {
+            return $callback();
+        } finally {
+            request()->attributes->remove(ChannelResolver::ATTRIBUTE);
+        }
+    }
+}

--- a/tests/Unit/CouponModelTest.php
+++ b/tests/Unit/CouponModelTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use App\Models\Coupon;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
@@ -98,7 +99,7 @@ class CouponModelTest extends TestCase
     {
         $coupon = $this->makeCoupon();
 
-        $this->assertInstanceOf(\Carbon\Carbon::class, $coupon->valid_until);
+        $this->assertInstanceOf(Carbon::class, $coupon->valid_until);
     }
 
     public function test_is_valid_handles_usage_limit_without_error(): void

--- a/tests/Unit/CouponModelTest.php
+++ b/tests/Unit/CouponModelTest.php
@@ -24,8 +24,16 @@ class CouponModelTest extends TestCase
         ], $overrides));
     }
 
-    /** Insert $count orders linked to a coupon by code (the real linkage column). */
-    private function seedOrders(string $couponCode, int $count): void
+    /**
+     * Insert $count orders linked to a coupon by code (the real linkage column)
+     * and to the coupon's own store, which is how the application writes them.
+     *
+     * The store matters now that codes are unique per store rather than per
+     * installation: the code alone names one coupon per merchant, so the
+     * relation carries the store too. An order with no store belongs to no
+     * merchant and counts against nobody's `max_uses`.
+     */
+    private function seedOrders(Coupon $coupon, int $count): void
     {
         $customerId = DB::table('customers')->insertGetId([
             'first_name' => 'Test',
@@ -41,11 +49,12 @@ class CouponModelTest extends TestCase
         for ($i = 0; $i < $count; $i++) {
             DB::table('orders')->insert([
                 'customer_id' => $customerId,
+                'store_id' => $coupon->store_id,
                 'order_date' => now()->toDateString(),
                 'total_amount' => 100,
                 'payment_status' => 'paid',
                 'shipping_status' => 'pending',
-                'coupon_code' => $couponCode,
+                'coupon_code' => $coupon->code,
             ]);
         }
     }
@@ -104,7 +113,7 @@ class CouponModelTest extends TestCase
     public function test_is_valid_false_when_usage_limit_reached(): void
     {
         $coupon = $this->makeCoupon(['code' => 'LIMIT2', 'max_uses' => 2]);
-        $this->seedOrders('LIMIT2', 2);
+        $this->seedOrders($coupon, 2);
 
         $this->assertSame(2, $coupon->orders()->count());
         $this->assertFalse($coupon->isValid());
@@ -113,7 +122,7 @@ class CouponModelTest extends TestCase
     public function test_is_valid_true_below_usage_limit(): void
     {
         $coupon = $this->makeCoupon(['code' => 'LIMIT3', 'max_uses' => 3]);
-        $this->seedOrders('LIMIT3', 2);
+        $this->seedOrders($coupon, 2);
 
         $this->assertTrue($coupon->isValid());
     }

--- a/tests/Unit/CouponServiceTest.php
+++ b/tests/Unit/CouponServiceTest.php
@@ -17,7 +17,7 @@ class CouponServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->service = new CouponService();
+        $this->service = new CouponService;
     }
 
     public function test_invalid_coupon_code_returns_error(): void

--- a/tests/Unit/CouponServiceTest.php
+++ b/tests/Unit/CouponServiceTest.php
@@ -140,7 +140,7 @@ class CouponServiceTest extends TestCase
 
     public function test_usage_limit_reached_returns_error(): void
     {
-        Coupon::create([
+        $coupon = Coupon::create([
             'code' => 'USEDUP',
             'type' => 'percentage',
             'value' => 10,
@@ -160,8 +160,12 @@ class CouponServiceTest extends TestCase
             'state' => 'CA',
             'postal_code' => '00000',
         ]);
+        // Stamped with the coupon's store, as the application writes it. Codes
+        // are unique per store, so an order that names no store is nobody's use
+        // of nobody's coupon.
         DB::table('orders')->insert([
             'customer_id' => $customerId,
+            'store_id' => $coupon->store_id,
             'order_date' => now()->toDateString(),
             'total_amount' => 100,
             'payment_status' => 'paid',


### PR DESCRIPTION
Wave 2's first grain correction, and the only one that turned out to be two problems.

## The index

`coupons.code` and `discounts.code` were unique across the whole installation. That reads like a correctness constraint and behaves like a land grab: the first merchant to issue `SUMMER10` takes that code from every other merchant on the deployment, and is told so by a database error on a form that had no way of knowing.

The `->unique()` is gone from both create migrations — this is develop stage, so the migration that got the grain wrong is the thing to fix — and `2026_08_09_000002` adds the composite once the owning column exists: `(store_id, code)` on coupons, `(team_id, code)` on discounts.

**The grain differs because the models do.** Coupons are store-scoped: two storefronts of one merchant are two shops. Discounts are team-scoped and deliberately not store-scoped yet (`StoreBackfillTest` records why), so team is the finest grain their schema can express today, and the constraint moves when that does.

Null owners collide freely, which is what SQL does with NULLs in a unique index and also what is wanted: a row nothing can attribute is not sellable, because nothing resolves a store for it.

## The half that was not about the index

Once two merchants hold the same code, every query that identifies a coupon **by code alone** crosses the boundary — and `max_uses` is derived from exactly such a query.

| Where | What it did |
| --- | --- |
| `Coupon::orders()` | Matched orders on `coupon_code` and nothing else. Another merchant's customers spend this merchant's coupon, and it goes dead early |
| `CouponService::getActiveCoupons()` | Joined `orders` on the same column. The store scope reaches `coupons`, never the table joined to it — so a competitor's order volume withdraws a live coupon from its own storefront |
| The panel's usage column | `counts('orders')` builds the relation from a **blank model instance**, whose store is null, so the constrained relation counts nothing. Counted per row instead: a wrong number in a usage column is worse than a slow one |
| The panel's `unique()` rule | A validation rule is a query builder query, so no Eloquent scope reaches it. Left bare it tells a merchant their code is taken when what is taken is a competitor's, and the database would have accepted the row |

The last two are the ones worth remembering: **a scope and a rule that agree today can disagree the moment the grain changes underneath them.**

## Not changed

`gift_cards.code` is also globally unique and stays that way. It is a generated 16-character bearer token rather than a word a merchant chose, and collision across merchants is a real hazard there rather than a land grab.

## Tests

`tests/Feature/PromoCodeGrainTest.php` — seven, over both halves: two merchants can issue one code and one merchant still cannot issue it twice; a storefront finds its own coupon and not the identical one next door; usage counts only the issuing store's orders, so the coupon survives a competitor's five sales; and the same pair for discounts at team grain.