### PR TITLE
fix: stop the public review listing publishing reviewer PII

### DIFF
--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -83,12 +83,39 @@ class ReviewController extends Controller
         return response()->json(['message' => 'Review approved successfully']);
     }
 
+    /**
+     * The public listing. Unauthenticated, so every field here is a publication
+     * decision rather than a serialisation default.
+     *
+     * It used to be `->with('customer')` and `response()->json($reviews)`.
+     * `Customer` declares no `$hidden` and carries `email`, `phone_number`,
+     * `address`, `city`, `state` and `postal_code`, so that returned the full
+     * postal address of every shopper who ever left a review, to anyone who
+     * asked, keyed by an incrementing product id. Nothing consumed the customer
+     * object — the eager load served no caller at all.
+     *
+     * Projected explicitly, and the whitelist is the control: a column added to
+     * either table later cannot start appearing here by itself.
+     */
     public function show($productId)
     {
         $reviews = ProductReview::where('product_id', $productId)
             ->approved()
-            ->with('customer')
-            ->get();
+            ->with('customer:id,first_name')
+            ->get()
+            ->map(fn (ProductReview $review) => [
+                'id' => $review->id,
+                'product_id' => $review->product_id,
+                'comments' => $review->comments,
+                'is_verified_purchase' => (bool) $review->is_verified_purchase,
+                'helpful_votes' => $review->helpful_votes,
+                'unhelpful_votes' => $review->unhelpful_votes,
+                // A first name is what a review page shows. A surname, an email
+                // and an address are not, and neither is the customer id — it
+                // joins a person's reviews together across products.
+                'author' => $review->customer?->first_name,
+                'created_at' => optional($review->created_at)->toIso8601String(),
+            ]);
 
         return response()->json($reviews);
     }

--- a/tests/Feature/ReviewControllerTest.php
+++ b/tests/Feature/ReviewControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Customer;
 use App\Models\Product;
 use App\Models\ProductReview;
 use App\Models\User;
@@ -102,6 +103,43 @@ class ReviewControllerTest extends TestCase
         $ids = array_column($response->json(), 'id');
         $this->assertContains($approved->id, $ids);
         $this->assertNotContains($pending->id, $ids, 'An unmoderated review reached the public listing.');
+    }
+
+    public function test_show_publishes_no_reviewer_pii(): void
+    {
+        $product = Product::factory()->create();
+        $customer = Customer::factory()->create([
+            'first_name' => 'Sarah',
+            'last_name' => 'Tregarthen',
+            'email' => 'sarah@example.test',
+            'phone_number' => '+44 7700 900123',
+            'address' => '14 Bellwether Row',
+            'city' => 'Falmouth',
+            'postal_code' => 'TR11 3QA',
+        ]);
+        ProductReview::factory()->approved()->create([
+            'product_id' => $product->id,
+            'customer_id' => $customer->id,
+        ]);
+
+        $body = $this->getJson("/product/{$product->id}/reviews")->assertStatus(200)->content();
+
+        // The route is unauthenticated and the product id is incrementing, so
+        // anything reachable here is reachable for every reviewer in the shop.
+        foreach ([
+            'Tregarthen',
+            'sarah@example.test',
+            '7700 900123',
+            'Bellwether Row',
+            'Falmouth',
+            'TR11 3QA',
+        ] as $leak) {
+            $this->assertStringNotContainsString($leak, $body, "Public review listing published: {$leak}");
+        }
+
+        // The customer id joins one person's reviews together across products.
+        $this->assertStringNotContainsString('customer_id', $body);
+        $this->assertStringContainsString('Sarah', $body, 'A review page shows who wrote it.');
     }
 
     public function test_vote_helpful_increments_helpful_votes(): void


### PR DESCRIPTION
The public review listing was returning every reviewer's full postal address.

`GET /product/{product}/reviews` is unauthenticated — `routes/web.php:177`, outside the `auth` group. `ReviewController::show()` eager-loaded the customer and handed the models to `response()->json()`. `App\Models\Customer` declares no `$hidden` and carries `email`, `phone_number`, `address`, `city`, `state` and `postal_code`.

Anyone, unauthenticated, could walk incrementing product ids and harvest the email, phone number and postal address of every shopper who had ever left a review.

**Nothing consumed the customer object.** No Blade view, no Livewire component, no JS references the route. The eager load served no caller — it was there because serialising a model graph is the default and nobody chose otherwise.

## The fix

The listing is projected explicitly. A public route's payload is a publication decision rather than a serialisation default, and a whitelist means a column added to either table later cannot start appearing by itself.

The reviewer's first name survives, because a review page shows who wrote it. The surname, the contact details and the `customer_id` do not — that last one joins one person's reviews together across every product they have rated.

A regression test asserts the six leaked values are absent from the response body by name, and that the first name is still there.

## Why now

Found while surveying the host for the Reviews and Ratings extraction ([#907](https://github.com/liberusoftware/ecommerce-laravel/issues/907)), where it is the module's first recorded host fault. It is fixed here rather than left to the extraction: the module lands over months, and this is unauthenticated today.