### PR TITLE
fix: stop the promo-code route confirming which codes exist

### DIFF
--- a/app/Services/CouponService.php
+++ b/app/Services/CouponService.php
@@ -7,37 +7,49 @@ use App\Models\Coupon;
 class CouponService
 {
     /**
+     * The one refusal. Every way of failing says exactly this.
+     *
+     * `/cart/apply-coupon` is unauthenticated and the route already names the
+     * threat — "distinguishable valid/invalid responses make this
+     * brute-forceable to enumerate discount codes" — but the mitigation chosen
+     * was a per-IP throttle while the responses stayed distinguishable. They
+     * were three: a code that does not exist, a code that exists but is spent,
+     * and a code that exists, is live, and whose *minimum spend was printed to
+     * the caller*. The last is the worst of the three: it hands a stranger the
+     * terms of a coupon they do not hold.
+     *
+     * A throttle limits how fast an oracle can be asked. It does not stop it
+     * being an oracle, and merchant codes are guessable by construction —
+     * SUMMER10, WELCOME, BLACKFRIDAY are the codes people actually issue, and
+     * they fall well inside 10 guesses a minute.
+     *
+     * This is the rule the gift-card module already settled for the same
+     * reason: enumeration is closed by making every wrong answer the same
+     * answer. It costs a shopper holding a real code the "spend £8 more"
+     * prompt, and that is the trade — the prompt cannot be given to the holder
+     * without also giving it to the guesser, because the server cannot tell
+     * them apart.
+     *
+     * Response *timing* still differs slightly, since a found coupon runs a
+     * usage count and a missing one does not. That is a far weaker oracle than
+     * distinct text over a throttled route, and closing it means doing the
+     * count either way.
+     */
+    private const REFUSED = 'That code cannot be applied to this order.';
+
+    /**
      * Validate and apply a coupon to a cart
      */
     public function validateAndApplyCoupon(string $couponCode, float $subtotal): array
     {
         $coupon = Coupon::where('code', $couponCode)->first();
 
-        if (! $coupon) {
-            return [
-                'valid' => false,
-                'error' => 'Invalid coupon code.',
-                'discount' => 0,
-            ];
-        }
-
-        if (! $coupon->isValid()) {
-            return [
-                'valid' => false,
-                'error' => 'This coupon has expired or reached its usage limit.',
-                'discount' => 0,
-            ];
+        if (! $coupon || ! $coupon->isValid()) {
+            return $this->refuse();
         }
 
         if ($coupon->min_purchase_amount && $subtotal < $coupon->min_purchase_amount) {
-            return [
-                'valid' => false,
-                'error' => sprintf(
-                    'Minimum purchase amount of $%.2f required to use this coupon.',
-                    $coupon->min_purchase_amount
-                ),
-                'discount' => 0,
-            ];
+            return $this->refuse();
         }
 
         $discount = $this->calculateDiscount($coupon, $subtotal);
@@ -47,6 +59,16 @@ class CouponService
             'coupon' => $coupon,
             'discount' => $discount,
             'message' => sprintf('Coupon applied! You saved $%.2f', $discount),
+        ];
+    }
+
+    /** @return array{valid: false, error: string, discount: int} */
+    private function refuse(): array
+    {
+        return [
+            'valid' => false,
+            'error' => self::REFUSED,
+            'discount' => 0,
         ];
     }
 

--- a/tests/Feature/PromoCodeEnumerationTest.php
+++ b/tests/Feature/PromoCodeEnumerationTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Coupon;
+use App\Models\Product;
+use App\Models\ProductCategory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * `/cart/apply-coupon` is unauthenticated, so its refusal is an oracle.
+ *
+ * The route was already throttled against exactly this — its comment says
+ * "distinguishable valid/invalid responses make this brute-forceable to
+ * enumerate discount codes" — and the responses stayed distinguishable
+ * anyway. There were three of them: a code that does not exist, a code that
+ * exists but is spent, and a code that exists, is live, and whose configured
+ * minimum spend was printed back to a caller who does not hold it.
+ *
+ * A throttle limits the rate at which an oracle can be asked; it does not stop
+ * it being one. The codes merchants actually issue — SUMMER10, WELCOME —
+ * are guessable inside ten attempts.
+ *
+ * The rule here is the one the gift-card module already settled: enumeration
+ * is closed by making every wrong answer the same answer.
+ */
+class PromoCodeEnumerationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** The minimum spend that must never reach an unauthenticated caller. */
+    private const MIN_SPEND = 250.00;
+
+    public function test_every_refusal_is_the_same_refusal(): void
+    {
+        $this->fillACart();
+
+        Coupon::create([
+            'code' => 'EXPIRED',
+            'type' => 'percentage', 'value' => 10,
+            'valid_from' => now()->subDays(30), 'valid_until' => now()->subDay(),
+        ]);
+        Coupon::create([
+            'code' => 'EXHAUSTED',
+            'type' => 'percentage', 'value' => 10,
+            'valid_from' => now()->subDay(), 'valid_until' => now()->addDay(),
+            'max_uses' => 0,
+        ]);
+        Coupon::create([
+            'code' => 'NOTYET',
+            'type' => 'percentage', 'value' => 10,
+            'valid_from' => now()->addDay(), 'valid_until' => now()->addDays(30),
+        ]);
+        Coupon::create([
+            'code' => 'BIGSPEND',
+            'type' => 'percentage', 'value' => 10,
+            'valid_from' => now()->subDay(), 'valid_until' => now()->addDay(),
+            'min_purchase_amount' => self::MIN_SPEND,
+        ]);
+
+        // A code that does not exist is the baseline every other refusal must
+        // be indistinguishable from.
+        $baseline = $this->refusalFor('NO-SUCH-CODE');
+
+        $this->assertNotSame('', $baseline, 'the unknown-code path must refuse at all');
+
+        foreach (['EXPIRED', 'EXHAUSTED', 'NOTYET', 'BIGSPEND'] as $code) {
+            $this->assertSame(
+                $baseline,
+                $this->refusalFor($code),
+                "refusing `{$code}` tells a stranger the code exists"
+            );
+        }
+    }
+
+    public function test_a_coupons_minimum_spend_is_never_disclosed(): void
+    {
+        $this->fillACart();
+
+        Coupon::create([
+            'code' => 'BIGSPEND',
+            'type' => 'percentage', 'value' => 10,
+            'valid_from' => now()->subDay(), 'valid_until' => now()->addDay(),
+            'min_purchase_amount' => self::MIN_SPEND,
+        ]);
+
+        $refusal = $this->refusalFor('BIGSPEND');
+
+        // Both renderings, because the leak was a `sprintf('%.2f')` and a
+        // future one need not be.
+        $this->assertStringNotContainsString('250', $refusal);
+        $this->assertStringNotContainsString('250.00', $refusal);
+    }
+
+    public function test_a_usable_coupon_still_applies(): void
+    {
+        // The point is that refusals are uniform, not that everything refuses.
+        $this->fillACart();
+
+        Coupon::create([
+            'code' => 'GOOD10',
+            'type' => 'percentage', 'value' => 10,
+            'valid_from' => now()->subDay(), 'valid_until' => now()->addDay(),
+        ]);
+
+        $response = $this->post(route('cart.apply-coupon'), ['coupon_code' => 'GOOD10']);
+
+        $response->assertSessionHas('success');
+        $response->assertSessionMissing('error');
+        $this->assertSame('GOOD10', session('coupon')['code']);
+    }
+
+    private function refusalFor(string $code): string
+    {
+        // Forget the two flash keys rather than flushing: the guest cart is
+        // identified by a token held in this same session, and flushing it
+        // would empty the cart the next request needs.
+        session()->forget(['error', 'success']);
+
+        $this->post(route('cart.apply-coupon'), ['coupon_code' => $code])
+            ->assertSessionMissing('success');
+
+        return (string) session('error');
+    }
+
+    /**
+     * The route refuses an empty cart before it ever looks at the code, so
+     * every case here needs a line in the cart or it proves nothing.
+     */
+    private function fillACart(): void
+    {
+        $category = ProductCategory::create([
+            'name' => 'Test Category',
+            'slug' => 'enumeration-'.uniqid(),
+        ]);
+
+        $product = Product::create([
+            'name' => 'Test Product',
+            'slug' => 'enumeration-'.uniqid(),
+            'price' => 100.00,
+            'category_id' => $category->id,
+            'inventory_count' => 100,
+            'is_downloadable' => false,
+        ]);
+
+        $this->post(route('cart.add', $product), ['quantity' => 1])
+            ->assertSessionHas('success');
+    }
+}

