### PR TITLE
refactor: name the two recommenders after what they actually do

### DIFF
--- a/app/Console/Commands/GenerateProductRecommendations.php
+++ b/app/Console/Commands/GenerateProductRecommendations.php
@@ -2,16 +2,17 @@
 
 namespace App\Console\Commands;
 
-use App\Services\ProductRecommendationService;
+use App\Services\ProductRecommendationEngine;
 use Illuminate\Console\Command;
 
 class GenerateProductRecommendations extends Command
 {
     protected $signature = 'recommendations:generate';
+
     protected $description = 'Generate product recommendations using collaborative filtering';
 
     public function __construct(
-        protected ProductRecommendationService $recommendationService
+        protected ProductRecommendationEngine $engine
     ) {
         parent::__construct();
     }
@@ -21,11 +22,13 @@ class GenerateProductRecommendations extends Command
         $this->info('Generating product recommendations...');
 
         try {
-            $this->recommendationService->generateCollaborativeRecommendations();
+            $this->engine->generateCollaborativeRecommendations();
             $this->info('Product recommendations generated successfully!');
+
             return self::SUCCESS;
         } catch (\Exception $e) {
             $this->error("Failed to generate recommendations: {$e->getMessage()}");
+
             return self::FAILURE;
         }
     }

--- a/app/Http/Controllers/Frontend/ProductController.php
+++ b/app/Http/Controllers/Frontend/ProductController.php
@@ -7,19 +7,18 @@ use App\Models\BrowsingHistory;
 use App\Models\Product;
 use App\Models\ProductCategory;
 use App\Models\StockNotification;
