### PR TITLE
feat: PHPStan static-analysis gate (wave 0 enforcement layer)

### DIFF
--- a/.github/workflows/phpstan-measure.yml
+++ b/.github/workflows/phpstan-measure.yml
@@ -1,0 +1,53 @@
+name: PHPStan Measure
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+          ini-values: memory_limit=2G
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-scripts
+
+      - name: Count errors per level
+        run: |
+          set -uo pipefail
+          mkdir -p reports
+          for level in 0 1 2 3 4 5 6 7 8 9 10; do
+            ./vendor/bin/phpstan analyse --level "$level" --no-progress --error-format=json \
+              > "reports/level-$level.json" 2>"reports/level-$level.stderr" || true
+            count=$(php -r '$j=json_decode(file_get_contents($argv[1]),true); echo $j["totals"]["file_errors"] ?? "ERR";' "reports/level-$level.json")
+            echo "level $level: $count" | tee -a reports/counts.txt
+          done
+
+      - name: Generate candidate baselines
+        if: always()
+        run: |
+          set -uo pipefail
+          mkdir -p baselines
+          for level in 6 7 8; do
+            ./vendor/bin/phpstan analyse --level "$level" --no-progress \
+              --generate-baseline "baselines/phpstan-baseline-$level.neon" || true
+          done
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: phpstan-measurement
+          path: |
+            baselines
+            reports

--- a/.github/workflows/phpstan-measure.yml
+++ b/.github/workflows/phpstan-measure.yml
@@ -1,6 +1,8 @@
 name: PHPStan Measure
 
 on:
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 8
+    paths:
+        - app
+        - bootstrap
+        - database
+        - routes
+    treatPhpDocTypesAsCertain: false


### PR DESCRIPTION
Lands the static-analysis half of the wave 0 **enforcement layer**. `pint.json` and the architecture tests already existed; PHPStan was configured nowhere. It is now.

No new dependency: `phpstan/phpstan` 2.2.6 is already in `composer.lock`, pulled in transitively by `rector/rector`, so `vendor/bin/phpstan` exists after `composer install`. Nothing was added to `require` or `require-dev` and `composer.lock` is untouched.

## The level: measured, not guessed

The plan asks for level 8. A temporary CI job ran `phpstan analyse --level N` across the whole ladder on `app`, `bootstrap`, `database`, `routes`:

| level | errors | | level | errors |
| --- | ---: | --- | --- | ---: |
| 0 | **26** | | 6 | 2015 |
| 1 | 481 | | 7 | 2065 |
| 2 | 909 | | 8 | **2068** |
| 3 | 934 | | 9 | 2376 |
| 4 | 938 | | 10 | 4380 |
| 5 | 956 | | | |

`larastan/larastan` is not installed and cannot be installed in this environment, so PHPStan has no idea what Eloquent or the facades are. That is what the cliff between 26 and 481 is. At level 2, **802 of the 909 errors are two identifiers**:

- `property.notFound` — `Access to an undefined property App\Models\Order::$id.` (×24), `App\Models\User::$id` (×22), …
- `staticMethod.notFound` — `Call to an undefined static method App\Models\Product::where().` (×12), …

Those are Eloquent working exactly as designed. Larastan is the package whose entire job is to explain them to PHPStan.

**Chosen: level 0, whole tree, no baseline.** Burying ~2000 magic-noise errors in a baseline to be able to say "level 8" would not be a record of debt — it would be a way of not looking, and the handful of real findings would be lost inside it. The gate lands where every finding the tool produces is true. The full ladder and the upgrade path are written into `phpstan.neon`, not just this PR: install `larastan/larastan` (needs Composer network), add its `extension.neon` to `includes`, re-measure, climb.

## What level 0 found on day one

26 errors, and they were almost all real. All fixed in this PR, which is why the gate is green with nothing hidden behind it.

