### PR TITLE
fix: chat conversations were readable across every team

### DIFF
--- a/app/Filament/Admin/Resources/ChatConversations/ChatConversationResource.php
+++ b/app/Filament/Admin/Resources/ChatConversations/ChatConversationResource.php
@@ -21,17 +21,16 @@ class ChatConversationResource extends Resource
     protected static ?string $model = ChatConversation::class;
 
     /*
-     * Not tenant-scoped: `chat_conversations` has no `team_id` and the model has
-     * no `team` relationship, so Filament would raise a LogicException on every
-     * query rather than isolate anything. A conversation belongs to the person
-     * having it.
+     * Tenant-scoped, by inheriting the panel's default. This used to declare
+     * `$isScopedToTenant = false`, and the reason it gave was true — the table
+     * had no `team_id` and the model no `team` relationship, so Filament would
+     * have raised a LogicException rather than isolated anything.
      *
-     * Declared as a property rather than set with `scopeToTenant()`, which
-     * writes one storage slot shared by every resource that does not redeclare
-     * it — see App\Filament\Admin\Resources\RoleResource.
+     * The reason was true and the outcome was still a leak: every staff user
+     * saw every team's conversations, customer names, emails and message bodies
+     * included. The fix is the missing key, not the opt-out — `ChatConversation`
+     * now carries `team_id` and `store_id` via IsTenantModel and IsStoreScoped.
      */
-    protected static bool $isScopedToTenant = false;
-
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-chat-bubble-left-right';
 
     protected static string|\UnitEnum|null $navigationGroup = 'Customer Support';

--- a/app/Models/ChatAnalytics.php
+++ b/app/Models/ChatAnalytics.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -34,7 +35,7 @@ class ChatAnalytics extends Model
      */
     public static function averageResponseTime()
     {
-        return static::whereNotNull('response_time_seconds')->avg('response_time_seconds');
+        return static::inScope()->whereNotNull('response_time_seconds')->avg('response_time_seconds');
     }
 
     /**
@@ -42,6 +43,21 @@ class ChatAnalytics extends Model
      */
     public static function averageSatisfactionRating()
     {
-        return static::whereNotNull('satisfaction_rating')->avg('satisfaction_rating');
+        return static::inScope()->whereNotNull('satisfaction_rating')->avg('satisfaction_rating');
+    }
+
+    /**
+     * Analytics rows carry no tenant key of their own — they hang off a
+     * conversation, and the conversation is what is scoped.
+     *
+     * `whereHas` rather than a join, because the global scope on
+     * `ChatConversation` applies to the subquery for free. Both callers of the
+     * two averages above are panel surfaces — `ChatStatsWidget` and
+     * `ChatAgentDashboard` — and a widget is exactly where Filament's own
+     * tenancy does not reach.
+     */
+    protected static function inScope(): Builder
+    {
+        return static::whereHas('conversation');
     }
 }

--- a/app/Models/ChatConversation.php
+++ b/app/Models/ChatConversation.php
@@ -2,15 +2,34 @@
 
 namespace App\Models;
 
