### PR TITLE
ci: a dispatchable Composer require, for a machine whose DNS Composer cannot use

### DIFF
--- a/.github/workflows/composer-require.yml
+++ b/.github/workflows/composer-require.yml
@@ -1,0 +1,71 @@
+# This repository cannot run `composer require` locally, and the reason is not
+# going to be fixed by trying again. PHP's libcurl here is built against c-ares,
+# which resolves over UDP; UDP :53 is black-holed on the maintainer's network,
+# which is exactly why /etc/resolv.conf carries `options use-vc`. glibc honours
+# that and resolves over TCP — so curl, git and gh all work — and c-ares ignores
+# it, so Composer alone cannot resolve a single host.
+#
+# The runner has working DNS. This job is the way to add or update a dependency
+# from a machine that does not.
+name: Composer Require
+
+on:
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: 'Packages to require, space separated (e.g. "vendor/a vendor/b:^2.0")'
+        required: true
+        type: string
+      dev:
+        description: 'Add to require-dev instead of require'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  require:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+
+      # No cache. A require resolves against current Packagist by definition,
+      # and a stale cache is the failure mode this whole job exists to avoid.
+
+      # --no-scripts: package:discover boots the application, and the point of
+      # this job is to produce a lockfile, not to prove the app boots. The full
+      # CI run on the resulting commit is what proves that.
+      - name: Require
+        run: |
+          set -euo pipefail
+          read -r -a pkgs <<< "${{ inputs.packages }}"
+          composer require ${{ inputs.dev && '--dev' || '' }} \
+            --no-interaction --no-progress --no-scripts -- "${pkgs[@]}"
+
+      # modules/ and themes/ are tracked — ADR 0010 is withdrawn — so a package
+      # of type liberu-module installed by composer-installer lands in the tree
+      # and belongs in this commit. `git add -A` over the three paths keeps
+      # deletions (an uninstall) as well as additions.
+      - name: Commit
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A composer.json composer.lock modules themes 2>/dev/null || git add -A composer.json composer.lock
+          if git diff --cached --quiet; then
+            echo "Nothing changed — the requirement was already satisfied."
+            exit 0
+          fi
+          git commit -m "chore(deps): require ${{ inputs.packages }}"
+          git push origin HEAD:${{ github.ref_name }}


### PR DESCRIPTION
## The problem this solves

`composer require` fails on the maintainer's machine at name resolution, on every host, every time. It is not Composer, and the machine is not offline.

```
curl error 6 while downloading https://repo.packagist.org/packages.json: Could not resolve host
```

The cause: **PHP's libcurl is built against c-ares**, which resolves over UDP.

```
$ php -r '$v=curl_version(); echo ($v["features"] & CURL_VERSION_ASYNCHDNS) ? "c-ares" : "glibc";'
c-ares
```

UDP `:53` is black-holed on that network — which is exactly why `/etc/resolv.conf` carries `options use-vc`, forcing DNS over TCP. **glibc honours that option; c-ares ignores it.** So `curl`, `git`, `gh` and `getent` all work perfectly, and Composer alone cannot resolve a single name. That asymmetry is why this reads as "Composer is hanging" or "no network" and is neither.

Two local workarounds were tried and rejected:

- **Pinning hosts in a private mount namespace** (`unshare -r -m` + bind-mounted `/etc/hosts`) — no root needed, and it does fix resolution. But PHP here runs under `lerd`, inside podman, so the namespace the fix lands in is not the namespace PHP runs in.
- **A local HTTP proxy**, which would move DNS to the proxy process. PHP cannot reach the host's loopback (`errno=7`, connection refused, on a listener the host can curl) — same reason: separate network namespace.

Both are the wrong shape anyway. They fix one machine.

## What this does

The runner has working DNS. Dispatch this workflow on a branch, give it packages, and it runs the require there and pushes `composer.json`, `composer.lock` and any installed `modules/` back to that branch.

```
gh api -X POST repos/liberusoftware/ecommerce-laravel/actions/workflows/composer-require.yml/dispatches \
  -f ref=my-branch \
  -f 'inputs[packages]=vendor/package vendor/other:^2.0'
```

`--no-scripts` on the require: `package:discover` boots the application, and this job's output is a lockfile. Whether the app boots with it is what the full CI run on the resulting commit is for. No Composer cache either — a require resolves against current Packagist by definition, and a stale cache is precisely the failure this exists to avoid.

## Why it is its own pull request

A `workflow_dispatch` workflow is not dispatchable until it is on the default branch:

```
$ gh api -X POST .../workflows/composer-require.yml/dispatches -f ref=feat/adopt-module-manager
{"message":"Not Found","status":"404"}
```

So it cannot ship in the change that needs it. This merges first; [the module-manager adoption](https://github.com/liberusoftware/ecommerce-laravel/issues/972) follows and uses it.

## Test plan

Dispatching it is the test, and that happens immediately after this merges — the adoption branch is already pushed and waiting for it. Full CI runs on whatever commit it produces.