### PR TITLE
docs: the CMS and CRM repositories exist, so stop saying they do not

### DIFF
--- a/docs/CHAT_ARCHITECTURE_DIAGRAM.md
+++ b/docs/CHAT_ARCHITECTURE_DIAGRAM.md
@@ -1,6 +1,6 @@
 # Chat System Architecture Diagram
 
-> **Held as named debt.** The live-chat feature belongs to the **CRM** product (`chat-and-bots`), which is documentation-only — no repository exists. This code stays in the host until it does; see [#943](https://github.com/liberusoftware/ecommerce-laravel/issues/943) and [`CONFORMANCE.md` §4.2](./CONFORMANCE.md#42-the-98-unmappable-files-were-an-artifact).
+> **Held as named debt, and now a duplicate rather than an orphan.** The live-chat feature belongs to the **CRM** product (`chat-and-bots`). `liberusoftware/crm-laravel` exists — it is on `2.0.1` — and it already carries its own chat stack (`LiveChat`, `ChatMessage`, `Chatbot`, `ChatbotInteraction`), so this code is not waiting for a home, it is a second implementation of one that exists. Which stack survives is a cross-repository merge decision, not a move; see [#943](https://github.com/liberusoftware/ecommerce-laravel/issues/943) and [`CONFORMANCE.md` §4.2](./CONFORMANCE.md#42-the-98-unmappable-files-were-an-artifact).
 
 ## System Components Flow
 

--- a/docs/CHAT_IMPLEMENTATION_SUMMARY.md
+++ b/docs/CHAT_IMPLEMENTATION_SUMMARY.md
@@ -1,6 +1,6 @@
 # Implementation Summary: Customer Support Chat System
 
-> **Held as named debt.** The live-chat feature belongs to the **CRM** product (`chat-and-bots`), which is documentation-only — no repository exists. This code stays in the host until it does; see [#943](https://github.com/liberusoftware/ecommerce-laravel/issues/943) and [`CONFORMANCE.md` §4.2](./CONFORMANCE.md#42-the-98-unmappable-files-were-an-artifact).
+> **Held as named debt, and now a duplicate rather than an orphan.** The live-chat feature belongs to the **CRM** product (`chat-and-bots`). `liberusoftware/crm-laravel` exists — it is on `2.0.1` — and it already carries its own chat stack (`LiveChat`, `ChatMessage`, `Chatbot`, `ChatbotInteraction`), so this code is not waiting for a home, it is a second implementation of one that exists. Which stack survives is a cross-repository merge decision, not a move; see [#943](https://github.com/liberusoftware/ecommerce-laravel/issues/943) and [`CONFORMANCE.md` §4.2](./CONFORMANCE.md#42-the-98-unmappable-files-were-an-artifact).
 
 ## Overview
 Successfully implemented a comprehensive live chat system for customer support with minimal changes to the existing codebase.

--- a/docs/CHAT_QUICK_REFERENCE.md
+++ b/docs/CHAT_QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Chat System Quick Reference Guide
 
-> **Held as named debt.** The live-chat feature belongs to the **CRM** product (`chat-and-bots`), which is documentation-only — no repository exists. This code stays in the host until it does; see [#943](https://github.com/liberusoftware/ecommerce-laravel/issues/943) and [`CONFORMANCE.md` §4.2](./CONFORMANCE.md#42-the-98-unmappable-files-were-an-artifact).
+> **Held as named debt, and now a duplicate rather than an orphan.** The live-chat feature belongs to the **CRM** product (`chat-and-bots`). `liberusoftware/crm-laravel` exists — it is on `2.0.1` — and it already carries its own chat stack (`LiveChat`, `ChatMessage`, `Chatbot`, `ChatbotInteraction`), so this code is not waiting for a home, it is a second implementation of one that exists. Which stack survives is a cross-repository merge decision, not a move; see [#943](https://github.com/liberusoftware/ecommerce-laravel/issues/943) and [`CONFORMANCE.md` §4.2](./CONFORMANCE.md#42-the-98-unmappable-files-were-an-artifact).
 
 ## For Developers
 

--- a/docs/CHAT_SYSTEM.md
+++ b/docs/CHAT_SYSTEM.md
@@ -1,6 +1,6 @@
 # Customer Support Chat System
 
-> **Held as named debt.** The live-chat feature belongs to the **CRM** product (`chat-and-bots`), which is documentation-only — no repository exists. This code stays in the host until it does; see [#943](https://github.com/liberusoftware/ecommerce-laravel/issues/943) and [`CONFORMANCE.md` §4.2](./CONFORMANCE.md#42-the-98-unmappable-files-were-an-artifact).
+> **Held as named debt, and now a duplicate rather than an orphan.** The live-chat feature belongs to the **CRM** product (`chat-and-bots`). `liberusoftware/crm-laravel` exists — it is on `2.0.1` — and it already carries its own chat stack (`LiveChat`, `ChatMessage`, `Chatbot`, `ChatbotInteraction`), so this code is not waiting for a home, it is a second implementation of one that exists. Which stack survives is a cross-repository merge decision, not a move; see [#943](https://github.com/liberusoftware/ecommerce-laravel/issues/943) and [`CONFORMANCE.md` §4.2](./CONFORMANCE.md#42-the-98-unmappable-files-were-an-artifact).
 
 ## Overview
 A comprehensive live chat system for customer support with real-time messaging, agent management, and analytics tracking.

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -492,6 +492,12 @@ Two asymmetries drive the whole plan:
 ## 4. What is outside this plan
 
 - **The 105 modules themselves** — the execution epics.
-- **The deferred CMS and CRM code** ([#942](https://github.com/liberusoftware/ecommerce-laravel/issues/942), [#943](https://github.com/liberusoftware/ecommerce-laravel/issues/943)). It moves when those products have repositories, not on a date this plan can name.
+- **The deferred CMS and CRM code** ([#942](https://github.com/liberusoftware/ecommerce-laravel/issues/942), [#943](https://github.com/liberusoftware/ecommerce-laravel/issues/943)). This plan said it moves *"when those products have repositories, not on a date this plan can name"*. **They have repositories** — re-checked 2026-08-09, `cms-laravel` is live and `crm-laravel` is on `2.0.1` — so the condition this plan set has been met and the item still is not takeable, for two different reasons.
+
+  For **CMS**, the destination is now nameable per cluster: `cms-laravel/packages/liberu-cms/` holds 21 path packages, among them `cms-pages`, `cms-posts`, `cms-seo` and `cms-forms`, which own all three clusters #942 lists. None is published, so the exit criterion's second half stands — but the receiving host has none of the code, which makes this a move whenever somebody decides to make it.
+
+  For **CRM** it stopped being a move at all. `crm-laravel` already carries `LiveChat`, `ChatMessage`, `Chatbot` and `ChatbotInteraction`, so the live-chat stack here is a **second implementation of one that exists**, in a different repository, with neither authoritative. That is the reviews/ratings duplicate stack again with the two halves split across repositories — and the larger implementation is the one in the repository that should not own it.
+
+  Recorded rather than acted on: which stack survives is a decision about a product this repository has no mandate over. What this plan can say is that the deferral's premise expired, and a deferral whose premise has expired needs re-deciding rather than re-applying.
 - **The five out-of-scope flavours** — `react`, `vue`, `nuxt`, `flutter`, `react-native`.
 - **Adding a locale.** `en` only; adding a language is product scope. The RTL machinery in `TRANSLATIONS.md` and `THEMES.md` §18.1 stays unexercised as a result, which is recorded as a deliberate deferral rather than an oversight.


### PR DESCRIPTION
Re-checked the premise behind #942 and #943, one month on. **Both product repositories are live.** The four `docs/CHAT_*.md` banners and `MIGRATION_PLAN.md` still asserted they were not.

- `liberusoftware/cms-laravel` — live, and `packages/liberu-cms/` already holds 21 path packages including `cms-pages`, `cms-posts`, `cms-seo` and `cms-forms`, which own all three clusters #942 lists. Unpublished, so the exit criterion’s second half stands.
- `liberusoftware/crm-laravel` — on `2.0.1`, **and it already carries a chat stack**: `LiveChat`, `ChatMessage`, `Chatbot`, `ChatbotInteraction`.

That second one changes the shape of the debt rather than clearing it. The live-chat code here is not waiting for a home — it is a **second implementation of one that exists**, in another repository, with neither side authoritative and neither side seeing the other’s changes. That is the reviews/ratings duplicate stack ([ADR 0008](../blob/main/docs/adr/0008-reviews-and-ratings-merge.md)) with the halves split across repositories, and the larger implementation is the one in the repository that should not own it.

**Nothing is moved or merged.** Which stack survives is a decision about products this repository has no mandate over. What it can do is stop publishing a premise that expired — a deferral whose condition has been met but which still is not takeable is exactly the thing that goes quiet and becomes permanent.

`CONFORMANCE.md` is deliberately untouched: it is a dated snapshot and it was correct on 2026-08-08. Findings on #942, #943 and #961 record the re-check.