### PR TITLE
chore: minimum-stability stable — the loosened gate had no consumer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,6 @@
             "ext-posix": "1.0.0"
         }
     },
-    "minimum-stability": "beta",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cbaec2d2d66e4a6229be8b5ede956e00",
+    "content-hash": "3d1bbe2e66af02afd23ffbc6d748183c",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",


### PR DESCRIPTION
Finding **27** of `docs/research/standards-gap-audit.md` (`ADOPTION.md` row): `minimum-stability: beta`.

**Zero of the packages in `composer.lock` are alpha, beta, RC or dev.** So the loosened constraint admitted nothing that `prefer-stable: true` had not already rejected — a weakened gate with no beneficiary, sitting where a contributor would reasonably read it as permission to pull in a beta.

**The resolution cannot change.** Tightening `minimum-stability` can only remove candidates from consideration, and none of the removed candidates was chosen. So `composer.lock`'s package list is untouched and only its `content-hash` moves — which is exactly what `composer update --lock` would have produced.

**On hand-editing the hash.** Composer hangs on every invocation in this environment, including `composer --version`, so the lock could not be regenerated the usual way. The hash was computed by replicating `Composer\Package\Locker::getContentHash()` in a standalone PHP script — and **verified first by reproducing the existing hash `cbaec2d2…` from the unmodified `composer.json`**, so the method is proven before it is trusted. `composer install` in CI is the second check: an inconsistent lock fails there.