### PR TITLE
docs: ADR 0011 — what adopting module-manager actually costs

### DIFF
--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -68,6 +68,10 @@ This table used to describe `app/Modules/` as *"1,095 lines of unused scaffoldin
 
 The rule `MODULES.md:193` states still stands: the manual class scanner is forbidden and this scaffolding goes. But it goes by being **replaced**, and the difference is those two test files. They describe behaviour something currently depends on, so they are the specification of what the adopted registrar has to keep — read before the deletion, not deleted with it. *The tests that pass are the tests that no longer exist* is the failure mode ADR 0008 was written to avoid, and it applies to a registrar as much as to a review table.
 
+They have now been read, against `module-manager` `1.4.2`'s actual source, and the diff is [**ADR 0011**](./adr/0011-adopting-module-manager.md). The short version: the two systems agree on almost nothing except the word "module". The host holds "enabled" in a **database table** and lets it change at runtime; `module-manager` holds it in **configuration** and resolves it once in `register()`. So the adoption drops runtime enablement, the `modules` table and the four lifecycle events — affordable only because **nothing calls them**: `enable()`, `disable()`, `install()` and `uninstall()` have no callers outside `php artisan module` and the two tests. There is no operator surface, which makes it an unexercised code path rather than an operational capability.
+
+The default also inverts, in the right direction. `isModuleEnabled()` returns `true` for a module with no row *and* `true` from its `catch (\Throwable)` — so an unknown module runs, and a database error runs all of them. `module-manager` starts from nothing enabled and makes the host name its selection: the same argument this plan made against `team_id`'s `default(1)`.
+
 ### Also in wave 0, because they are one-line and shipping today — ✅ **done**
 
 The small faults that needed nobody's permission. Landed ahead of the rest of wave 0, since none of them depends on the packaging mechanism existing.

