### PR TITLE
docs: the CMS and CRM packages are built from ground, so the debt is not a move

### DIFF
--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -229,6 +229,10 @@ Its promotion gate is [`MODULE_DEVELOPMENT.md` §6.1](./MODULE_DEVELOPMENT.md#61
 
 `ecommerce-core` is provisioned in all four flavours, so promotion pushes into existing repositories.
 
+**One prerequisite is a contribution rather than a fix, and it is nobody's defect report.** [ADR 0006](./adr/0006-late-bound-host-model-resolution.md) has commerce modules resolve host models late and never import them. That needs a **team resolver** in `organizations-teams`, and it does not exist. Until it lands, a commerce module cannot resolve a team — which is a hard block on wave 1, not a nice-to-have.
+
+It is recorded here because it was previously recorded *only* inside [#961](https://github.com/liberusoftware/ecommerce-laravel/issues/961), the upstream-issue tracker, as the one item of 24 that had never been filed anywhere. #961 is now closed ([ADR 0013](./adr/0013-cms-and-crm-packages-are-built-from-ground.md)), and a wave 1 prerequisite belongs in the wave 1 section rather than in a list of other repositories' bugs.
+
 ---
 
 ## Wave 1.5 — stores, channels, and the tenant scope
@@ -545,12 +549,12 @@ Two asymmetries drive the whole plan:
 ## 4. What is outside this plan
 
 - **The 105 modules themselves** — the execution epics.
-- **The deferred CMS and CRM code** ([#942](https://github.com/liberusoftware/ecommerce-laravel/issues/942), [#943](https://github.com/liberusoftware/ecommerce-laravel/issues/943)). This plan said it moves *"when those products have repositories, not on a date this plan can name"*. **They have repositories** — re-checked 2026-08-09, `cms-laravel` is live and `crm-laravel` is on `2.0.1` — so the condition this plan set has been met and the item still is not takeable, for two different reasons.
+- **The CMS and CRM code — no longer deferred, and no longer a move.** ~~#942, #943~~ are closed, superseded by [**ADR 0013**](./adr/0013-cms-and-crm-packages-are-built-from-ground.md).
 
-  For **CMS**, the destination is now nameable per cluster: `cms-laravel/packages/liberu-cms/` holds 21 path packages, among them `cms-pages`, `cms-posts`, `cms-seo` and `cms-forms`, which own all three clusters #942 lists. None is published, so the exit criterion's second half stands — but the receiving host has none of the code, which makes this a move whenever somebody decides to make it.
+  This plan said the code moves *"when those products have repositories, not on a date this plan can name"*. They have repositories, so the condition was met — and then the answer changed underneath it. **The CMS and CRM packages are being built from ground**, each tracked by its own module issue. They are not extractions of this code, so there is no move to schedule. The local code is **deleted at cutover**, in the change that adopts the module.
 
-  For **CRM** it stopped being a move at all. `crm-laravel` already carries `LiveChat`, `ChatMessage`, `Chatbot` and `ChatbotInteraction`, so the live-chat stack here is a **second implementation of one that exists**, in a different repository, with neither authoritative. That is the reviews/ratings duplicate stack again with the two halves split across repositories — and the larger implementation is the one in the repository that should not own it.
+  Both premises had expired first, in opposite directions, which is what forced the re-decision. `crm-laravel` `2.0.1` already carries `LiveChat`, `ChatMessage`, `Chatbot` and `ChatbotInteraction` — the local stack was a second implementation, not an orphan. And `cms-laravel` holds 21 committed path packages under `packages/liberu-cms/`, so the CMS implementation exists too; only the tags do not. A deferral whose premise has expired needs re-deciding, because re-applying it is how debt outlives its reason.
 
-  Recorded rather than acted on: which stack survives is a decision about a product this repository has no mandate over. What this plan can say is that the deferral's premise expired, and a deferral whose premise has expired needs re-deciding rather than re-applying.
+  What survives, and is the reason closing the trackers costs nothing: [`reconciliation/cms-owned-code.md`](./reconciliation/cms-owned-code.md) and [`reconciliation/crm-chat-stack.md`](./reconciliation/crm-chat-stack.md) were written as *how to move this* and are now *what a fresh package must cover*. ADR 0013 lists the findings a from-scratch build will not rediscover — the inverted `user_id`, the read receipts and rate limits that exist only here, `cms-forms`' `'email'` instead of `'email:rfc'`, and the sitemap's canonical root and 50k cap that `cms-contracts` cannot express.
 - **The five out-of-scope flavours** — `react`, `vue`, `nuxt`, `flutter`, `react-native`.
 - **Adding a locale.** `en` only; adding a language is product scope. The RTL machinery in `TRANSLATIONS.md` and `THEMES.md` §18.1 stays unexercised as a result, which is recorded as a deliberate deferral rather than an oversight.

--- a/docs/adr/0013-cms-and-crm-packages-are-built-from-ground.md
+++ b/docs/adr/0013-cms-and-crm-packages-are-built-from-ground.md
@@ -1,0 +1,50 @@
+# CMS and CRM packages are built from ground; the local code is deleted at cutover, not moved
+
+**Status**: accepted — 2026-08-09. Supersedes the deferral recorded in [#932](https://github.com/liberusoftware/ecommerce-laravel/issues/932) (D1) for the CMS and CRM clusters.
+
+D1 said: code owned by a product whose repository does not exist yet **stays in the host as named debt**, rather than being extracted into module packages this effort has no mandate to found. [#942](https://github.com/liberusoftware/ecommerce-laravel/issues/942) and [#943](https://github.com/liberusoftware/ecommerce-laravel/issues/943) were the debt registers, each with the same exit criterion: *the repository exists and the owning module is published — the code moves then.*
+
+**The packages are now being built from ground.** They are not extractions of this repository's code, and each module has its own issue. So the exit criterion describes a move that will not happen.
+
+## Why the deferral had to be re-decided rather than re-applied
+
+Both premises expired, in opposite directions, and neither expiry was visible from the issues themselves.
+
+- **CRM.** `crm-laravel` `2.0.1` already carries `LiveChat`, `ChatMessage`, `Chatbot` and `ChatbotInteraction`. The local stack stopped being an orphan waiting for a home and became a **second implementation** of one that exists.
+- **CMS.** `cms-laravel` holds **21 committed path packages** under `packages/liberu-cms/` — `cms-pages`, `cms-posts`, `cms-seo`, `cms-forms` and the rest. The implementation exists; only the tags do not.
+
+A deferral whose premise has expired needs re-deciding. Re-applying it is how debt outlives the reason for it.
+
+## The decision
+
+1. **The fresh packages are authoritative.** Neither `cms-laravel`'s nor this repository's implementation is a source to copy from.
+2. **This repository's CMS and CRM code is deleted at cutover, not moved.** When a module package covers a cluster, the local code goes in the same change that adopts it.
+3. **The two reconciliation documents change role, and keep their value.** They were written as *how to move this*. They are now *what a fresh package must cover* — the requirements record, which is the more useful of the two readings and the reason closing the trackers loses nothing:
+   - [`docs/reconciliation/cms-owned-code.md`](../reconciliation/cms-owned-code.md)
+   - [`docs/reconciliation/crm-chat-stack.md`](../reconciliation/crm-chat-stack.md)
+4. **#942, #943 and [#961](https://github.com/liberusoftware/ecommerce-laravel/issues/961) close.** The first two are superseded by this ADR; the third is a duplicate index, below.
+
+## What the requirements record has to carry, because a fresh build will not rediscover it
+
+These are the findings that cost the most to establish and are the easiest to lose. They are stated in full in the two documents; they are listed here so that closing the issues does not bury them.
+
+- **`user_id` means the opposite thing on each side of the chat stacks.** Here it is the customer and `agent_id` is the agent; in `crm-laravel` it is the agent and `contact_id` is the customer. A column-name mapping files every customer as the agent.
+- **Read receipts, `system` sender, rate limits, the IDOR guard and time-to-first-response** exist only in this repository's chat implementation. A fresh package that reads only `crm-laravel` will not have them, and 49 test cases here specify them.
+- **`cms-forms` maps its email field to `'email'`, not `'email:rfc'`.** Adopting it as-is silently reopens a header-injection hole this repository already closed.
+- **The sitemap is not CMS-owned as written.** `SitemapController` holds a primary-domain canonical root — 6 of its 9 tests — and a 50,000-URL cap. `cms-contracts`' `SitemapUrl` can express neither, so a fresh CMS package that models the sitemap on that contract regresses it.
+- **`Page` adoption costs two things**: `cascadeOnDelete` becomes `nullOnDelete`, and `getStatuses()` has no counterpart.
+
+## On closing #961
+
+#961 tracked 23 upstream issues across nine repositories. All 23 are still open, and closing the tracker does not close them — **it stops maintaining a second copy of a list.** Each deviation's ADR already links its own upstream issue, and [`CONFORMANCE.md` chapter 8](../CONFORMANCE.md#8-upstream-gaps) holds the full table with the reasoning. A tracker that duplicates two authoritative places is a third place to forget to update.
+
+Two things had to be handled before it could close, rather than being allowed to vanish with it:
+
+- **One of the 23 is now withdrawn.** [`documentation` #20](https://github.com/liberusoftware/documentation/issues/20) argued that `THEMES.md` §3.2 should permit gitignoring `/themes`. [#972](https://github.com/liberusoftware/ecommerce-laravel/issues/972) withdrew ADR 0010, so this repository no longer wants that change. Recorded in [`adr/README.md`](./README.md); the upstream issue is another repository's to close.
+- **One item was never filed anywhere.** The **team resolver** that `organizations-teams` needs for [ADR 0006](./0006-late-bound-host-model-resolution.md) is a contribution rather than a defect report, so it had no upstream issue and existed only inside #961. It is a **wave 1 prerequisite** — commerce modules cannot resolve a team until it lands — and it is now recorded in `MIGRATION_PLAN.md`'s wave 1 section, which is where a prerequisite belongs.
+
+## Consequences
+
+The `article_*` Shield permissions left behind by [ADR 0012](./0012-deleting-the-empty-cms-scaffolds.md) stay unused, unchanged by this.
+
+The local CMS and CRM code keeps running until its module lands. Nothing is deleted by this ADR — it changes what happens *at* cutover, and cutover is each module's own issue.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,8 +18,11 @@ Gaps become findings, never silent exemptions. A deviation without an ADR is a b
 | [0010](./0010-modules-and-themes-are-gitignored.md) | ~~`/modules` and `/themes` are gitignored~~ | **withdrawn** — [#972](https://github.com/liberusoftware/ecommerce-laravel/issues/972); the repo conforms to `THEMES.md` §3.2 |
 | [0011](./0011-adopting-module-manager.md) | Adopting `module-manager` drops runtime module enablement | behaviour loss |
 | [0012](./0012-deleting-the-empty-cms-scaffolds.md) | The Article/FAQ and `seo_settings` scaffolds are deleted, not moved | behaviour loss |
+| [0013](./0013-cms-and-crm-packages-are-built-from-ground.md) | CMS and CRM packages are built from ground; local code is deleted at cutover | supersedes a deferral |
 
-Every deviation above also has an upstream issue filed against the document it deviates from — all 23 are filed, tracked as [#961](https://github.com/liberusoftware/ecommerce-laravel/issues/961). One of the 23, [`documentation` #20](https://github.com/liberusoftware/documentation/issues/20), is withdrawn along with ADR 0010: this repository no longer wants §3.2 changed. They are listed in [`../CONFORMANCE.md`](../CONFORMANCE.md)'s upstream chapter — a reader hitting one of these ADRs needs to know the disagreement is filed rather than forgotten.
+Every deviation above also has an upstream issue filed against the document it deviates from — all 23 are filed. One of the 23, [`documentation` #20](https://github.com/liberusoftware/documentation/issues/20), is withdrawn along with ADR 0010: this repository no longer wants §3.2 changed.
+
+They were tracked as [#961](https://github.com/liberusoftware/ecommerce-laravel/issues/961), which is **closed** — see [ADR 0013](./0013-cms-and-crm-packages-are-built-from-ground.md). The issues are still open upstream; what closed is a second copy of the list. Each ADR above links its own, and [`../CONFORMANCE.md` chapter 8](../CONFORMANCE.md#8-upstream-gaps) holds the full table with the reasoning behind each. A reader hitting one of these ADRs needs to know the disagreement is filed rather than forgotten, and the ADR itself is where that now lives. They are listed in [`../CONFORMANCE.md`](../CONFORMANCE.md)'s upstream chapter — a reader hitting one of these ADRs needs to know the disagreement is filed rather than forgotten.
 
 ## Adding one
 


### PR DESCRIPTION
[ADR 0013](https://github.com/liberusoftware/ecommerce-laravel/blob/main/docs/adr/0013-cms-and-crm-packages-are-built-from-ground.md). Closes #942, #943, #961.

## What changed

D1 in #932 held CMS- and CRM-owned code in the host as **named debt**, to move once the owning module was published. #942 and #943 were the debt registers, each with the same exit criterion.

**The packages are being built from ground**, each tracked by its own module issue. They are not extractions of this repository's code, so the exit criterion describes a move that will not happen. The local code is **deleted at cutover** — in the change that adopts the module — rather than migrated into it.

## Why this needed re-deciding rather than re-applying

Both premises had already expired, in opposite directions, and neither expiry was visible from the issues:

- **CRM** — `crm-laravel` `2.0.1` already carries `LiveChat`, `ChatMessage`, `Chatbot`, `ChatbotInteraction`. The local stack was a **second implementation**, not an orphan waiting for a home.
- **CMS** — `cms-laravel` holds **21 committed path packages** under `packages/liberu-cms/`. The implementation exists; only the tags do not.

A deferral whose premise has expired needs re-deciding. Re-applying it is how debt outlives the reason for it.

## Why closing these costs nothing

The two reconciliation documents were written as *how to move this*. They are now *what a fresh package must cover* — the requirements record, which is the more useful reading. ADR 0013 lists the findings a from-scratch build will **not** rediscover, so they do not die with the issues:

- **`user_id` means the opposite thing on each side of the chat stacks** — customer here, agent there. A column-name mapping files every customer as the agent.
- **Read receipts, the `system` sender, rate limits, the IDOR guard and time-to-first-response exist only here.** 49 test cases specify them; a package built from `crm-laravel` alone will not have them.
- **`cms-forms` maps its email field to `'email'`, not `'email:rfc'`** — adopting it as-is silently reopens a header-injection hole already closed here.
- **The sitemap is not CMS-owned as written** — a primary-domain canonical root (6 of 9 tests) and a 50,000-URL cap that `cms-contracts`' `SitemapUrl` cannot express.
- **`Page` adoption costs `cascadeOnDelete` → `nullOnDelete` and `getStatuses()`.**

## On #961

It tracked 23 upstream issues across nine repositories. **All 23 are still open, and closing the tracker does not close them** — it stops maintaining a second copy of a list. Each deviation's ADR already links its own issue and `CONFORMANCE.md` chapter 8 holds the full table with reasoning. A third place is a third place to forget.

Two things were rescued before it could close rather than being allowed to vanish with it:

- **`documentation` #20 is withdrawn**, along with ADR 0010 (#972). This repository no longer wants §3.2 changed. Recorded in `adr/README.md`; the upstream issue is another repository's to close.
- **One item was never filed anywhere.** The **team resolver** that `organizations-teams` needs for ADR 0006 is a contribution, not a defect report, so it had no upstream issue and lived only inside #961. It is a **hard wave 1 block** — commerce modules cannot resolve a team without it — and it is now in the wave 1 section of `MIGRATION_PLAN.md`, where a prerequisite belongs.

## Not touched

`docs/CONFORMANCE.md` — a dated snapshot that is never revised. The gap between it and the plan is the progress record.

## Test plan

Docs only, no PHP changed. Five-green.