+use App\Traits\IsStoreScoped;
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
+/**
+ * A conversation is a customer talking to one merchant, on one storefront.
+ *
+ * It had neither key until now, which is why `ChatConversationResource` opted
+ * out of Filament's tenancy — honestly, and with a comment saying the column
+ * was not there. The opt-out was accurate and the consequence was still a leak:
+ * staff on any team read every team's conversations, including the customer
+ * name, email and every message body.
+ *
+ * Both keys, for the reason `Product` carries both. `store_id` is the grain the
+ * storefront reads on and it is what the global scope filters; `team_id` is
+ * what Filament's tenancy joins on in the panel. Neither is in `$fillable` —
+ * the traits' `creating` hooks are the only writers, so no request can post
+ * its way into another merchant's tenancy.
+ */
 class ChatConversation extends Model
 {
     use HasFactory;
+    use IsStoreScoped;
+    use IsTenantModel;
 
     protected $fillable = [
         'session_id',

--- a/database/factories/ChatAnalyticsFactory.php
+++ b/database/factories/ChatAnalyticsFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ChatAnalytics;
+use App\Models\ChatConversation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ChatAnalytics>
+ */
+class ChatAnalyticsFactory extends Factory
+{
+    protected $model = ChatAnalytics::class;
+
+    public function definition(): array
+    {
+        return [
+            'conversation_id' => ChatConversation::factory(),
+            'message_count' => 0,
+            'agent_message_count' => 0,
+            'customer_message_count' => 0,
+        ];
+    }
+}

--- a/database/factories/ChatConversationFactory.php
+++ b/database/factories/ChatConversationFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ChatConversation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ChatConversation>
+ */
+class ChatConversationFactory extends Factory
+{
+    protected $model = ChatConversation::class;
+
+    public function definition(): array
+    {
+        return [
+            'session_id' => $this->faker->uuid(),
+            'status' => 'queued',
+            'customer_name' => $this->faker->name(),
+            'customer_email' => $this->faker->safeEmail(),
+        ];
+    }
+
+    /**
+     * `store_id` and `team_id` are absent from the definition on purpose.
+     *
+     * The traits' `creating` hooks derive both from the resolved store, and a
+     * factory that supplied them would test the factory rather than the hook.
+     * A test that needs a specific store passes it explicitly — factories
+     * bypass mass assignment, which is what makes that possible without
+     * putting either key in `$fillable`.
+     */
+    public function active(): static
+    {
+        return $this->state(fn () => ['status' => 'active', 'started_at' => now()]);
+    }
+}

--- a/database/migrations/2026_02_16_194922_create_chat_conversations_table.php
+++ b/database/migrations/2026_02_16_194922_create_chat_conversations_table.php
@@ -21,8 +21,15 @@ return new class extends Migration
             // unattributable row is left unstamped, which an operator can see
             // and fix — App\Traits\IsTenantModel records why the default was
             // itself the bug.
-            $table->foreignId('store_id')->nullable()->constrained('stores')->nullOnDelete();
-            $table->foreignId('team_id')->nullable()->constrained('teams')->nullOnDelete();
+            // Nullable and unconstrained, both of them, matching
+            // 2026_08_08_000002_add_store_id_to_team_scoped_tables: a foreign
+            // key would force a default for a row that belongs to nobody, and
+            // that default is the mistake being unpicked. `stores` is also
+            // created two migrations from the end, long after this one — a
+            // constraint here fails on MySQL with "Failed to open the
+            // referenced table", which SQLite does not reproduce.
+            $table->unsignedBigInteger('store_id')->nullable()->index();
+            $table->unsignedBigInteger('team_id')->nullable()->index();
             $table->foreignId('user_id')->nullable()->constrained('users')->onDelete('cascade');
             $table->foreignId('agent_id')->nullable()->constrained('users')->onDelete('set null');
             $table->enum('status', ['queued', 'active', 'closed'])->default('queued');

--- a/database/migrations/2026_02_16_194922_create_chat_conversations_table.php
+++ b/database/migrations/2026_02_16_194922_create_chat_conversations_table.php
@@ -14,6 +14,15 @@ return new class extends Migration
         Schema::create('chat_conversations', function (Blueprint $table) {
             $table->id();
             $table->string('session_id')->unique();
+            // A conversation is a customer talking to one merchant on one
+            // storefront. Both keys were absent, which is why the Filament
+            // resource opted out of tenancy and every team could read every
+            // other team's conversations. Deliberately no default(1): an
+            // unattributable row is left unstamped, which an operator can see
+            // and fix — App\Traits\IsTenantModel records why the default was
+            // itself the bug.
+            $table->foreignId('store_id')->nullable()->constrained('stores')->nullOnDelete();
+            $table->foreignId('team_id')->nullable()->constrained('teams')->nullOnDelete();
             $table->foreignId('user_id')->nullable()->constrained('users')->onDelete('cascade');
             $table->foreignId('agent_id')->nullable()->constrained('users')->onDelete('set null');
             $table->enum('status', ['queued', 'active', 'closed'])->default('queued');
@@ -23,7 +32,7 @@ return new class extends Migration
             $table->string('customer_name')->nullable();
             $table->string('customer_email')->nullable();
             $table->timestamps();
-            
+
             $table->index('status');
             $table->index('agent_id');
             $table->index('created_at');

--- a/tests/Feature/ChatConversationTenantScopeTest.php
+++ b/tests/Feature/ChatConversationTenantScopeTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ChatAnalytics;
+use App\Models\ChatConversation;
+use App\Models\Store;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The leak `AdminPanelTenancyTest` was built to catch and could not.
+ *
+ * That test asks whether an unscoped resource *declared its own* exemption,
+ * because the failure it was written for was one resource's `scopeToTenant(false)`
+ * silently unscoping every other. `ChatConversationResource` declared its
+ * exemption, honestly, with a comment explaining that `chat_conversations` had
+ * no `team_id` — so the ratchet passed, and staff on any team still read every
+ * team's conversations, customer names, emails and message bodies included.
+ *
+ * An honest opt-out is still a leak when the reason for it is a missing column
+ * rather than data that genuinely spans tenants. So the assertion here is about
+ * the data, not the declaration: rows, through the model, as a panel user.
+ */
+class ChatConversationTenantScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return array{0: Store, 1: User}
+     */
+    private function merchant(): array
+    {
+        $team = Team::factory()->create();
+        $store = Store::factory()->create(['team_id' => $team->id]);
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+
+        return [$store, $user];
+    }
+
+    public function test_a_panel_user_does_not_see_another_teams_conversations(): void
+    {
+        [$mine, $me] = $this->merchant();
+        [$theirs] = $this->merchant();
+
+        $ours = ChatConversation::factory()->create(['store_id' => $mine->id]);
+        $hidden = ChatConversation::factory()->create([
+            'store_id' => $theirs->id,
+            'customer_email' => 'someone-elses-customer@example.com',
+        ]);
+
+        $this->actingAs($me);
+
+        $visible = ChatConversation::query()->pluck('id')->all();
+
+        $this->assertSame([$ours->id], $visible);
+        $this->assertNotContains($hidden->id, $visible);
+    }
+
+    /**
+     * The two averages have no tenant key of their own — they hang off the
+     * conversation — and both callers are panel surfaces (`ChatStatsWidget`,
+     * `ChatAgentDashboard`), which is exactly where Filament's resource
+     * tenancy does not reach.
+     */
+    public function test_the_analytics_averages_do_not_aggregate_across_teams(): void
+    {
+        [$mine, $me] = $this->merchant();
+        [$theirs] = $this->merchant();
+
+        ChatAnalytics::factory()->create([
+            'conversation_id' => ChatConversation::factory()->create(['store_id' => $mine->id])->id,
+            'response_time_seconds' => 10,
+            'satisfaction_rating' => 5,
+        ]);
+
+        ChatAnalytics::factory()->create([
+            'conversation_id' => ChatConversation::factory()->create(['store_id' => $theirs->id])->id,
+            'response_time_seconds' => 990,
+            'satisfaction_rating' => 1,
+        ]);
+
+        $this->actingAs($me);
+
+        // 10, not 500 — the other team's row must not move our average.
+        $this->assertSame(10.0, (float) ChatAnalytics::averageResponseTime());
+        $this->assertSame(5.0, (float) ChatAnalytics::averageSatisfactionRating());
+    }
+
+    /**
+     * `team_id` and `store_id` are absent from `$fillable` on purpose: the
+     * traits' `creating` hooks are the only writers. A request that could post
+     * either one could post itself into another merchant's tenancy.
+     */
+    public function test_the_tenant_keys_cannot_be_mass_assigned(): void
+    {
+        [$mine, $me] = $this->merchant();
+        [$theirs] = $this->merchant();
+
+        $this->actingAs($me);
+
+        $conversation = ChatConversation::create([
+            'session_id' => 'attempted-cross-tenant',
+            'store_id' => $theirs->id,
+            'team_id' => $theirs->team_id,
+            'status' => 'queued',
+        ]);
+
+        $this->assertNotSame($theirs->id, $conversation->store_id);
+        $this->assertNotSame($theirs->team_id, $conversation->team_id);
+    }
+}


### PR DESCRIPTION
Found while reconciling the two chat stacks for #943 ([#1020](https://github.com/liberusoftware/ecommerce-laravel/pull/1020)). It is a live leak rather than a merge concern, so it lands on its own and ahead of the merge.

## What was wrong

`ChatConversationResource` declared:

```php
protected static bool $isScopedToTenant = false;
```

and the comment on it was **true**: `chat_conversations` had no `team_id` and the model no `team` relationship, so Filament would have raised a `LogicException` on every query rather than isolated anything.

The reason was correct and the outcome was still a leak. The admin panel is tenant-scoped (`->tenant(Team::class, ownershipRelationship: 'team')`), so staff on any team read **every** team's conversations — customer name, customer email, and every message body.

## The fix is the missing key, not the opt-out

`ChatConversation` now uses `IsStoreScoped` and `IsTenantModel` — the pair `Product` already carries. `store_id` is the grain the storefront reads on and what the global scope filters; `team_id` is what Filament tenancy joins on. Neither is in `$fillable`: the traits' `creating` hooks are the only writers, so no request can post its way into another merchant's tenancy. No `default(1)` on either column, for the reason `IsTenantModel`'s docblock sets out at length — a default that answers the question on the row's behalf produces rows nobody can later attribute.

**A global scope rather than eight guards.** `ChatStatsWidget` and `ChatAgentDashboard` make five bare `ChatConversation::where(...)` calls between them. Scoping at the caller is the original failure behind #939, #950 and #952 — it has to be remembered every time, and it was not. One scope is remembered once.

`ChatAnalytics::averageResponseTime()` and `averageSatisfactionRating()` were averaging across all teams. They carry no tenant key of their own, so they now filter through `whereHas('conversation')` and inherit the conversation's scope for free. Both callers are panel surfaces — a widget and a custom page — which is precisely where Filament's *resource* tenancy does not reach.

## Why the existing ratchet did not catch it

`AdminPanelTenancyTest::test_no_resource_is_unscoped_without_declaring_it_itself` asks whether an unscoped resource **declared its own** exemption. That is the right question for the fault it was built for: one `scopeToTenant(false)` written for Shield's role resource silently unscoped every resource in both panels, because they share one storage slot.

This resource declared its exemption, honestly and with a comment. The ratchet passed. The data leaked anyway.

**An honest opt-out is still a leak when the reason for it is a missing column rather than data that genuinely spans tenants.** The new test therefore asserts on rows, as a panel user, rather than on declarations:

- another team's conversation is not visible through the model
- the two analytics averages do not move when another team has rows (`10.0`, not `500.0`)
- neither tenant key can be mass-assigned

I have **not** widened `AdminPanelTenancyTest` to "may only opt out if the model has no `team_id`". Four other resources opt out — `RoleResource`, `StoreResource`, `TaxClassResource`, `PageResource` — and at least `StoreResource` needs a real decision rather than a sweep. That gap is worth its own issue; I would rather report it than half-close it inside a security fix.

## Notes

- Migration edited in place. Pre-production: every database is built from the migrations, so there is nothing to migrate.
- `ChatConversationFactory` and `ChatAnalyticsFactory` are new — neither existed. The conversation factory deliberately does not define `store_id`/`team_id`, so a test exercises the hook rather than the factory.
- Pint reformatted the migration (`class_definition`, `braces_position`, `no_whitespace_in_blank_line`) — pre-existing debt in a file this change touches, which is how the ratchet is meant to work.

## Test plan

`ChatConversationTenantScopeTest`, three cases, plus five-green CI.