--- a/docs/adr/0011-adopting-module-manager.md
+++ b/docs/adr/0011-adopting-module-manager.md
@@ -1,0 +1,55 @@
+# Adopting `liberusoftware/module-manager` over the host's own module system
+
+**Status**: proposed — the adoption itself needs Composer network this repository's agent environment does not have
+
+`MIGRATION_PLAN.md` wave 0 has always said `module-manager` is *"the only registrar"* and that adopting it deletes `app/Modules/`. It described that directory as *"1,095 lines of unused scaffolding"*. That was wrong: `AppServiceProvider` registers it, `app/Console/Commands/ModuleCommand.php` drives it, `config/modules.php` configures it, a `modules` table backs it, and two test files cover it.
+
+So the adoption is a **replacement**, and a replacement has a diff. This ADR is that diff, written before the swap rather than discovered during it — the same discipline [ADR 0008](./0008-reviews-and-ratings-merge.md) applied to the reviews and ratings stacks, for the same reason: *the tests that pass are the tests that no longer exist.*
+
+## The decision
+
+Adopt `liberusoftware/module-manager` (`1.4.2`, published) and delete `app/Modules/`, accepting that **runtime module enablement is not carried across**. Enablement becomes deployment configuration rather than mutable state.
+
+## What the two systems actually are
+
+They agree on almost nothing except the word "module".
+
+| | `app/Modules/` (host) | `module-manager` `1.4.2` |
+| --- | --- | --- |
+| Where "enabled" lives | the `modules` **database table** | `config/modules.php`, read from `MODULES_ENABLED` / `MODULES_DISABLED` env |
+| When it is decided | any time, at runtime | once, in `register()` |
+| Default for an unknown module | **enabled** — `isModuleEnabled()` returns `true` when there is no row, and `true` again on any exception | **disabled** — *"Installed packages are disabled by default. The host application owns its explicit selection."* |
+| Lifecycle | `install()` / `uninstall()` run migrations and publish or remove assets | none — installation is Composer's job |
+| Events | `ModuleInstalled`, `ModuleUninstalled`, `ModuleEnabled`, `ModuleDisabled` | none |
+| Discovery | scans directories for classes | `module.json` manifests, from `InstalledVersions::getInstalledPackagesByType('liberu-module')` and configured paths |
+| Dependencies | a `dependencies` array, unresolved | `composer/semver` resolution, with `DependencyResolutionFailed` |
+| Conflicts | none | duplicate module name, duplicate Composer package and **duplicate capability** all throw `InvalidManifest` |
+| Validation | none | `ModuleValidationGuard` checks each selected module against the running Laravel version |
+| Console | `php artisan module {action}` | six commands: list, status, validate, list-features, cache, clear |
+| Caching | — | an opt-in compiled registry at `bootstrap/cache/liberu-modules.php.cache` |
+
+## What is lost, and why it is affordable
+
+**Runtime enablement, the `modules` table, and the four lifecycle events.** This is the whole of the loss, and it is a real capability, not a rounding error.
+
+It is affordable because **nothing uses it.** `enable()`, `disable()`, `install()` and `uninstall()` have no callers in `app/` or `routes/` — only `php artisan module` and the two test files. There is no Filament page, no settings screen, no HTTP route that toggles a module. The capability was built and then never wired to anything a person could reach except a console command.
+
+A runtime toggle with no operator surface is not an operational capability, it is an unexercised code path. Carrying it forward into the packaged world would mean re-implementing DB-backed state on top of a registrar that deliberately resolves once at boot — and *deliberately* is the key word: `module-manager` resolves in `register()` so the set of registered providers is a fixed function of the deployment, which is what makes a boot reproducible.
+
+**The default inverts, and that is an improvement.** The host's `isModuleEnabled()` returns `true` for a module with no row, and `true` again from its `catch (\Throwable)`. So an unknown module runs, and a database error also makes every module run. `module-manager` starts from nothing enabled and requires the host to name what it wants. That is the same argument this plan made against `team_id`'s `default(1)`: *a default that answers the question on the row's behalf* is how something ends up enabled that nobody decided to enable.
+
+## What the two test files mean afterwards
+
+They do not fail. They stop applying, which is worse, because a deleted test makes no noise.
+
+- `ModuleSystemTest::test_module_persists_enabled_state_to_the_database` and `ModuleStateTest::test_enabled_state_survives_a_cache_clear` pin the exact behaviour being dropped. Their docblocks record a real past bug — enablement once lived in a cache key, so `install()` never persisted it and `cache:clear` wiped all module state. **That bug cannot recur under configuration-based enablement**, because there is no state to lose. The tests go with the code, and this ADR is the record of why.
+- `ModuleStateTest::test_a_module_without_module_json_has_a_usable_name_and_does_not_fatal` pins a different fault — `getName()` reading an uninitialised typed property and throwing `\Error` on every request. Under `module-manager` a module without `module.json` is not discovered at all, so the fault is structurally impossible rather than merely fixed. Worth confirming against the adopted version rather than assumed.
+- The remaining `ModuleSystemTest` cases assert getters on `BaseModule`. They test the class being deleted and carry nothing forward.
+
+## Consequences
+
+`app/Modules/` goes: 43 files, including four stub modules (`Api`, `Core`, `Filament`, `Livewire`) that ship a `module.json`, a `composer.json` and empty route files each. `AppServiceProvider`, `app/Console/Commands/ModuleCommand.php` and `config/modules.php` are rewritten or deleted with it, and the `modules` table's migration goes — this is pre-production, so it is edited out rather than dropped by a new migration.
+
+**One thing to check at adoption time rather than trust here.** `ModuleDiscovery` requires every discovered module to have a `composer.json` with a package name, and throws on a duplicate capability across modules. The four stubs in `app/Modules/` each declare one. If any of them is moved rather than deleted, it has to be checked against those rules — a stub that was harmless as scaffolding becomes a boot failure as a manifest.
+
+The adoption needs `composer require`, and Composer has no network in the agent environment working this repository. It wants a human or a networked session. Everything downstream is ordinary work — tracked on [#972](https://github.com/liberusoftware/ecommerce-laravel/issues/972).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,7 @@ Gaps become findings, never silent exemptions. A deviation without an ADR is a b
 | [0008](./0008-reviews-and-ratings-merge.md) | Reviews/ratings merge keeps moderation, backfills customers | behaviour loss avoided |
 | [0009](./0009-vendor-rename-to-liberusoftware.md) | Vendor rename `liberu-eccommerce` → `liberusoftware` | deviation — naming |
 | [0010](./0010-modules-and-themes-are-gitignored.md) | `/modules` and `/themes` are gitignored | deviation — `THEMES.md` §3.2 |
+| [0011](./0011-adopting-module-manager.md) | Adopting `module-manager` drops runtime module enablement | behaviour loss |
 
 Every deviation above also has an upstream issue filed against the document it deviates from — all 23 are filed, tracked as [#961](https://github.com/liberusoftware/ecommerce-laravel/issues/961). They are listed in [`../CONFORMANCE.md`](../CONFORMANCE.md)'s upstream chapter — a reader hitting one of these ADRs needs to know the disagreement is filed rather than forgotten.
 


### PR DESCRIPTION
Wave 0 says adopting `module-manager` deletes `app/Modules/`. #1009 corrected the claim that it was unused. This is the next step: **a replacement has a diff, and it is worth having before the swap rather than during it.**

Read `module-manager` `1.4.2`'s actual source against the host's own system. They agree on almost nothing except the word "module".

| | `app/Modules/` | `module-manager` |
| --- | --- | --- |
| Where "enabled" lives | the `modules` **database table** | `config/modules.php` from `MODULES_ENABLED` env |
| When it is decided | any time, at runtime | once, in `register()` |
| Unknown module defaults to | **enabled** | **disabled** |
| Lifecycle, events | `install()`/`uninstall()`, four events | none |
| Dependencies, conflicts | unresolved array | `composer/semver`, duplicate-capability detection, version guard |

**What is lost:** runtime enablement, the `modules` table, the four lifecycle events. Affordable only because **nothing calls them** — `enable()`, `disable()`, `install()` and `uninstall()` have no callers outside `php artisan module` and the two test files. No Filament page, no route, no settings screen. A runtime toggle with no operator surface is an unexercised code path, not an operational capability.

**The default inverts, in the right direction.** `isModuleEnabled()` returns `true` for a module with no row, and `true` again from its `catch (\Throwable)` — so an unknown module runs, and a *database error* runs all of them. `module-manager` starts from nothing enabled and makes the host name its selection. That is the argument this plan already made against `team_id`'s `default(1)`: a default that answers the question on the row's behalf.

**What the two tests mean afterwards:** they do not fail, they stop applying — which is worse, because a deleted test makes no noise. Both pin real past bugs (enablement in a cache key; `getName()` throwing `\Error` on an uninitialised typed property). Under configuration-based enablement neither can recur, and the ADR is the record of why.

Docs only. Nothing adopted — that needs `composer require` and Composer has no network in this environment.