### PR TITLE
fix: stop a customer's "active groups" returning other customers' groups

### DIFF
--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -74,12 +74,16 @@ class Customer extends Model
         return $this->hasMany(AnalyticsEvent::class);
     }
 
+    /**
+     * The groups this customer is currently in.
+     *
+     * The live-membership predicate lives on `CustomerGroup` — see the docblock
+     * on `constrainToLiveMemberships()` for what the ungrouped `or` here used
+     * to return, which was other people's groups.
+     */
     public function getActiveGroupsAttribute()
     {
-        return $this->groups()
-            ->wherePivot('expires_at', '>', now())
-            ->orWherePivotNull('expires_at')
-            ->get();
+        return CustomerGroup::constrainToLiveMemberships($this->groups())->get();
     }
 
     public function getTotalSpentAttribute(): float

--- a/app/Models/CustomerGroup.php
+++ b/app/Models/CustomerGroup.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Traits\IsTenantModel;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -38,8 +39,8 @@ class CustomerGroup extends Model
     public function customers(): BelongsToMany
     {
         return $this->belongsToMany(Customer::class, 'customer_group_memberships')
-                    ->withPivot(['joined_at', 'expires_at'])
-                    ->withTimestamps();
+            ->withPivot(['joined_at', 'expires_at'])
+            ->withTimestamps();
     }
 
     public function discounts(): HasMany
@@ -65,17 +66,45 @@ class CustomerGroup extends Model
         return $this->customers()->where('customer_id', $customer->id)->exists();
     }
 