**Live bug**
- `app/Models/Team.php:78` — `collections()` returned `hasMany(App\Models\Collection::class)`. That model was renamed to `ProductCollection` (`CollectionResource` already points at the new name; `App\Models\Collection` does not exist). `$team->collections()` fataled. → `ProductCollection::class`.

**Dead code that referenced classes that do not exist** — none of it registered anywhere, so none of it could have been wired up without failing:
- `app/Actions/Fortify/CreateNewUserWithTeams.php` — `app(TeamManagementService::class)`; no such class in the repo. Unbound. **Deleted.**
- `app/Listeners/CreatePersonalTeam.php` — constructor type-hints `App\Services\TeamManagementService`; same missing class, so the container could never build it. Referenced only in commented-out blocks in `AppPanelProvider` and `JetstreamServiceProvider`. **Deleted**, along with those dead comments and the now-dangling imports.
- `app/Listeners/EmailTracker.php` — calls `App\Models\EmailCampaign::find()` and `App\Models\Lead::find()`. Neither model exists; both are CRM concepts. A leftover of the same family as the `ScreeningDataEncryptor` deleted earlier in wave 0. **Deleted.**
- `database/factories/CollectionFactory.php` — targets the same renamed `Collection` model. `ProductCollectionFactory` is the live one. **Deleted.**
- `app/Notifications/PaypalTransactionNotification::toNexmo()` — instantiates `Illuminate\Notifications\Messages\NexmoMessage`, removed from the framework in Laravel 9. `via()` returns only `mail` and `database`, so it was unreachable rather than actively fataling. **Deleted**, with its import and the stale comment pointing at it.

**PHP 8.4 implicit-nullable deprecations** — on a repo whose `require` is `php: ^8.5`:
- `AddTeamMember::add()`, `InviteTeamMember::invite()` — `string $role = null`
- `ExternalModuleLoader::loadFromVendor()` — `string $vendorPath = null`
- `UserFactory::withPersonalTeam()`, `UserFactory::withConnectedAccount()` — `callable $callback = null`

**Not bugs, but invisible to static analysis** — `\Log::` (×10 in `ModuleManager`) and `DB::`/`\DB::` (×4 in a migration and a seeder) reached through the runtime alias loader. They work; they just cannot be checked. Imported properly, matching the neighbouring files which already do.

## Scope and shape

**Paths: `app`, `bootstrap`, `database`, `routes`** — the same four `ArchitectureTest::SCANNED` calls "code that ships and runs in production", for the same reason. `config/` is excluded because it is array literals with nothing to infer. `tests/` is excluded because without larastan the Laravel testing traits generate exactly the same magic-noise as the app code, and a gate whose failures are mostly noise is a gate people learn to ignore. Both are candidates once larastan lands.

**Whole tree, not changed files** — deliberately the opposite of the Pint job next to it, and the reasoning is in `lint.yml`. Formatting is per-file; type analysis is whole-program. A changed signature breaks callers the diff never names, and analysing only the diff would never see them.

**One `ignoreErrors` entry**, not a baseline: `Undefined variable: $this` in `routes/console.php`. `Artisan::command()` binds its closure to the `Command` instance at runtime; PHPStan cannot see a `bindTo` and larastan would not help either. Scoped to that one message in that one file, so a genuinely undefined variable there still fails.

## Composer scripts

```
"analyse": "@php vendor/bin/phpstan analyse --memory-limit=1G"
"check":   ["@lint", "@analyse", "@test"]
```

`analyse` matches the name the sibling repositories use. `check` is the whole gate in one command, so "did I break CI" is answerable locally without remembering three script names.

## CI

A `phpstan` job in `lint.yml` rather than a sixth workflow — it is a static gate and that is where the static gate lives. Runs `./vendor/bin/phpstan analyse --no-progress` over the whole tree, `--no-scripts` on install for the same reason the Pint job does it: this needs `vendor/` on disk and nothing else, so a failure reads as an analysis failure and not as the application failing to boot.

Pint debt on the touched files is cleared in the same commit, which is what the Lint gate's changed-files policy asks for.