--- a/tests/Unit/CouponServiceTest.php
+++ b/tests/Unit/CouponServiceTest.php
@@ -20,12 +20,25 @@ class CouponServiceTest extends TestCase
         $this->service = new CouponService;
     }
 
+    /**
+     * The refusal a code that does not exist gets.
+     *
+     * Asserted against rather than a literal on purpose: what these tests are
+     * pinning is that every refusal is *the same* refusal, and comparing them
+     * to the unknown-code case says that directly. A literal would pass just
+     * as well if three of the four drifted apart together.
+     */
+    private function theOneRefusal(): string
+    {
+        return $this->service->validateAndApplyCoupon('NO-SUCH-CODE-'.uniqid(), 1000.0)['error'];
+    }
+
     public function test_invalid_coupon_code_returns_error(): void
     {
         $result = $this->service->validateAndApplyCoupon('NONEXISTENT', 100.0);
 
         $this->assertFalse($result['valid']);
-        $this->assertStringContainsString('Invalid', $result['error']);
+        $this->assertSame($this->theOneRefusal(), $result['error']);
         $this->assertEquals(0, $result['discount']);
     }
 
@@ -44,7 +57,7 @@ class CouponServiceTest extends TestCase
         $result = $this->service->validateAndApplyCoupon('EXPIRED10', 100.0);
 
         $this->assertFalse($result['valid']);