-use App\Services\RecommendationService;
+use App\Services\UserHistoryRecommender;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
 
 class ProductController extends Controller
 {
-    protected $recommendationService;
+    protected $recommender;
 
-    public function __construct(RecommendationService $recommendationService)
+    public function __construct(UserHistoryRecommender $recommender)
     {
-        $this->recommendationService = $recommendationService;
+        $this->recommender = $recommender;
     }
 
     /**
@@ -131,7 +130,7 @@ class ProductController extends Controller
         // // Get recommendations
         // $recommendations = [];
         // if (auth()->check()) {
-        //     $recommendations = $this->recommendationService->getRecommendations(auth()->user());
+        //     $recommendations = $this->recommender->getRecommendations(auth()->user());
         // }
 
         // $metaTitle = $product->meta_title ?? $product->name;

--- a/app/Services/ProductRecommendationEngine.php
+++ b/app/Services/ProductRecommendationEngine.php
@@ -3,13 +3,26 @@
 namespace App\Services;
 
 use App\Models\Product;
-use App\Models\ProductRecommendation;
 use App\Models\ProductInteraction;
+use App\Models\ProductRecommendation;
 use App\Models\RecommendationRule;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
-class ProductRecommendationService
+/**
+ * Owns the stored recommendation set end to end: it captures the interactions
+ * (`trackView` and friends write ProductInteraction rows), builds the
+ * `product_recommendations` table from them by collaborative filtering — that half is
+ * driven offline by the `recommendations:generate` command — and serves the result
+ * back to requests. "Engine" rather than "reader" or "generator" because it is
+ * genuinely both, and splitting the write half out would leave two classes over one
+ * table with no caller asking for the seam.
+ *
+ * Its recommendations are cross-customer: what other people bought together, what is
+ * trending this week. For suggestions drawn from a single shopper's own history, and
+ * needing no precomputed table, see UserHistoryRecommender.
+ */
+class ProductRecommendationEngine
 {
     /**
      * Get personalized recommendations for a user

--- a/app/Services/UserHistoryRecommender.php
+++ b/app/Services/UserHistoryRecommender.php
@@ -5,7 +5,18 @@ namespace App\Services;
 use App\Models\Product;
 use App\Models\User;
 
-class RecommendationService
+/**
+ * Recommends from what one shopper has already done: their orders, their browsing
+ * history and the products they rated. Everything is derived at request time and
+ * nothing is stored — this half of Recommendations never reads or writes the
+ * `product_recommendations` table, so it has no batch to wait for and works on a
+ * user who signed up a minute ago.
+ *
+ * Its counterpart is ProductRecommendationEngine, which serves the precomputed,
+ * cross-customer recommendations. Reach for this one when the signal you want is
+ * the individual's own history; reach for that one when it is the crowd's.
+ */
+class UserHistoryRecommender
 {
     public function getRecommendations(User $user, $limit = 5)
     {

--- a/docs/CHAT_IMPLEMENTATION_SUMMARY.md
+++ b/docs/CHAT_IMPLEMENTATION_SUMMARY.md
@@ -380,7 +380,7 @@ Successfully added enterprise-grade features inspired by **Shopify Winter 2026 E
 ### Service Layer
 ```
 3 Service Classes:
-├── ProductRecommendationService
+├── ProductRecommendationEngine
 │   ├── getPersonalizedRecommendations()
 │   ├── getAlsoBoughtRecommendations()
 │   ├── getSimilarProducts()
@@ -497,7 +497,7 @@ $segment->calculateMembers();
 
 ### Product Recommendations
 ```php
-$service = app(ProductRecommendationService::class);
+$service = app(ProductRecommendationEngine::class);
 
 // Personalized
 $recommendations = $service->getPersonalizedRecommendations($userId, limit: 10);

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -290,7 +290,7 @@ Seven pairs were reported by the inventory. **Three are not duplicates.**
 
 | Pair | Why not |
 | --- | --- |
-| `RecommendationService` (82 lines) / `ProductRecommendationService` (230) | Not the read/generator split this table first recorded — reading the code, both read and only one writes. The short one derives suggestions from a single shopper's own orders, browsing and ratings at request time and stores nothing; the long one captures interactions, builds the `product_recommendations` table from cross-customer co-occurrence, and serves it back. Different signals, not two halves of one algorithm. Both belong to Recommendations. **Renamed** to `UserHistoryRecommender` and `ProductRecommendationEngine` |
+| `RecommendationService` (82 lines) / `ProductRecommendationService` (230) | A read/generator split of one module — one serves `Frontend/ProductController`, the other is driven by the `GenerateProductRecommendations` command. Both belong to Recommendations; rename to say so |
 | Products / Reports / Settings across both Filament panels | **`MODULES.md` §5.6 requires it**: a `-filament` package "presents only its matching domain module, covers **all panels** that module requires". The real work is deduplicating the shared schema *inside* that one package — choosing a panel is what §5.6 forbids |
 | Two `MenuResource` classes | A 13-line wrapper over `biostate/filament-menu-builder`'s `BaseMenuResource` and a 76-line hand-written resource on the same model. Keep the wrapper — but **diff the hand-written one against the package base first**, so anything it does that the base doesn't is known before it goes |
 

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -290,7 +290,7 @@ Seven pairs were reported by the inventory. **Three are not duplicates.**
 
 | Pair | Why not |
 | --- | --- |
-| `RecommendationService` (82 lines) / `ProductRecommendationService` (230) | A read/generator split of one module — one serves `Frontend/ProductController`, the other is driven by the `GenerateProductRecommendations` command. Both belong to Recommendations; rename to say so |
+| `RecommendationService` (82 lines) / `ProductRecommendationService` (230) | Not the read/generator split this table first recorded — reading the code, both read and only one writes. The short one derives suggestions from a single shopper's own orders, browsing and ratings at request time and stores nothing; the long one captures interactions, builds the `product_recommendations` table from cross-customer co-occurrence, and serves it back. Different signals, not two halves of one algorithm. Both belong to Recommendations. **Renamed** to `UserHistoryRecommender` and `ProductRecommendationEngine` |
 | Products / Reports / Settings across both Filament panels | **`MODULES.md` §5.6 requires it**: a `-filament` package "presents only its matching domain module, covers **all panels** that module requires". The real work is deduplicating the shared schema *inside* that one package — choosing a panel is what §5.6 forbids |
 | Two `MenuResource` classes | A 13-line wrapper over `biostate/filament-menu-builder`'s `BaseMenuResource` and a 76-line hand-written resource on the same model. Keep the wrapper — but **diff the hand-written one against the package base first**, so anything it does that the base doesn't is known before it goes |
 

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -433,7 +433,15 @@ Prerequisites specific to this wave, from [`CONFORMANCE.md` §5](./CONFORMANCE.m
   `guest_token` is deliberately **not** a session id. A session id is a credential, and this column is read by staff tooling and abandoned-cart jobs. It is also not the `session_id` column deleted a few commits earlier: that one was written by every path and read by none, which is what made the API's `'api'` sentinel possible. This one has one writer, one reader, and a constraint.
 
   A consequence worth naming: the cart is store-scoped like everything else in wave 1.5, so a guest's cart no longer follows them between merchants' storefronts. That was the defect this plan describes as *"items added on one storefront appearing on another means a shopper checks out a competitor's basket"* — it was only ever half-fixed, because the session copy was never scoped by anything.
-- The **recommender rename** lands with Recommendations.
+- ~~The **recommender rename** lands with Recommendations.~~ — ✅ **done, and the pair is not what `CONFORMANCE.md` §5.1 recorded.**
+
+  The snapshot calls it *"a read/generator split of one module"*. It is not. Both read, only one writes, and they read different things: the short service derives suggestions at request time from **one shopper's own** orders, browsing and ratings, and stores nothing; the long one captures interactions, builds `product_recommendations` from **cross-customer** co-occurrence, and serves the stored set back. Two recommenders over two signals, not two halves of one algorithm — and of the long one's nine methods exactly one generates.
+
+  So the obvious `…Reader` / `…Generator` pair would have been a fresh lie in both directions: the "reader" is the one that computes from scratch, and the "generator" is mostly reads. They are `UserHistoryRecommender` and `ProductRecommendationEngine`, because the question a caller actually has is *whose behaviour is the signal* — this shopper's, or the crowd's.
+
+  **`UserHistoryRecommender` has no live caller.** `Frontend/ProductController` injects it, but the only call sits in a commented-out block alongside a commented-out `BrowsingHistory::create` — so the whole personal read path is dormant, and its test asserts nothing but that the container can build it. §5.1 said keep both, on a characterisation that turned out wrong; whether a dormant recommender is worth keeping is a decision for Recommendations, not for a rename.
+
+  Left standing deliberately: `BrowsingHistory` and `ProductInteraction` rows of type `view` record the same fact in two tables, and both services run a same-category "similar products" query. Real duplication, but a rename that also refactors is a rename nobody can review.
 
 After wave 3 the sequencing rule in §1 carries the rest with no further enumeration.
 

--- a/tests/Unit/ProductRecommendationEngineTest.php
+++ b/tests/Unit/ProductRecommendationEngineTest.php
@@ -7,32 +7,32 @@ use App\Models\ProductCategory;
 use App\Models\ProductInteraction;
 use App\Models\ProductRecommendation;
 use App\Models\User;
-use App\Services\ProductRecommendationService;
+use App\Services\ProductRecommendationEngine;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class ProductRecommendationServiceTest extends TestCase
+class ProductRecommendationEngineTest extends TestCase
 {
     use RefreshDatabase;
 
-    private ProductRecommendationService $service;
+    private ProductRecommendationEngine $service;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->service = app(ProductRecommendationService::class);
+        $this->service = app(ProductRecommendationEngine::class);
     }
 
     private function makeProduct(array $overrides = []): Product
     {
         $category = ProductCategory::create([
             'name' => 'Rec Category',
-            'slug' => 'rec-cat-' . uniqid(),
+            'slug' => 'rec-cat-'.uniqid(),
         ]);
 
         return Product::create(array_merge([
             'name' => 'Rec Product',
-            'slug' => 'rec-prod-' . uniqid(),
+            'slug' => 'rec-prod-'.uniqid(),
             'price' => 25.00,
             'category_id' => $category->id,
             'inventory_count' => 5,
@@ -41,7 +41,7 @@ class ProductRecommendationServiceTest extends TestCase
 
     public function test_service_can_be_resolved(): void
     {
-        $this->assertInstanceOf(ProductRecommendationService::class, $this->service);
+        $this->assertInstanceOf(ProductRecommendationEngine::class, $this->service);
     }
 
     public function test_product_recommendation_model_can_be_created(): void

--- a/tests/Unit/UserHistoryRecommenderTest.php
+++ b/tests/Unit/UserHistoryRecommenderTest.php
@@ -4,19 +4,19 @@ namespace Tests\Unit;
 
 use App\Models\Product;
 use App\Models\User;
-use App\Services\RecommendationService;
+use App\Services\UserHistoryRecommender;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class RecommendationServiceTest extends TestCase
+class UserHistoryRecommenderTest extends TestCase
 {
     use RefreshDatabase;
 
     public function test_service_can_be_resolved(): void
     {
-        $service = app(RecommendationService::class);
+        $service = app(UserHistoryRecommender::class);
 
-        $this->assertInstanceOf(RecommendationService::class, $service);
+        $this->assertInstanceOf(UserHistoryRecommender::class, $service);
     }
 
     public function test_browsing_history_can_be_recorded_and_related(): void


### PR DESCRIPTION
Last named prerequisite of wave 3 in `docs/MIGRATION_PLAN.md`. `docs/CONFORMANCE.md` §5.1 rules `RecommendationService` / `ProductRecommendationService` **not a duplicate** — both survive, neither is merged or deleted here. The defect was that the names did not say which was which, and the shorter one read like the general-purpose recommender when it is the narrower of the two.

## The doc's characterisation was wrong

§5.1 called the pair "a read/generator split of one module". Reading the code, it isn't. **Both read; only one writes**, and they read entirely different data:

| Was | Now | What it actually does |
| --- | --- | --- |
| `RecommendationService` | `UserHistoryRecommender` | Derives suggestions at request time from **one shopper's own** orders, browsing history and product ratings. Never touches `product_recommendations`, never writes anything, needs no batch to have run. |
| `ProductRecommendationService` | `ProductRecommendationEngine` | Owns the **stored, cross-customer** set end to end: captures interactions (`trackView`/`trackAddToCart`/`trackPurchase` write `ProductInteraction`), builds `product_recommendations` by collaborative filtering (`recommendations:generate`), and serves it back (`getPersonalizedRecommendations`, `getTrendingProducts`, `getAlsoBoughtRecommendations`, `getSimilarProducts`). |

Only one of the long service's nine methods generates; the rest are reads. Naming it `…Generator` would have been a fresh lie, so it is `…Engine` — it genuinely both writes and reads one table.

The distinction that matters to a caller is the **signal**: the individual's own history, or the crowd's. The names now say that. §5.1 is corrected in this PR to match the code.

## Also in here

- Class-level docblocks on both services saying which half of Recommendations they are and who drives them.
- `$recommendationService` properties renamed to match their new types (`$recommender`, `$engine`).
- Pint on the touched files, which cleared some pre-existing debt in `ProductController` and the command (unused `Response` import, statement spacing).
- `docs/CHAT_IMPLEMENTATION_SUMMARY.md` code samples updated. The `docs/research/*` inventories are dated snapshots and were left alone.

## Deliberately not done

- **No logic moved between the two.** They do overlap conceptually — `UserHistoryRecommender` reads `BrowsingHistory` while `ProductRecommendationEngine` reads `ProductInteraction` rows of type `view`, which is the same fact recorded twice in two tables, and both compute a same-category "similar products" query. Real duplication, worth collapsing, but a rename that also refactors is a rename nobody can review.
- **`UserHistoryRecommender` currently has no live caller.** `Frontend/ProductController` still constructor-injects it, but its only call site is inside the commented-out block in `show()`. Left as found — §5.1 says both services stay.