### PR TITLE
refactor: rename CartItem::products() to product()

### DIFF
--- a/app/GraphQL/StorefrontSchema.php
+++ b/app/GraphQL/StorefrontSchema.php
@@ -188,7 +188,7 @@ class StorefrontSchema
                 'quantity' => Type::nonNull(Type::int()),
                 'price' => ['type' => Type::nonNull(Type::float()), 'resolve' => fn (CartItem $i) => (float) $i->price],
                 'lineTotal' => ['type' => Type::nonNull(Type::float()), 'resolve' => fn (CartItem $i) => round((float) $i->price * $i->quantity, 2)],
-                'product' => ['type' => $product, 'resolve' => fn (CartItem $i) => $i->products],
+                'product' => ['type' => $product, 'resolve' => fn (CartItem $i) => $i->product],
             ],
         ]);
     }

--- a/app/Http/Controllers/Api/CartController.php
+++ b/app/Http/Controllers/Api/CartController.php
@@ -18,7 +18,7 @@ class CartController extends Controller
     public function index(Request $request): JsonResponse
     {
         $items = CartItem::where('user_id', $request->user()->id)
-            ->with('products')
+            ->with('product')
             ->get();
 
         return response()->json([
@@ -51,7 +51,7 @@ class CartController extends Controller
             'price' => $product->price,
         ])->save();
 
-        return response()->json(['data' => $item->load('products')], 201);
+        return response()->json(['data' => $item->load('product')], 201);
     }
 
     public function update(Request $request, int $product): JsonResponse
@@ -72,7 +72,7 @@ class CartController extends Controller
 
         $item->update(['quantity' => $data['quantity']]);
 
-        return response()->json(['data' => $item->load('products')]);
+        return response()->json(['data' => $item->load('product')]);
     }
 
     public function destroy(Request $request, int $product): JsonResponse

--- a/app/Models/CartItem.php
+++ b/app/Models/CartItem.php
@@ -24,22 +24,10 @@ class CartItem extends Model
     ];
 
     /**
-     * The product on this line.
-     *
-     * The foreign key is named because Eloquent derives it from the *method*,
-     * and this method is plural: `products` gave `products_id`, a column that
-     * does not exist. Nothing errored — a missing key attribute reads as null,
-     * so eager loading quietly returned no product at all, and every caller
-     * treated that as "this line has no product": the API returned a cart with
-     * null products, the GraphQL cart resolved `product: null`, and the
-     * headless checkout skipped every line when calculating tax.
-     *
-     * The name stays plural because four call sites say `products`, and a
-     * relation that works under a bad name beats a rename in the middle of a
-     * merge. Worth correcting on its own.
+     * Nullable in practice: a line outlives the product it points at.
      */
-    public function products()
+    public function product()
     {
-        return $this->belongsTo(Product::class, 'product_id');
+        return $this->belongsTo(Product::class);
     }
 }

--- a/app/Services/CartService.php
+++ b/app/Services/CartService.php
@@ -57,8 +57,8 @@ class CartService
     {
         $contents = [];
 
-        foreach ($this->query()->with('products')->get() as $item) {
-            $product = $item->products;
+        foreach ($this->query()->with('product')->get() as $item) {
+            $product = $item->product;
 
             $contents[$item->product_id] = [
                 'name' => $product?->name,

--- a/app/Services/HeadlessCheckoutService.php
+++ b/app/Services/HeadlessCheckoutService.php
@@ -30,7 +30,7 @@ class HeadlessCheckoutService
 
     public function place(User $user, array $input): Order
     {
-        $cart = CartItem::where('user_id', $user->id)->with('products')->get();
+        $cart = CartItem::where('user_id', $user->id)->with('product')->get();
         if ($cart->isEmpty()) {
             throw new CheckoutException('Your cart is empty.');
         }
@@ -145,7 +145,7 @@ class HeadlessCheckoutService
         // the calculator counts it when it spreads the discount pro-rata.
         $taxItems = [];
         foreach ($cart as $item) {
-            $taxItems[] = ['product' => $item->products, 'quantity' => $item->quantity, 'price' => (float) $item->price];
+            $taxItems[] = ['product' => $item->product, 'quantity' => $item->quantity, 'price' => (float) $item->price];
         }
 
         $result = $this->taxCalculator->calculateCartTax($taxItems, $address, $shippingCost, $discount);

--- a/tests/Feature/CartPersistenceTest.php
+++ b/tests/Feature/CartPersistenceTest.php
@@ -156,6 +156,24 @@ class CartPersistenceTest extends TestCase
     }
 
     /**
+     * A broken `belongsTo` does not error, it returns null — and every caller
+     * reads that as "this line has no product". Assert the product, not just
+     * the absence of an exception.
+     */
+    public function test_a_cart_line_resolves_its_product(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create(['name' => 'Brass Kettle']);
+        $item = $this->saved($user, $product, 1);
+
+        $this->assertTrue($product->is($item->fresh()->product));
+
+        $this->actingAs($user);
+        $contents = app(CartService::class)->contents();
+        $this->assertSame('Brass Kettle', $contents[$product->id]['name']);
+    }
+
+    /**
      * A saved cart belongs to an account or to a guest token, and to nothing
      * else.
      *

--- a/tests/Feature/GraphQLStorefrontTest.php
+++ b/tests/Feature/GraphQLStorefrontTest.php
@@ -136,6 +136,9 @@ class GraphQLStorefrontTest extends TestCase
 
         $this->assertSame(2, $data['data']['addToCart']['quantity']);
         $this->assertEqualsWithDelta(20.0, $data['data']['addToCart']['lineTotal'], 0.001);
+        // The query has always asked for the product; nothing asserted it, so a
+        // relation resolving to null read as a pass.
+        $this->assertSame($product->name, $data['data']['addToCart']['product']['name']);
         $this->assertDatabaseHas('cart_items', ['user_id' => $user->id, 'product_id' => $product->id, 'quantity' => 2]);
     }
 


### PR DESCRIPTION
A `belongsTo` returning one product was named `products`, which forced an explicit `product_id` argument just to undo the name. Singular name, derived key, argument gone.

Call sites updated:

- `app/Services/CartService.php` — `with()` + attribute
- `app/Services/HeadlessCheckoutService.php` — `with()` + attribute
- `app/GraphQL/StorefrontSchema.php` — cart item `product` resolver
- `app/Http/Controllers/Api/CartController.php` — one `with()`, two `load()`; not in the original list

Other models keep their genuinely plural `products()` (`ProductCollection`, `Invoice`, `Discount`, `Team`, `TaxonomyCategory`, `Category`) — untouched.

Two guards against the silent-null failure mode:

- `CartPersistenceTest::test_a_cart_line_resolves_its_product` — the relation returns the right `Product`, and `CartService::contents()` carries its name.
- `GraphQLStorefrontTest::test_add_to_cart_persists_an_item` — the query already asked for `product { name }` and asserted nothing about it, so a null resolver passed. It asserts now.

Note: the API cart response key changes from `products` to `product`.