-        $this->assertStringContainsString('expired', $result['error']);
+        $this->assertSame($this->theOneRefusal(), $result['error']);
     }
 
     public function test_percentage_coupon_calculates_correct_discount(): void
@@ -98,7 +111,7 @@ class CouponServiceTest extends TestCase
         $result = $this->service->validateAndApplyCoupon('MINBUY', 30.0);
 
         $this->assertFalse($result['valid']);
-        $this->assertStringContainsString('Minimum', $result['error']);
+        $this->assertSame($this->theOneRefusal(), $result['error']);
     }
 
     public function test_coupon_above_minimum_purchase_succeeds(): void
@@ -176,7 +189,7 @@ class CouponServiceTest extends TestCase
         $result = $this->service->validateAndApplyCoupon('USEDUP', 100.0);
 
         $this->assertFalse($result['valid']);
-        $this->assertStringContainsString('usage limit', $result['error']);
+        $this->assertSame($this->theOneRefusal(), $result['error']);
         $this->assertEquals(0, $result['discount']);
     }
 


### PR DESCRIPTION
`/cart/apply-coupon` is unauthenticated, so its refusal is an oracle. The route already named the threat — its comment reads *"distinguishable valid/invalid responses make this brute-forceable to enumerate discount codes; cap attempts per IP"* — and then the mitigation chosen was a per-IP throttle while the three responses stayed distinguishable:

| response | what it tells a stranger |
|---|---|
| `Invalid coupon code.` | the code does not exist |
| `This coupon has expired or reached its usage limit.` | the code **exists** |
| `Minimum purchase amount of $%.2f required to use this coupon.` | the code exists, is live, **and here are its terms** |

The third is the worst of the three: it discloses the configured minimum spend of a coupon the caller does not hold.

A throttle limits how fast an oracle can be asked. It does not stop it being one, and the codes merchants actually issue — `SUMMER10`, `WELCOME`, `BLACKFRIDAY` — fall well inside ten guesses a minute.

## The fix

Every refusal path returns one message. This is the rule the gift-card module already settled for the same reason: **enumeration is closed by making every wrong answer the same answer.**

## The trade, stated rather than buried

A shopper holding a real code loses the "spend £8 more" prompt. That prompt cannot be given to the holder without also giving it to the guesser, because the server cannot tell them apart.

Response *timing* still differs slightly — a found coupon runs a usage count and a missing one does not. That is a far weaker oracle than distinct text over a throttled route, and closing it means doing the count either way. Noted in the code rather than fixed.

## Tests

`PromoCodeEnumerationTest` drives four failure modes over the real route — unknown, expired, not-yet-started, exhausted, below minimum spend — and asserts each is **byte-identical to the unknown-code refusal**, plus that the minimum-spend figure never appears in the response, plus that a usable coupon still applies.

The four assertions in `CouponServiceTest` that pinned the distinguishing text now assert the same indistinguishability property rather than a literal, which would have passed just as well if three of the four drifted apart together.

Found while surveying the host for the Promotions extraction (#895).