### PR TITLE
docs: record the wave workflow and the project-board step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,67 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 See [AGENTS.md](./AGENTS.md) — it is the source of truth for agent configuration in this repo.
+
+## The wave workflow
+
+One architecture epic at a time, built as four packages, recorded, closed. Run it in this order.
+
+1. **Pick the epic.** The `Architecture: Ecommerce — <module>` epics are sequenced by
+   [`docs/MIGRATION_PLAN.md` §1](./docs/MIGRATION_PLAN.md) — tier order, then most-code-first
+   within a tier. Read that rule before choosing; `gh issue list` returns GitHub's order, not
+   the plan's.
+2. **Claim it.** Assign the issue and move it to **In Progress** on project board 10 — see
+   [`docs/agents/issue-tracker.md`](./docs/agents/issue-tracker.md#project-board-10). Do this
+   before any building, so the board reflects work in flight rather than work finished.
+3. **Survey the host from primary sources.** Read the migrations, models and services the
+   module replaces. Name each fault from the code, not from the issue text — the issue
+   describes the capability, not what is wrong here.
+4. **Write the wave addendum**, at
+   `~/.claude/projects/-home-tom-code-ecommerce-laravel/briefs/wave<N>-addendum.md`. It carries
+   the boundary statement, the host's faults, the one fact that shapes the module, and the
+   decisions agents must implement rather than rediscover. Briefs live outside `/tmp`, which is
+   not durable here.
+5. **Dispatch the domain agent**, pointing it at `module-build-brief.md`, the wave addendum and
+   `presentation-brief.md`, with the instruction to STOP if any is missing.
+6. **Verify green independently** against the GitHub API before believing the agent — see
+   "Verifying a package" below.
+7. **Dispatch the three presentation agents** (`-api`, `-filament`, `-livewire`) in parallel once
+   the domain package is tagged. Verify each as it returns, then bulk-verify all four.
+8. **Record the wave** in `docs/MIGRATION_PLAN.md` on a `docs/wave-<N>-shipped` branch, open a
+   PR, merge it, pull `main`.
+9. **Close the epic**: comment the shipped summary, `gh issue close --reason completed`, and move
+   the board item to **Done**.
+
+### Verifying a package
+
+Never report or close on an agent's own account of its results. Per package:
+
+```bash
+R=module-ecommerce-<module>
+gh run list --repo liberusoftware/$R --limit 12 --json workflowName,headBranch,conclusion \
+  --jq '[.[]|select(.conclusion!=null)]|group_by(.workflowName)|map(.[0]|"\(.workflowName)@\(.headBranch)=\(.conclusion)")|join(" ")'
+gh api repos/liberusoftware/$R/tags --jq '[.[].name]|join(" ")'
+gh api repos/liberusoftware/$R/commits --jq '.[].commit.message' \
+  | grep -iE 'claude\.ai|Claude-Session|session_0' && echo VIOLATION || echo "trailer clean"
+```
+
+Green means **Tests@main**, **Install@0.1.0** and **Compatibility@0.1.0** all `success`, and the
+`0.1.0` tag exists.
+
+## Standing constraints
+
+- **No session identifiers, anywhere.** No `Claude-Session:` trailer, no `claude.ai` URL, no
+  session id in a commit message, PR body, issue comment, tag message or file. Pass this to every
+  dispatched agent as an absolute rule and grep for it after every package.
+- **Modules live in their own GitHub repositories** under `liberusoftware`, never in a `modules/`
+  directory in this host.
+- **Dispatched agents never commit to this repository.** They clone their own module repo into
+  `~/work/wave<N>/` — not `/tmp`, which is not durable here and which concurrent agents contend
+  over.
+- **Pre-production: migrations are edited in place.** No corrective migrations.
+- **Composer cannot run locally.** PHP's libcurl is built against c-ares, which ignores the
+  `options use-vc` that makes `curl`, `git` and `gh` work over TCP. There is no `vendor/` here and
+  **GitHub Actions is the only test runner**. Require packages via
+  `.github/workflows/composer-require.yml`.
+- **Pint runs locally** via the release phar, with the fleet config — not the stock `laravel`
+  preset. See `module-build-brief.md` §6.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -33,6 +33,48 @@ Create a GitHub issue.
 
 Run `gh issue view <number> --comments`.
 
+## Project board 10
+
+The architecture epics are tracked on [project 10](https://github.com/orgs/liberusoftware/projects/10)
+— *"Architecture roadmap: Ecommerce — domain, API, Filament, Livewire"*. An epic moves to
+**In Progress** when its wave is claimed and to **Done** when the wave is recorded and the issue
+closed. See the wave workflow in [`CLAUDE.md`](../../CLAUDE.md#the-wave-workflow).
+
+Needs the `project` token scope, which a default `gh auth login` does not grant. `gh project`
+fails with `missing required scopes [read:project]` until you run — interactively, since it is a
+device flow — `gh auth refresh -s project --hostname github.com`.
+
+The ids are stable; the numbers in the board URL are not the ids the API wants:
+
+| | |
+|---|---|
+| Project | `PVT_kwDOCXeRJc4BfHfc` |
+| `Status` field | `PVTSSF_lADOCXeRJc4BfHfczhZcsso` |
+| `Todo` | `f75ad846` |
+| `In Progress` | `47fc9ee4` |
+| `Done` | `98236657` |
+
+An epic's item id is per-issue, so look it up:
+
+```bash
+gh project item-list 10 --owner liberusoftware --format json --limit 200 \
+  --jq '.items[] | select(.content.number == <issue>) | {id, status}'
+```
+
+Then move it, and assign in the same step — the board's `Assignees` field mirrors the issue, so
+assign on the issue rather than the item:
+
+```bash
+gh issue edit <issue> --repo liberusoftware/ecommerce-laravel --add-assignee @me
+gh project item-edit --project-id PVT_kwDOCXeRJc4BfHfc --id <item-id> \
+  --field-id PVTSSF_lADOCXeRJc4BfHfczhZcsso --single-select-option-id 47fc9ee4
+```
+
+`item-edit` prints nothing on success — re-run `item-list` to confirm the status actually moved.
+
+An epic not yet on the board is added with
+`gh project item-add 10 --owner liberusoftware --url <issue-url>`.
+
 ## Wayfinding operations
 
 Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.


### PR DESCRIPTION
The cycle that shipped waves 1–8 lived only in conversation. This writes it down.

## Where it goes

`CLAUDE.md` is loaded into every session; `AGENTS.md` is not. So the nine-step cycle goes in `CLAUDE.md`, which keeps its `AGENTS.md` pointer rather than forking the source of truth. The board mechanics go in `docs/agents/issue-tracker.md`, next to the other `gh` operations.

## What the eight waves did that nothing recorded

- **Green is verified against the GitHub API**, never taken from an agent's own report — Tests@main, Install@0.1.0, Compatibility@0.1.0, the tag, and a trailer grep. The one-liner is in the file now.
- **Claiming happens before building**, so the board reflects work in flight rather than work finished.

## The board half is new

Project 10 tracks the architecture epics and nothing has been moving items on it — the eight shipped waves are still in Todo. Recorded because none of it is guessable:

- `gh project` needs the `project` token scope, which a default `gh auth login` does not grant; it fails with `missing required scopes [read:project]` until an interactive `gh auth refresh`.
- The numbers in the board URL are not the ids the API wants. The project, `Status` field and three option ids are stable, so they are in the table; the item id is per-issue and gets a lookup.
- `item-edit` prints nothing on success, which is worth knowing before you believe it worked.

## Not in this PR

`CLAUDE.md`'s first line has carried `claude.ai/code` since before wave 1 — it is Anthropic's standard header, not a session identifier, and removing it is a separate call. The trailer grep in the workflow is scoped to module repos' commit messages, so it does not trip on it.

Backfilling the eight shipped waves to Done on the board is also left out.
