### PR TITLE
fix: a saved cart belongs to an account, so drop the session it never had

### DIFF
--- a/app/GraphQL/StorefrontSchema.php
+++ b/app/GraphQL/StorefrontSchema.php
@@ -267,7 +267,6 @@ class StorefrontSchema
         $this->assertStock($product, $quantity);
 
         $item->fill([
-            'session_id' => $item->session_id ?? 'api',
             'quantity' => $quantity,
             'price' => $product->price,
         ])->save();

--- a/app/Http/Controllers/Api/CartController.php
+++ b/app/Http/Controllers/Api/CartController.php
@@ -47,7 +47,6 @@ class CartController extends Controller
         }
 
         $item->fill([
-            'session_id' => $item->session_id ?? 'api',
             'quantity' => $quantity,
             'price' => $product->price,
         ])->save();

--- a/app/Models/CartItem.php
+++ b/app/Models/CartItem.php
@@ -14,7 +14,6 @@ class CartItem extends Model
     protected $table = 'cart_items';
 
     protected $fillable = [
-        'session_id',
         'user_id',
         'product_id',
         'quantity',

--- a/app/Services/CartService.php
+++ b/app/Services/CartService.php
@@ -22,11 +22,9 @@ class CartService
         DB::transaction(function () use ($user, $sessionCart) {
             CartItem::where('user_id', $user->id)->delete();
 
-            $sessionId = Session::getId();
             foreach ($sessionCart as $productId => $line) {
                 CartItem::create([
                     'user_id' => $user->id,
-                    'session_id' => $sessionId,
                     'product_id' => $productId,
                     'quantity' => $line['quantity'],
                     'price' => $line['price'],

--- a/database/migrations/2023_09_27_130936_create_cart_items_table.php
+++ b/database/migrations/2023_09_27_130936_create_cart_items_table.php
@@ -1,5 +1,5 @@
 <?php
-    
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,7 +15,13 @@ return new class extends Migration
     {
         Schema::create($this->table, function (Blueprint $table) {
             $table->id();
-            $table->string('session_id');
+            // No `session_id`. `user_id` below is a required foreign key, so a
+            // cart item always belongs to an account and never to a session —
+            // guests are not persisted at all. The column was written by every
+            // path and read by none, which left the API filling it with the
+            // literal string 'api' because it could not be left empty.
+            // `abandoned_carts` keeps its own `session_id`, and there it is
+            // load-bearing: an abandoned cart is usually a guest's.
             $table->foreignId('user_id')->constrained()->onDelete('cascade')->onUpdate('cascade');
             $table->foreignId('product_id')->constrained()->onDelete('cascade')->onUpdate('cascade');
             $table->integer('quantity');

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -385,7 +385,11 @@ Two items from this wave were never really about attributing existing rows, and 
   **The `Customer` backfill moved from a migration to the write path.** It was going to be a migration because reviews already existed keyed to a `User` with no `Customer`; with no rows, the same requirement lands where a review is created — `getOrCreateCustomer()`, which already existed for exports. A shopper who has never had a customer record gets one rather than having their review dropped as unmappable.
 
   Two things fell out that the ADR did not name. The star rating on a review is a *rating* now that ratings are their own record, so a review writes both — `firstOrCreate`, so a breakdown the shopper already left is not flattened to one number. And the panel had no moderation surface at all: approving was an HTTP endpoint and nothing else, which is a queue with no queue. The review resource now shows the flag, filters on it, and can set it.
-- **The cart `'api'` session sentinel**, which is a code fix in the cart's identity handling.
+- ~~**The cart `'api'` session sentinel**, which is a code fix in the cart's identity handling.~~ — ✅ **done, by deleting the column rather than the sentinel.**
+
+  `cart_items.session_id` was `NOT NULL`, written by every path and read by none. `user_id` on the same table is a **required** foreign key, so a cart item never belonged to a session in the first place — guests are not persisted at all. The API and the GraphQL mutation, having no session and no way to leave the column empty, wrote the literal string `'api'`: one identity shared by every API client, sitting in a column shaped like an identity. Nothing scoped by it, which is the only reason it was not a leak — the same "not a leak yet" that `default(1)` was.
+
+  Repairing it would have meant inventing a truthful value for a column nobody reads. `abandoned_carts` keeps its own `session_id` and the contrast is the point: an abandoned cart is usually a guest's, so there the session really is the identity.
 
 And the grain corrections this plan has been collecting, which are now edits to the migrations that got the grain wrong rather than corrections layered on top:
 

--- a/tests/Feature/Api/CartApiTest.php
+++ b/tests/Feature/Api/CartApiTest.php
@@ -29,9 +29,9 @@ class CartApiTest extends TestCase
         $other = User::factory()->create();
         $p1 = $this->product(price: 10);
         $p2 = $this->product(price: 5);
-        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $p1->id, 'quantity' => 2, 'price' => 10]);
-        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $p2->id, 'quantity' => 1, 'price' => 5]);
-        CartItem::create(['user_id' => $other->id, 'session_id' => 'api', 'product_id' => $p1->id, 'quantity' => 9, 'price' => 10]);
+        CartItem::create(['user_id' => $user->id, 'product_id' => $p1->id, 'quantity' => 2, 'price' => 10]);
+        CartItem::create(['user_id' => $user->id, 'product_id' => $p2->id, 'quantity' => 1, 'price' => 5]);
+        CartItem::create(['user_id' => $other->id, 'product_id' => $p1->id, 'quantity' => 9, 'price' => 10]);
 
         $this->actingAs($user)->getJson('/api/cart')
             ->assertOk()
@@ -59,7 +59,7 @@ class CartApiTest extends TestCase
     {
         $user = User::factory()->create();
         $product = $this->product();
-        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
 
         $this->actingAs($user)->postJson('/api/cart', ['product_id' => $product->id, 'quantity' => 3])
             ->assertCreated();
@@ -83,7 +83,7 @@ class CartApiTest extends TestCase
     {
         $user = User::factory()->create();
         $product = $this->product(stock: 10);
-        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
 
         $this->actingAs($user)->putJson("/api/cart/{$product->id}", ['quantity' => 6])
             ->assertOk();
@@ -95,7 +95,7 @@ class CartApiTest extends TestCase
     {
         $user = User::factory()->create();
         $product = $this->product(stock: 2);
-        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
 
         $this->actingAs($user)->putJson("/api/cart/{$product->id}", ['quantity' => 9])
             ->assertStatus(422);
@@ -114,7 +114,7 @@ class CartApiTest extends TestCase
     {
         $user = User::factory()->create();
         $product = $this->product();
-        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
 
         $this->actingAs($user)->deleteJson("/api/cart/{$product->id}")->assertOk();
 
@@ -126,7 +126,7 @@ class CartApiTest extends TestCase
         $user = User::factory()->create();
         $other = User::factory()->create();
         $product = $this->product();
-        CartItem::create(['user_id' => $other->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+        CartItem::create(['user_id' => $other->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
 
         $this->actingAs($user)->deleteJson("/api/cart/{$product->id}")->assertOk();
 
@@ -139,8 +139,8 @@ class CartApiTest extends TestCase
         $user = User::factory()->create();
         $other = User::factory()->create();
         $product = $this->product();
-        CartItem::create(['user_id' => $user->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
-        CartItem::create(['user_id' => $other->id, 'session_id' => 'api', 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
+        CartItem::create(['user_id' => $other->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 25]);
 
         $this->actingAs($user)->deleteJson('/api/cart')->assertOk();
 

--- a/tests/Feature/CartPersistenceTest.php
+++ b/tests/Feature/CartPersistenceTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Services\CartService;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Session;
 use Tests\TestCase;
 
@@ -19,7 +20,6 @@ class CartPersistenceTest extends TestCase
     {
         return CartItem::create([
             'user_id' => $user->id,
-            'session_id' => 'old-session',
             'product_id' => $product->id,
             'quantity' => $qty,
             'price' => $price,
@@ -76,6 +76,29 @@ class CartPersistenceTest extends TestCase
             'product_id' => $product->id,
             'quantity' => 2,
         ]);
+    }
+
+    /**
+     * A saved cart belongs to an account, and to nothing else.
+     *
+     * `cart_items.session_id` was written by every path and read by none, and
+     * `user_id` is a required foreign key — so a cart item never belonged to a
+     * session in the first place. The API, which has no session and could not
+     * leave the column empty, wrote the literal string `'api'`: one identity
+     * shared by every API client, sitting in a column that looks like an
+     * identity. Nothing was scoped by it, which is the only reason it was not a
+     * leak; the fix is to stop claiming it rather than to keep it honest.
+     */
+    public function test_a_saved_cart_item_belongs_to_an_account_not_to_a_session(): void
+    {
+        $this->assertFalse(
+            Schema::hasColumn('cart_items', 'session_id'),
+            'cart_items has a session_id again — something will fill it with a sentinel.',
+        );
+
+        // The contrast, and why this is not a blanket rule: an abandoned cart is
+        // usually a guest's, so there the session really is the identity.
+        $this->assertTrue(Schema::hasColumn('abandoned_carts', 'session_id'));
     }
 
     public function test_guest_add_does_not_persist(): void

--- a/tests/Feature/GraphQLShippingRatesTest.php
+++ b/tests/Feature/GraphQLShippingRatesTest.php
@@ -43,7 +43,7 @@ class GraphQLShippingRatesTest extends TestCase
     private function cartItem(User $user): Product
     {
         $product = Product::factory()->create(['price' => 100, 'inventory_count' => 5, 'is_downloadable' => false]);
-        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 100, 'session_id' => 'api']);
+        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 100]);
 
         return $product;
     }

--- a/tests/Feature/GraphQLStorefrontTest.php
+++ b/tests/Feature/GraphQLStorefrontTest.php
@@ -154,7 +154,7 @@ class GraphQLStorefrontTest extends TestCase
     {
         Sanctum::actingAs($user = User::factory()->create());
         $product = $this->product(['inventory_count' => 10]);
-        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 10, 'session_id' => 'api']);
+        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 10]);
 
         $this->gql('mutation($p: Int!) { updateCartItem(productId: $p, quantity: 4) { quantity } }', ['p' => $product->id]);
 
@@ -165,7 +165,7 @@ class GraphQLStorefrontTest extends TestCase
     {
         $owner = User::factory()->create();
         $product = $this->product(['inventory_count' => 10]);
-        CartItem::create(['user_id' => $owner->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 10, 'session_id' => 'api']);
+        CartItem::create(['user_id' => $owner->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 10]);
 
         // A different user cannot touch the owner's line item.
         Sanctum::actingAs(User::factory()->create());
@@ -179,7 +179,7 @@ class GraphQLStorefrontTest extends TestCase
     {
         Sanctum::actingAs($user = User::factory()->create());
         $product = $this->product();
-        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 10, 'session_id' => 'api']);
+        CartItem::create(['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 1, 'price' => 10]);
 
         $data = $this->gql('mutation($p: Int!) { removeCartItem(productId: $p) }', ['p' => $product->id]);
 


### PR DESCRIPTION
The last of wave 2's ordinary work — and it resolved by deleting the column rather than fixing the value in it.

## What was there

`cart_items.session_id` was `NOT NULL`, **written by every path and read by none**. `user_id` on the same table is a *required* foreign key, so a cart item never belonged to a session in the first place: guests are not persisted at all (`CartService` says so in as many words).

The API and the GraphQL cart mutation have no session and could not leave the column empty, so both wrote the same thing:

```php
'session_id' => $item->session_id ?? 'api',
```

One identity shared by every API client, in a column shaped like an identity. Nothing scoped by it, which is the only reason it was not a leak — the same *not a leak yet* that `default(1)` was.

## Why the column and not the value

Repairing the sentinel means inventing a truthful value for a column nobody reads. There is no such value: the real answer for an API client is *there was no session*, and a column that cannot say that will be filled with something that looks like an answer.

`abandoned_carts` keeps its own `session_id`, and the contrast is the point: an abandoned cart is usually a guest's, so there the session **is** the identity.

## Changed

- `session_id` dropped from the `cart_items` create migration, with the reasoning next to `user_id` so the next person to add it reads why it went.
- Both `?? 'api'` sites deleted (`Api\CartController`, `StorefrontSchema`), plus the write in `CartService`.
- Off `CartItem::$fillable`.
- Seven test fixtures stop passing `'session_id' => 'api'` — they only ever passed it because the column would not accept null.
- One regression test: the column is gone from `cart_items` and still present on `abandoned_carts`.