### PR TITLE
docs: state the quality bar, the disclosure route, and what is in docs/

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!--
+Short on purpose. See CONTRIBUTING.md for the gates and the reasoning behind them.
+There is no changelog: this pull request is squash-merged and its subject is the entry.
+-->
+
+## What changed, and why
+
+<!-- One paragraph. What a reader six months from now needs in order to not undo this. -->
+
+## Verification
+
+<!--
+Name the evidence. "CI is green" is not evidence a reviewer can read — say which test fails
+without this change, or say why no test applies. For a behaviour change with no test, say what
+you ran by hand and what you saw.
+-->
+
+- [ ] Install, Lint, Tests, Docker and Security are all green
+
+## Documentation
+
+- [ ] `docs/MIGRATION_PLAN.md` is updated, or this change does not touch anything it sequences
+- [ ] `docs/CONFORMANCE.md` and `docs/research/` are untouched — they are dated snapshots, and a correction goes in the plan

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,164 @@
+# Contributing
+
+What this repository asks of a change, and why each gate sits where it does. The governing documents
+are `standards/CONTRIBUTING.md` and `standards/DOCUMENTATION.md` in
+[`liberusoftware/documentation`](https://github.com/liberusoftware/documentation); this file records
+how they land here, and the places where knowing the local history saves you a wasted afternoon.
+
+---
+
+## Before you start
+
+This repository is mid-migration and its `docs/` directory mixes living plans, a frozen snapshot,
+decision records and dated research. [`docs/index.md`](docs/index.md) says what each document is and
+whether it is current — read it before trusting any of them. The two that will matter most are
+[`docs/MIGRATION_PLAN.md`](docs/MIGRATION_PLAN.md), which sequences the structural work, and
+[`docs/MODULE_DEVELOPMENT.md`](docs/MODULE_DEVELOPMENT.md), which describes the shape the codebase is
+heading towards.
+
+Branch from `main`, keep the change to one outcome, and search for the existing source of truth
+before adding a second one. For a change large enough to argue about, open an issue first — the plan
+is sequenced, and a change that lands out of order costs more to reconcile than it saves.
+
+---
+
+## The gates
+
+Three commands. `composer check` runs all three in order and is what CI amounts to:
+
+```bash
+composer lint      # Pint, --test (check only)
+composer lint:fix  # Pint, applying
+composer analyse   # PHPStan
+composer test      # php artisan test
+composer check     # lint, analyse, test
+```
+
+### Formatting — Pint
+
+`pint.json` is the Laravel preset and nothing else; there are no overrides to learn. The Lint
+workflow checks **only the PHP files your branch touches**, compared against `main`.
+
+That scoping is deliberate and it has a consequence you will meet. Running Pint across the tree would
+rewrite most of ~400 files in one commit, bury every real change under formatting noise and make
+`git blame` useless on a codebase whose history is the main tool for working out why something is the
+way it is. So the gate is a ratchet: files get formatted as they get edited. **A red Pint job is
+about your diff, never about the file.** Touching a long-unformatted file means adopting its
+formatting in the same commit — that is the point, not an accident.
+
+### Static analysis — PHPStan
+
+`phpstan.neon`, whole tree, no baseline, run in the Lint workflow.
+
+**Read the comment block at the top of `phpstan.neon` before you touch the `level`.** The level is 0
+and that is a measured decision, not an oversight: `larastan/larastan` is not installed, so PHPStan
+has no idea what Eloquent and the facades are, and on this tree level 2 already produces 909 errors
+of which 802 are two identifiers — `property.notFound` and `staticMethod.notFound` — that are
+Eloquent working exactly as designed. Baselining ~2000 of those to claim level 8 would bury the real
+findings among the magic. The file names the path up (install larastan, add its extension, re-measure,
+raise to the highest rung that is honest), and raising the level without doing that will be sent back.
+
+The 26 findings level 0 produced on day one were, almost to a line, real, which is why the count is
+now zero. Keep it there.
+
+### Tests
+
+`composer test` runs both suites — 226 test files under `tests/Unit` and `tests/Feature`. Coverage is
+uploaded to Codecov by the Tests workflow and gated by `codecov.yml`: 70% on the patch, and overall
+project coverage may not regress by more than 0.5%.
+
+Two tests are worth knowing about before they fail on you:
+
+- `tests/Unit/ArchitectureTest.php` reads the shipped code with `token_get_all` and enforces static
+  rules on it — most notably that `env()` is only called from `config/`, because under `config:cache`
+  every other call site silently resolves to null in production. Two classes shipped that way.
+- `tests/Feature/ComposerLockIsCurrentTest.php` fails when `composer.json` and `composer.lock`
+  disagree, so a dependency change must commit both.
+
+---
+
+## The five workflows
+
+| Workflow | File | Covers |
+| --- | --- | --- |
+| Install | `install.yml` | A clean install against MySQL: `composer install`, key generation, `migrate`, `db:seed`, `npm ci`, asset build |
+| Lint | `lint.yml` | Pint on branch-changed PHP files; PHPStan on the whole tree |
+| Tests | `tests.yml` | `php artisan test` with coverage, uploaded to Codecov |
+| Docker | `main.yml` | Builds the image, boots it, smoke-tests it, then pushes — the smoke test exists because two production faults got past a build-only gate |
+| Security | `security.yml` | `composer audit --locked` and `npm audit --omit=dev`, on push, on pull request, and weekly |
+
+All five must be green. Lint also accepts `workflow_dispatch`, because this repository drops
+`pull_request` synchronize events often enough that a pushed fix can sit with no run at all; if your
+branch shows no Lint run, dispatch one rather than pushing an empty commit.
+
+---
+
+## Architecture decisions
+
+One rule decides whether your change needs an ADR, and it is narrower than "significant": a deviation
+from the Liberu documentation, or a deliberate loss of behaviour. The rule and the numbering
+convention are in [`docs/adr/README.md`](docs/adr/README.md) — read its "Adding one" section rather
+than a restatement of it here. A deviation that ships without an ADR is a bug.
+
+---
+
+## Two documents with opposite rules
+
+[`docs/MIGRATION_PLAN.md`](docs/MIGRATION_PLAN.md) is **living**. It is edited as waves land and as
+the execution epics discover things the plan got wrong. If your change completes, invalidates or
+reorders anything the plan describes, update the plan in the same pull request.
+
+[`docs/CONFORMANCE.md`](docs/CONFORMANCE.md) is a **dated snapshot that is never revised.** Every
+number in it counts the tree at commit `2d1024c`. It is superseded finding by finding, not corrected,
+and the gap between it and the plan *is* the progress record — so a well-meant edit that brings the
+snapshot up to date destroys exactly the information both documents exist to carry.
+
+This is not hypothetical. A rename was once recorded by rewriting a row of the snapshot in place, and
+had to be reverted and re-landed in the plan instead (`17dc639`). If you find something in
+`CONFORMANCE.md` that is no longer true, that is the document working correctly. Write the correction
+into `MIGRATION_PLAN.md`.
+
+The same rule covers `docs/research/` for the same reason: those four documents are dated evidence,
+not maintained pages.
+
+---
+
+## There is no changelog, and that is deliberate
+
+`liberusoftware/ecommerce-laravel` has published no release. The five versions on Packagist
+(`v1.0.0`–`v1.0.3`, `v13.0.0`) belong to the old `liberu-eccommerce` vendor name, carry a `v` prefix
+the release triggers do not fire on, and therefore skipped the release gates — see
+[ADR 0005](docs/adr/0005-bare-version-tags.md) and [ADR 0009](docs/adr/0009-vendor-rename-to-liberusoftware.md).
+Writing them into a `CHANGELOG.md` would grant them a legitimacy those ADRs specifically deny.
+
+Until there is a gated release to describe, the record of what changed is `git log`: every pull
+request is squash-merged with a descriptive subject and its number. Do not add a changelog entry to
+your pull request; write the commit subject as though it were one, because it is. When the first
+release under this vendor name is tagged, `CHANGELOG.md` starts there and describes releases, which
+is what the documentation standard asks it to own.
+
+---
+
+## Documentation
+
+A behaviour change is not finished until the document that owns the behaviour is current in the same
+pull request. Define a rule once, in its owning document, and link to it from anywhere else that needs
+it. Use sentence-case headings, **must** for requirements and **should** for recommendations, and
+relative links between files in this repository.
+
+If you add a document to `docs/`, add it to [`docs/index.md`](docs/index.md) with an honest status.
+"Status unaudited" is information; a confident wrong label is not.
+
+Do not claim support, coverage, security or deployment capability without evidence that a reader can
+follow to something that runs.
+
+---
+
+## Pull requests
+
+The template at [`.github/pull_request_template.md`](.github/pull_request_template.md) is short and
+asks for the two things this repository has repeatedly needed stated. Beyond it: identify any public
+contract you changed, and include tests or say why tests do not apply. Respond to review with fresh
+commits rather than a force-push, so a reviewer can read what changed since they last looked.
+
+Vulnerabilities do not go in a pull request or a public issue. Follow [`SECURITY.md`](SECURITY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,8 @@ is sequenced, and a change that lands out of order costs more to reconcile than 
 
 ## The gates
 
-Three commands. `composer check` runs all three in order and is what CI amounts to:
+There are three: formatting, static analysis, tests. `composer check` runs them in that order and is
+what CI amounts to.
 
 ```bash
 composer lint      # Pint, --test (check only)

--- a/README.md
+++ b/README.md
@@ -100,12 +100,15 @@ chmod +x setup.sh
 
 | Document | Covers |
 | --- | --- |
+| [`docs/index.md`](docs/index.md) | Index of everything in `docs/` — what each document is, and whether it is current |
 | [`docs/INSTALLATION.md`](docs/INSTALLATION.md) | Manual and Docker installs, Stripe, DropXL |
 | [`docs/OPERATIONS.md`](docs/OPERATIONS.md) | Console commands, the admin panels, queues, troubleshooting |
 | [`docs/MODULE_DEVELOPMENT.md`](docs/MODULE_DEVELOPMENT.md) | Building, testing, promoting and releasing a module |
 | [`docs/CONFORMANCE.md`](docs/CONFORMANCE.md) | Where this repository stands against the Liberu standards |
 | [`docs/MIGRATION_PLAN.md`](docs/MIGRATION_PLAN.md) | The ordered plan from here to the modular target |
 | [`docs/adr/`](docs/adr/) | Architecture decision records |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | The quality gates, the five workflows, and the ADR rule |
+| [`SECURITY.md`](SECURITY.md) | Reporting a vulnerability privately, and what is in scope |
 | [`CONTEXT.md`](CONTEXT.md) | Domain glossary — merchant, team, store, channel, tenant |
 
 ---
@@ -132,21 +135,23 @@ Liberu Ecommerce is part of the wider **Liberu** open-source ecosystem. All proj
 
 ---
 
+## Security
+
+Please do not report security vulnerabilities through public GitHub issues. Follow [`SECURITY.md`](SECURITY.md) for private reporting through GitHub Security Advisories, and for what is in and out of scope.
+
+---
+
 ## Contributing
 
-Contributions are warmly welcomed! Here is how to get involved:
+Contributions are warmly welcomed. Branch from `main`, keep the change to one outcome, and run the gates before pushing:
 
-1. **Fork** the repository and create a feature branch from `main`.
-2. **Write focused, testable code** — add or update tests for any new behaviour.
-3. **Run the CI checks locally** before pushing:
-   ```bash
-   ./vendor/bin/phpunit
-   ```
-4. **Open a Pull Request** against `main` with a clear description of what you changed and why.
-5. The CI pipeline (install, tests, Docker workflows) must pass before a PR can be merged.
-6. A maintainer will review your PR, suggest changes if necessary, and merge when ready.
+```bash
+composer check   # Pint, PHPStan, then the test suite
+```
 
-If you have a larger feature in mind, please open an issue first to discuss the approach — this avoids duplicated effort and helps us keep the codebase cohesive.
+[`CONTRIBUTING.md`](CONTRIBUTING.md) has the rest: what each gate checks and why it is scoped the way it is, the five CI workflows, when a change needs an ADR, and the two documents in `docs/` with opposite editing rules. Read it before a first pull request — several of the rules here are not the obvious ones, and the reasoning is recorded rather than assumed.
+
+For a larger feature, open an issue first. This repository is mid-migration and the work is sequenced, so a change that lands out of order costs more to reconcile than it saves.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report privately through GitHub, never in a public issue or a pull request:
+[**Report a vulnerability**](https://github.com/liberusoftware/ecommerce-laravel/security/advisories/new).
+Private vulnerability reporting is enabled on this repository, so the draft advisory is visible only
+to you and the maintainers until it is published. No email address or PGP key is needed, and this
+project publishes neither.
+
+A useful report says what an attacker can do, not only what looks wrong. Include the affected file or
+route, the version or commit you tested, the steps to reproduce, and what an attacker gains — reading
+another tenant's data, escalating a role, forging a webhook, and so on. A proof of concept against
+your own local install is worth more than a description.
+
+## What to expect
+
+This is a volunteer-maintained open-source project. There is no response-time commitment, no bug
+bounty and no published support policy, and rather than invent one: reports are read, and you will be
+told whether the finding is accepted, already known, or out of scope. If it is accepted you will be
+credited in the advisory unless you ask not to be.
+
+Please give maintainers a reasonable chance to ship a fix before disclosing publicly.
+
+## Scope
+
+In scope is anything in this repository that ships and runs: `app/`, `routes/`, `database/`,
+`bootstrap/`, `config/`, the Blade and Livewire views under `resources/`, the Filament panels, the
+`Dockerfile` and `.docker/`, and the GitHub Actions workflows.
+
+Out of scope:
+
+- Third-party dependencies. Report those to their own maintainers; `security.yml` already runs
+  `composer audit` and `npm audit` on every push and weekly.
+- Findings that only apply with `APP_DEBUG=true`, default `.env.example` credentials, or a
+  deliberately misconfigured install. `.env.example` and `.env.testing` hold development values by
+  design and are not secrets.
+- Anything reachable only by a user who already has administrator rights in the Filament admin panel.
+- Automated scanner output with no demonstrated impact.
+
+## Known findings
+
+This repository is pre-production and mid-migration, and it documents its own open security gaps
+rather than implying it has none. [`docs/CONFORMANCE.md` §6](docs/CONFORMANCE.md#6-security-findings)
+records the tenancy findings measured at commit `2d1024c`, and
+[`docs/MIGRATION_PLAN.md`](docs/MIGRATION_PLAN.md) sequences the fixes. Please check both before
+reporting — a finding already recorded there is known, and a report that it is still present is only
+useful if it shows the impact is worse than recorded.
+
+## Supported versions
+
+No release under the `liberusoftware` vendor name has been published yet, so there is no supported
+release line. Fixes land on `main`. The five versions still on Packagist under the former
+`liberu-eccommerce` name are unsupported and should not be used — see
+[ADR 0009](docs/adr/0009-vendor-rename-to-liberusoftware.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,124 @@
+# Documentation index
+
+What is in `docs/`, what each document is for, and whether you can trust it.
+
+That last column is the reason this page exists. This directory holds documents with genuinely
+different lifespans — two that are edited continuously, one that is frozen on purpose, eleven
+immutable decision records, four dated research dumps, and a handful of feature documents of varying
+age — and nothing on the page you are reading distinguishes them by filename. Reading a frozen
+snapshot as current, or editing it because it looks stale, both cause real damage. So each entry
+below says which kind it is.
+
+Where currency could not be established by reading the code, the entry says **status unaudited**
+rather than guessing.
+
+---
+
+## Living documents
+
+Edited as the work lands. If your change makes one of these wrong, fix it in the same pull request.
+
+| Document | What it is |
+| --- | --- |
+| [`MIGRATION_PLAN.md`](./MIGRATION_PLAN.md) | The ordered plan from the state recorded in `CONFORMANCE.md` to the shape `MODULE_DEVELOPMENT.md` describes. Sequences the structural work — the enforcement layer, the packaging mechanism, the tenancy fix, four data migrations, the extraction order. It does not build the 105 modules; the execution epics do that against it. This is also where corrections to the snapshot belong. |
+| [`MODULE_DEVELOPMENT.md`](./MODULE_DEVELOPMENT.md) | How to build, test, promote and release an Ecommerce module. The document that outlives the migration: `CONFORMANCE.md` describes a codebase that starts changing the day wave 0 lands and `MIGRATION_PLAN.md` is finished when the last module ships, but this one stays useful. Deviations from the Liberu standards are marked **⚠ deviation** at the point they apply. |
+
+## Frozen snapshot
+
+| Document | What it is |
+| --- | --- |
+| [`CONFORMANCE.md`](./CONFORMANCE.md) | Where this repository stood against the Liberu standards, measured 2026-08-08 against commit `2d1024c`. **Never revised.** Every number counts the tree at that commit; it is superseded finding by finding by the execution epics, and the gap between it and `MIGRATION_PLAN.md` is the progress record. Correcting it in place erases that record — it has happened once and was reverted. Read it as history, and write corrections into the plan. |
+
+## Decisions
+
+| Document | What it is |
+| --- | --- |
+| [`adr/`](./adr/) | Eleven architecture decision records, plus a [README](./adr/README.md) that carries the index and the one rule for adding another: an ADR exists for a deviation from the Liberu documentation or a deliberate loss of behaviour, and nothing else. ADRs are immutable — a decision is superseded by a new record, not rewritten. Current as a set: the README's table is maintained. |
+
+## Running the thing
+
+| Document | What it is | Status |
+| --- | --- | --- |
+| [`INSTALLATION.md`](./INSTALLATION.md) | Getting the application running locally, manually, or under Docker: requirements, the interactive `setup.sh` path, Stripe configuration, DropXL setup. | Current. The path it documents is the one `install.yml` exercises on every pull request. |
+| [`OPERATIONS.md`](./OPERATIONS.md) | Running an installed instance: every registered console command and what it does, the admin panels, queues, troubleshooting. | Current. The command table was generated from `app/Console/Commands/`. |
+
+## Feature documentation
+
+| Document | What it is | Status |
+| --- | --- | --- |
+| [`ANALYTICS.md`](./ANALYTICS.md) | The admin analytics dashboard — what it shows, how to read it, how to extend it. Merged from the former `ANALYTICS.md` and `ANALYTICS_GUIDE.md`, which documented the same feature twice. | Written against the tree as of 2026-08-08 and accurate then. Not re-checked since. |
+| [`API_COLLECTIONS.md`](./API_COLLECTIONS.md) | Endpoint reference for the product-collections API: Sanctum authentication, request and response shapes. | **Status unaudited.** Last substantively touched before the conformance work, and it predates the API findings in [`CONFORMANCE.md`](./CONFORMANCE.md) and the [standards gap audit](./research/standards-gap-audit.md) — no versioning, no API Resources, raw model attributes in responses. The routes it documents do exist (`routes/api.php`, `Api/CollectionController`); whether every field and status code it lists is still right has not been verified. |
+
+## Held debt
+
+These four describe code that ships today but is not staying. They are kept because deleting the
+description would not delete the duplication, and the next reader would rediscover it.
+
+| Document | What it is |
+| --- | --- |
+| [`CHAT_SYSTEM.md`](./CHAT_SYSTEM.md) | Feature overview of the live-chat system — widget, agent console, analytics. |
+| [`CHAT_ARCHITECTURE_DIAGRAM.md`](./CHAT_ARCHITECTURE_DIAGRAM.md) | Component and message-flow diagrams for the same system. |
+| [`CHAT_IMPLEMENTATION_SUMMARY.md`](./CHAT_IMPLEMENTATION_SUMMARY.md) | What was built: migrations, models, services, components. |
+| [`CHAT_QUICK_REFERENCE.md`](./CHAT_QUICK_REFERENCE.md) | Developer quick reference — commands, endpoints, configuration. |
+
+All four carry the same banner and it is the important part: live chat belongs to the **CRM** product
+(`chat-and-bots`), and `liberusoftware/crm-laravel` already ships its own chat stack. This is not code
+waiting for a home, it is a second implementation of one that exists. Which stack survives is a
+cross-repository merge decision, tracked as
+[#943](https://github.com/liberusoftware/ecommerce-laravel/issues/943) and read alongside
+[`CONFORMANCE.md` §4.2](./CONFORMANCE.md#42-the-98-unmappable-files-were-an-artifact). Describing the
+duplicate accurately is in scope; describing it as the plan of record is not.
+
+## Partly superseded
+
+| Document | What it is |
+| --- | --- |
+| [`STABLE_RELEASE_TASKS.md`](./STABLE_RELEASE_TASKS.md) | A product-readiness backlog: 18 feature workstreams and a cross-cutting checklist. `MIGRATION_PLAN.md` covers structural conformance and does not replace it — the two cover different work. Its own banner names the three workstreams that **are** superseded (14 tenancy, 15 modules, 18 installer and Docker) and where each now lives. The other 15 stand. |
+
+## Research
+
+Point-in-time investigations, all measured against commit `2d1024c` and merged from the throwaway
+branches they were written on. **These are not maintained, and that is what makes them useful:** when
+a finding in `CONFORMANCE.md` is disputed, this is the evidence it rested on. Treat them the same way
+as the snapshot — superseded, never revised.
+
+[`research/README.md`](./research/README.md) is the index and carries the caveat that applies across
+all four. In short:
+
+| Document | Question it answered |
+| --- | --- |
+| [`research/standards-gap-audit.md`](./research/standards-gap-audit.md) | Where does this repository violate the 36 Liberu standards documents? One section per standard, with severity and a mechanical-versus-structural class. The 29-row summary table at the end is the ranked finding list the migration works through. |
+| [`research/app-to-module-inventory.md`](./research/app-to-module-inventory.md) | Which `ECOMMERCE.md` module does each part of `app/` belong to? All 906 files bucketed. Its "98 unmappable files" figure is an artifact of the brief — `CONFORMANCE.md` §4.2 has the corrected reading. |
+| [`research/foundation-module-matrix.md`](./research/foundation-module-matrix.md) | Which of the 28 foundation modules does this repository need, and what does each replace? |
+| [`research/packaging-mechanism.md`](./research/packaging-mechanism.md) | How do `modules/`, `composer-installer` and `module-manager` actually work in `boilerplate-laravel`? |
+
+Note that parts of the gap audit have been closed since it was written — it lists `LICENSE`, the ADR
+directory and this index among the missing, and all three now exist. The audit is not edited to say
+so; that is the same rule as the snapshot.
+
+## Agent configuration
+
+| Document | What it is |
+| --- | --- |
+| [`agents/domain.md`](./agents/domain.md) | How the engineering skills should consume this repository's domain documentation — read `CONTEXT.md` and the relevant ADRs before exploring. |
+| [`agents/issue-tracker.md`](./agents/issue-tracker.md) | Issues live on GitHub; the `gh` invocations to read and write them. |
+| [`agents/triage-labels.md`](./agents/triage-labels.md) | Maps the skills' five canonical triage roles onto this tracker's label strings. |
+
+These support [`AGENTS.md`](../AGENTS.md) at the repository root, which is the source of truth for
+agent configuration.
+
+---
+
+## Outside `docs/`
+
+| Document | What it is |
+| --- | --- |
+| [`README.md`](../README.md) | Project identity, features, badges and the quick start. |
+| [`CONTRIBUTING.md`](../CONTRIBUTING.md) | The quality gates, the five workflows, the ADR rule, and the two documents with opposite editing rules. |
+| [`SECURITY.md`](../SECURITY.md) | How to report a vulnerability privately, and what is in scope. |
+| [`CONTEXT.md`](../CONTEXT.md) | Domain glossary — merchant, team, store, channel, tenant. |
+| [`AGENTS.md`](../AGENTS.md) | Agent configuration for this repository. |
+
+There is no `CHANGELOG.md`. Nothing has been released under this vendor name yet, so `git log` is the
+record of what changed; [`CONTRIBUTING.md`](../CONTRIBUTING.md) explains the reasoning and what will
+change when the first gated release ships.


### PR DESCRIPTION
Closes findings **17 (DOCUMENTATION.md)** and **28 (CONTRIBUTING.md)** of [`docs/research/standards-gap-audit.md`](docs/research/standards-gap-audit.md), less the parts already closed since it was written — `LICENSE` and `docs/adr/` now exist.

Four new documents, all written against what this repository actually does rather than a template.

## `CONTRIBUTING.md`

The gates as they are, with the reasoning that is not obvious from reading the config:

- **Pint** is a ratchet scoped to branch-changed files, so a red job is about the diff and never the file.
- **PHPStan** is the opposite and has to be — whole tree, no baseline. It also says, at length, why `phpstan.neon` sits at level 0: larastan is not installed, level 2 already yields 909 errors of which 802 are two Eloquent-magic identifiers, and raising the level without installing larastan first will be sent back. A contributor who does not read that comment will file a PR "fixing" the level.
- The five workflows and what each covers, including the `workflow_dispatch` escape hatch on Lint.
- The ADR rule, pointed at [`docs/adr/README.md`](docs/adr/README.md) rather than restated.
- **`docs/MIGRATION_PLAN.md` is living; `docs/CONFORMANCE.md` is a frozen snapshot.** Correcting the snapshot in place erases the progress record. This has already happened once — `17dc639` reverted it and re-landed the correction in the plan — so it is stated with the commit.

## `SECURITY.md`

Private reporting via GitHub Security Advisories. **Private vulnerability reporting was disabled on this repository and is now enabled**, so the link in the policy actually works; there is no invented `security@` address, no PGP key, no SLA and no bounty, because none of those exist. Scope is explicit, and it points at `CONFORMANCE.md` §6 so a reporter can tell a known finding from a new one.

## `docs/index.md`

The directory holds documents with genuinely different lifespans and nothing in the filenames distinguishes them. Grouped by kind — living, frozen snapshot, decisions, operations, feature docs, held debt, research, agent config — with a status on each. `API_COLLECTIONS.md` is marked **status unaudited**: its routes exist, but it predates the API findings and its field-level accuracy has not been verified. That is recorded rather than guessed at.

## `.github/pull_request_template.md`

Three checkboxes and two prose prompts. The two that have mattered repeatedly here: evidence a reviewer can read rather than "CI is green", and whether `MIGRATION_PLAN.md` needs updating — plus the guard against editing the snapshot.

## No `CHANGELOG.md`

Deliberate, and argued in `CONTRIBUTING.md`. Nothing has been released under the `liberusoftware` vendor name. The five versions still on Packagist (`v1.0.0`–`v1.0.3`, `v13.0.0`) belong to the former `liberu-eccommerce` name and carry a `v` prefix the release triggers do not fire on, so they published having skipped the release gates — [ADR 0005](docs/adr/0005-bare-version-tags.md) and [ADR 0009](docs/adr/0009-vendor-rename-to-liberusoftware.md). Writing them into a changelog would grant them a legitimacy those ADRs specifically deny, and a `## Unreleased` heading over squash-merged commits that already carry descriptive subjects and PR numbers is a file that goes stale in a fortnight. `git log` is the record until there is a gated release to describe; the reasoning and the trigger for reversing it are written down.

## Also

`README.md` gains a Security section (required by `architecture/REPOSITORIES.md` §13), index rows for the three new documents, and a Contributing section that points at `CONTRIBUTING.md` instead of telling contributors to run `./vendor/bin/phpunit` — which is not what any gate runs.

Documentation only; no PHP touched.

## Verification

- [x] Every relative link in the four new files resolves to a file that exists.
- [x] `docs/MIGRATION_PLAN.md`, `docs/CONFORMANCE.md`, `docs/research/`, `composer.json` and `composer.lock` are untouched.