### PR TITLE
fix: withdraw ADR 0010, and take theme.json out of the module stubs

### DIFF
--- a/app/Modules/Api/theme.json
+++ b/app/Modules/Api/theme.json
@@ -1,5 +1,0 @@
-{
-    "name": "Api Theme",
-    "version": "1.0.0",
-    "description": "Theme configuration for Api module"
-}

--- a/app/Modules/Core/theme.json
+++ b/app/Modules/Core/theme.json
@@ -1,5 +1,0 @@
-{
-    "name": "Core Theme",
-    "version": "1.0.0",
-    "description": "Theme configuration for Core module"
-}

--- a/app/Modules/Filament/theme.json
+++ b/app/Modules/Filament/theme.json
@@ -1,5 +1,0 @@
-{
-    "name": "Filament Theme",
-    "version": "1.0.0",
-    "description": "Theme configuration for Filament module"
-}

--- a/app/Modules/Livewire/theme.json
+++ b/app/Modules/Livewire/theme.json
@@ -1,5 +1,0 @@
-{
-    "name": "Livewire Theme",
-    "version": "1.0.0",
-    "description": "Theme configuration for Livewire module"
-}

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -502,7 +502,9 @@ Full detail in [`MODULE_DEVELOPMENT.md` §6](./MODULE_DEVELOPMENT.md#6-promotion
 
 **Promotion is per-package, the moment each qualifies** — not per wave. Batching promotions adds a synchronisation barrier where the slowest module holds the rest. A hundred small reviewable host commits beat four large ones.
 
-**Promotion is a source-of-truth flip, not a code move.** During the path phase a module's code is committed to the host. At promotion its `.gitignore` flips, its files **leave the host tree**, and Composer becomes the only source. Whether a module is promoted becomes answerable by `ls`. [ADR 0010](./adr/0010-modules-and-themes-are-gitignored.md).
+**Promotion is a source-of-truth flip, and the code stays.** During the path phase a module's code is committed to the host under `app/`; at promotion it moves to `modules/` and **stays tracked there**, with Composer as the authoritative source and the host tree as an installed copy. Whether a module is promoted is answerable by its `composer.json` entry, not by `ls`.
+
+[ADR 0010](./adr/0010-modules-and-themes-are-gitignored.md) argued the opposite — flip `.gitignore` per package so promotion is visible in the file tree — and is **withdrawn**, [#972](https://github.com/liberusoftware/ecommerce-laravel/issues/972). It was never implemented: `.gitignore` has never named `/modules` or `/themes`, because nothing has been promoted yet. So this is a plan correction with no code behind it, which is the cheapest moment such a reversal is ever available. The duplication ADR 0010 objected to is real and now accepted; `git diff --exit-code --stat -- modules themes` is what stops it drifting.
 
 **The soak is retrospective.** No cross-boundary edit in its last N commits, computed from `git log` at promotion time — not a thirty-day calendar wait. Both measure whether the boundary has stopped moving; only one cannot be waived under schedule pressure.
 

--- a/docs/MODULE_DEVELOPMENT.md
+++ b/docs/MODULE_DEVELOPMENT.md
@@ -246,7 +246,7 @@ Eight steps, scripted as `fleet promote <module>`, because a hundred repetitions
 2. Create the repository **if absent** — most already exist as stubs. 103 of the catalogue's 105 are provisioned; Checkout and Checkout Extensibility are not.
 3. Force-push the split history over the stub. The generated README records nothing worth keeping, and merging on top of it would leave a wrong `composer require` line permanently in the history.
 4. Scaffold the three workflows and Composer script aliases.
-5. Flip `.gitignore` for that module — its files leave the host tree. **⚠ deviation** — [ADR 0010](./adr/0010-modules-and-themes-are-gitignored.md).
+5. Move the module's files from `app/` into the tracked `modules/` tree. They stay committed — the installed copy is the host's, the authoritative copy is the package, and `git diff --exit-code --stat -- modules themes` in `release.yml` is what keeps them equal. [ADR 0010](./adr/0010-modules-and-themes-are-gitignored.md) proposed gitignoring instead and was withdrawn.
 6. Swap the host's path entry for a VCS `repositories` entry.
 7. Update `.liberu-meta.json`.
 8. Run the host composition test.

--- a/docs/adr/0010-modules-and-themes-are-gitignored.md
+++ b/docs/adr/0010-modules-and-themes-are-gitignored.md
@@ -1,6 +1,14 @@
 # `/modules` and `/themes` are gitignored; a promoted package leaves the host tree
 
-**Status**: accepted
+**Status**: **withdrawn 2026-08-09** — [#972](https://github.com/liberusoftware/ecommerce-laravel/issues/972). `/modules` and `/themes` stay tracked, as `THEMES.md` §3.2 requires. The deviation this ADR argued for was never implemented — `.gitignore` never named either directory, because nothing has been promoted yet — so withdrawal costs one line of prose per referring document and no code.
+
+Kept rather than deleted: the reasoning below is the record of why the flip looked attractive, and the next person who proposes it should read the counter-argument before re-proposing.
+
+**What replaces it.** Promotion becomes what `boilerplate-laravel` already does — the installed tree stays committed, and the host holds a copy of code whose authoritative source is Composer. That duplication is real and this ADR was right that it is a cost. It is now an accepted cost rather than a deviation, and the guard against drift is `git diff --exit-code --stat -- modules themes`, the mechanism this ADR rejected. The upstream issue arguing §3.2 should change is withdrawn with it.
+
+**Withdrawn as a side effect: the `theme.json` files under `app/Modules/`.** Four module stubs each shipped one, describing a theme that does not exist. Nothing read them. A `theme.json` belongs to a theme package and to nothing else; in a module it is a manifest that would be discovered and validated as a claim the module cannot honour.
+
+---
 
 `THEMES.md` §3.2 states *"the current decision, matching `/modules`, is **not** to add `/themes` to `.gitignore`"*, restated in §20's definition of done, and changeable *"only through an ADR and migration plan"* — the standard names the instrument, and this is it.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,10 +15,10 @@ Gaps become findings, never silent exemptions. A deviation without an ADR is a b
 | [0007](./0007-events-and-identifiers-across-product-boundaries.md) | Events and stable identifiers only across product boundaries | extension |
 | [0008](./0008-reviews-and-ratings-merge.md) | Reviews/ratings merge keeps moderation, backfills customers | behaviour loss avoided |
 | [0009](./0009-vendor-rename-to-liberusoftware.md) | Vendor rename `liberu-eccommerce` → `liberusoftware` | deviation — naming |
-| [0010](./0010-modules-and-themes-are-gitignored.md) | `/modules` and `/themes` are gitignored | deviation — `THEMES.md` §3.2 |
+| [0010](./0010-modules-and-themes-are-gitignored.md) | ~~`/modules` and `/themes` are gitignored~~ | **withdrawn** — [#972](https://github.com/liberusoftware/ecommerce-laravel/issues/972); the repo conforms to `THEMES.md` §3.2 |
 | [0011](./0011-adopting-module-manager.md) | Adopting `module-manager` drops runtime module enablement | behaviour loss |
 
-Every deviation above also has an upstream issue filed against the document it deviates from — all 23 are filed, tracked as [#961](https://github.com/liberusoftware/ecommerce-laravel/issues/961). They are listed in [`../CONFORMANCE.md`](../CONFORMANCE.md)'s upstream chapter — a reader hitting one of these ADRs needs to know the disagreement is filed rather than forgotten.
+Every deviation above also has an upstream issue filed against the document it deviates from — all 23 are filed, tracked as [#961](https://github.com/liberusoftware/ecommerce-laravel/issues/961). One of the 23, [`documentation` #20](https://github.com/liberusoftware/documentation/issues/20), is withdrawn along with ADR 0010: this repository no longer wants §3.2 changed. They are listed in [`../CONFORMANCE.md`](../CONFORMANCE.md)'s upstream chapter — a reader hitting one of these ADRs needs to know the disagreement is filed rather than forgotten.
 
 ## Adding one
 


### PR DESCRIPTION
Closes #972.

The issue asks for two things. Both are here.

## `/modules` and `/themes` stay tracked

[ADR 0010](https://github.com/liberusoftware/ecommerce-laravel/blob/main/docs/adr/0010-modules-and-themes-are-gitignored.md) argued for gitignoring both per package at promotion, so that whether a module was promoted would be answerable by `ls` rather than by reading a lockfile. It is **withdrawn**.

The decisive fact is that **it was never implemented**. `.gitignore` has never named `/modules` or `/themes`, because nothing has been promoted yet. So the reversal is a doc change with no code behind it — the cheapest moment such a reversal was ever going to be available.

What withdrawing costs, stated plainly: the host keeps an installed copy of code whose authoritative source is Composer. ADR 0010 was right that this is duplication. It is now an **accepted cost rather than a deviation**, and the guard against drift is `git diff --exit-code --stat -- modules themes` in `release.yml` — the exact mechanism the ADR rejected, and what `boilerplate-laravel` already does.

The ADR file is marked withdrawn rather than deleted. The reasoning below the banner is the record of why the flip looked attractive; whoever proposes it next should meet the counter-argument before re-proposing.

**Upstream consequence.** `documentation` [#20](https://github.com/liberusoftware/documentation/issues/20) exists solely to argue that `THEMES.md` §3.2 should permit the gitignore. This repository no longer wants that change, so the issue is withdrawn with the ADR. `docs/adr/README.md` says so. I have **not** closed the upstream issue — that is another repository, and it is yours to close.

## `theme.json` out of the module stubs

`app/Modules/{Api,Core,Filament,Livewire}/theme.json` — four files, deleted.

Each declared a theme that does not exist:

```json
{ "name": "Api Theme", "version": "1.0.0", "description": "Theme configuration for Api module" }
```

Nothing in `app/`, `config/`, `routes/` or `tests/` reads `theme.json` — grep returns the two research documents and nothing else. They were harmless as scaffolding. They stop being harmless the moment a real discoverer validates manifests, which is exactly the failure mode [ADR 0011](https://github.com/liberusoftware/ecommerce-laravel/blob/main/docs/adr/0011-adopting-module-manager.md) flagged for these same four stubs: *"a stub that was harmless as scaffolding becomes a boot failure as a manifest."*

## Not touched

`docs/CONFORMANCE.md` still lists 0010 as a live deviation. It is a dated snapshot that is never revised — the gap between it and the plan is the progress record.

## Test plan

No PHP changed. Full CI for the deletions.