+    /**
+     * The one live-membership predicate. Every question about whether a
+     * membership is still current asks it here.
+     *
+     * It was written out three times — here, in `scopeWithActiveMembers()`
+     * below, and in `Customer::getActiveGroupsAttribute()` — each time as
+     * `->where('expires_at', '>', now())->orWhereNull('expires_at')` with no
+     * grouping. `AND` binds tighter than `OR`, so what those three produced was
+     *
+     *     WHERE customer_id = 12 AND expires_at > now() OR expires_at IS NULL
+     *
+     * which SQL reads as `(customer_id = 12 AND expires_at > now()) OR
+     * (expires_at IS NULL)`. The second half is unqualified by anything: every
+     * membership on the deployment that never expires satisfies it, whoever it
+     * belongs to. So a customer's "active groups" included strangers' groups,
+     * and a group's active-member count counted every other group's members.
+     * A never-expiring membership is the normal case, so this was not an edge.
+     *
+     * The `or` has to live inside its own closure to be parenthesised, and the
+     * column has to be qualified because this also runs inside `whereHas`,
+     * where a bare `expires_at` resolves against `customers` — a column that is
+     * not there.
+     */
+    public static function constrainToLiveMemberships(Builder|BelongsToMany $query): Builder|BelongsToMany
+    {
+        return $query->where(function (Builder $query) {
+            $query->where('customer_group_memberships.expires_at', '>', now())
+                ->orWhereNull('customer_group_memberships.expires_at');
+        });
+    }
+
     public function getActiveCustomersCount(): int
     {
-        return $this->customers()
-                    ->wherePivot('expires_at', '>', now())
-                    ->orWherePivotNull('expires_at')
-                    ->count();
+        return self::constrainToLiveMemberships($this->customers())->count();
     }
 
     public function calculateDiscount(float $orderAmount): float
     {
-        if (!$this->is_active || $orderAmount < $this->minimum_order_amount) {
+        if (! $this->is_active || $orderAmount < $this->minimum_order_amount) {
             return 0;
         }
 
@@ -98,9 +127,8 @@ class CustomerGroup extends Model
 
     public function scopeWithActiveMembers($query)
     {
-        return $query->whereHas('customers', function ($q) {
-            $q->where('expires_at', '>', now())
-              ->orWhereNull('expires_at');
+        return $query->whereHas('customers', function ($query) {
+            self::constrainToLiveMemberships($query);
         });
     }
 }

--- a/tests/Unit/CustomerGroupModelTest.php
+++ b/tests/Unit/CustomerGroupModelTest.php
@@ -27,6 +27,7 @@ class CustomerGroupModelTest extends TestCase
     private function makeCustomer(): Customer
     {
         $user = User::factory()->create();
+
         return Customer::create([
             'user_id' => $user->id,
             'first_name' => 'Group',
@@ -116,5 +117,68 @@ class CustomerGroupModelTest extends TestCase
 
         $this->assertContains($active->id, $results);
         $this->assertNotContains($inactive->id, $results);
+    }
+
+    /**
+     * The four tests below pin the ungrouped `or`.
+     *
+     * Two of them fail against the old predicate and two do not, and the split
+     * is the lesson: the ones that catch it are the ones that put a second
+     * customer's never-expiring membership in the database and then assert it
+     * is *absent*. A test that sets up one customer and asks only "is my group
+     * here" passes either way, which is why this survived a test file.
+     */
+    public function test_active_groups_does_not_include_another_customers_groups(): void
+    {
+        $mine = $this->makeGroup(['name' => 'Mine']);
+        $theirs = $this->makeGroup(['name' => 'Theirs']);
+
+        $me = $this->makeCustomer();
+        $them = $this->makeCustomer();
+
+        // Both memberships never expire, which is the ordinary case.
+        $mine->addCustomer($me);
+        $theirs->addCustomer($them);
+
+        $names = $me->active_groups->pluck('name');
+
+        $this->assertContains('Mine', $names);
+        $this->assertNotContains('Theirs', $names);
+    }
+
+    public function test_active_groups_excludes_an_expired_membership(): void
+    {
+        $group = $this->makeGroup(['name' => 'Lapsed']);
+        $customer = $this->makeCustomer();
+
+        $group->addCustomer($customer, now()->subDay());
+
+        $this->assertNotContains('Lapsed', $customer->active_groups->pluck('name'));
+    }
+
+    public function test_active_member_count_counts_only_this_groups_members(): void
+    {
+        $group = $this->makeGroup(['name' => 'Counted']);
+        $other = $this->makeGroup(['name' => 'Not counted']);
+
+        $group->addCustomer($this->makeCustomer());
+        $other->addCustomer($this->makeCustomer());
+        $other->addCustomer($this->makeCustomer());
+
+        $this->assertSame(1, $group->getActiveCustomersCount());
+    }
+
+    public function test_with_active_members_ignores_a_group_whose_memberships_have_all_lapsed(): void
+    {
+        $live = $this->makeGroup(['name' => 'Live']);
+        $lapsed = $this->makeGroup(['name' => 'Lapsed']);
+
+        $live->addCustomer($this->makeCustomer());
+        $lapsed->addCustomer($this->makeCustomer(), now()->subDay());
+
+        $names = CustomerGroup::withActiveMembers()->pluck('name');
+
+        $this->assertContains('Live', $names);
+        $this->assertNotContains('Lapsed', $names);
     }
 }


### PR DESCRIPTION
Three places wrote the live-membership predicate as `->where('expires_at', '>', now())->orWhereNull('expires_at')` with no grouping — `Customer::getActiveGroupsAttribute()`, `CustomerGroup::getActiveCustomersCount()` and `CustomerGroup::scopeWithActiveMembers()`.

`AND` binds tighter than `OR`, so what reached the database was

```sql
WHERE customer_id = 12 AND expires_at > now() OR expires_at IS NULL
```

which SQL reads as `(customer_id = 12 AND expires_at > now()) OR (expires_at IS NULL)`. The right-hand side is constrained by nothing, so every never-expiring membership on the deployment satisfied it. A customer's active groups included strangers' groups; a group's active-member count counted every other group's members. A membership with no expiry is the ordinary case, so this was not an edge.

The predicate now lives once, on `CustomerGroup::constrainToLiveMemberships()`, with the `or` in its own closure so it is parenthesised and the column qualified — the same predicate runs inside `whereHas`, where a bare `expires_at` resolves against `customers`, which has no such column.

Four tests pin it. Two fail against the old predicate and two do not, and the split is the lesson: the ones that catch it put a second customer's never-expiring membership in the database and assert it is absent. `CustomerGroupModelTest` covered the discount arithmetic and the active scope, and none of the three expiry paths.

Found while surveying the host for the Commerce Customers extraction (#840).