### PR TITLE
fix: stop a segment recalculation drawing members from every merchant

### DIFF
--- a/app/Models/CustomerSegment.php
+++ b/app/Models/CustomerSegment.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Traits\IsTenantModel;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -43,17 +44,27 @@ class CustomerSegment extends Model
             return;
         }
 
-        $query = User::query();
+        $query = $this->membershipCandidates();
 
         // match_type 'any' => OR the conditions, 'all' => AND them.
         // Each condition is its own nested group so whereHas/has clauses combine correctly.
         $boolean = $this->match_type === 'any' ? 'orWhere' : 'where';
 
-        foreach ($this->conditions as $condition) {
-            $query->{$boolean}(function ($q) use ($condition) {
-                $this->applyCondition($q, $condition);
-            });
-        }
+        // The whole condition set is one group, and that grouping is what makes
+        // the tenant constraint above survive. Applied directly to $query, an
+        // `orWhere` condition would sit at the top level beside the tenant
+        // predicate — `WHERE (customer is this merchant's) OR (condition)` —
+        // and the right-hand side is qualified by nothing, so a single
+        // match_type='any' segment selects every user on the deployment. AND
+        // binds tighter than OR, so the constraint has to be outside a group
+        // the conditions are inside.
+        $query->where(function ($query) use ($boolean) {
+            foreach ($this->conditions as $condition) {
+                $query->{$boolean}(function ($query) use ($condition) {
+                    $this->applyCondition($query, $condition);
+                });
+            }
+        });
 
         $userIds = $query->pluck('id');
 
@@ -65,6 +76,47 @@ class CustomerSegment extends Model
             'customer_count' => $userIds->count(),
             'last_calculated_at' => now(),
         ]);
+    }
+
+    /**
+     * The users this segment is allowed to consider at all.
+     *
+     * A segment belongs to one merchant, so its members do too. This used to be
+     * a bare `User::query()`, which is every user on the deployment, and the
+     * `sync()` below then wrote other merchants' shoppers into this segment.
+     *
+     * It is not a corner case. `IsTenantModel` writes `team_id` on create and
+     * installs no read scope, so `CustomerSegment::active()->get()` in
+     * `segments:calculate` returns *every* merchant's segments and fills each
+     * one from every merchant's users. One run of one command crossed every
+     * tenant boundary on the deployment.
+     *
+     * The link is the shopper's `Customer` record, which is where a person's
+     * relationship with a merchant is actually recorded — the same path
+     * `in_customer_group` already takes. `Customer`'s own store scope rides
+     * along on top and narrows further inside a panel; it is inert on the
+     * console, which is exactly where this runs, so it is not the control.
+     *
+     * **An unstamped segment sees unstamped customers, and only those.**
+     * `team_id` is nullable on both tables and null means nobody could say who
+     * owns the row, which is the ordinary state of a deployment that has not
+     * configured tenancy yet. Matching null to null keeps that deployment
+     * working exactly as it did while still making a tenanted one correct:
+     * team 1's segment never sees team 2's shoppers either way.
+     *
+     * The alternative — an unstamped segment matching nobody — reads as the
+     * safer choice and is not. It turns a leak into a silently empty segment,
+     * and a merchant reading an empty segment acts on it just as confidently as
+     * one reading a wrong one. A control that fails closed has to fail visibly,
+     * and there is nowhere here to say so.
+     */
+    private function membershipCandidates(): Builder
+    {
+        return User::query()->whereHas('customer', function (Builder $query) {
+            $this->team_id === null
+                ? $query->whereNull('customers.team_id')
+                : $query->where('customers.team_id', $this->team_id);
+        });
     }
 
     /**

--- a/tests/Unit/CustomerSegmentTest.php
+++ b/tests/Unit/CustomerSegmentTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Unit;
 
-use App\Models\Customer;
 use App\Models\CustomerMetric;
 use App\Models\CustomerSegment;
 use App\Models\Order;
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -24,9 +24,23 @@ class CustomerSegmentTest extends TestCase
         ]);
     }
 
-    private function userWithLtv(float $ltv): User
+    /**
+     * A shopper, with the Customer file that is the only thing tying a user to a
+     * merchant. The helpers below all create one now, because segment membership
+     * is drawn from customer files rather than from `users` — a user who is
+     * nobody's customer has no relationship with any merchant to be segmented on.
+     */
+    private function shopper(): User
     {
         $user = User::factory()->create();
+        $user->getOrCreateCustomer();
+
+        return $user;
+    }
+
+    private function userWithLtv(float $ltv): User
+    {
+        $user = $this->shopper();
         CustomerMetric::create([
             'user_id' => $user->id,
             'lifetime_value' => $ltv,
@@ -38,11 +52,8 @@ class CustomerSegmentTest extends TestCase
 
     private function userWithOrderCount(int $count): User
     {
-        $user = User::factory()->create();
-        $customer = Customer::create([
-            'first_name' => 'A', 'last_name' => 'B', 'email' => uniqid().'@x.com',
-            'phone_number' => 5551234, 'address' => 'a', 'city' => 'c', 'state' => 's', 'postal_code' => 'z',
-        ]);
+        $user = $this->shopper();
+        $customer = $user->customer;
 
         for ($i = 0; $i < $count; $i++) {
             Order::create([
@@ -166,7 +177,7 @@ class CustomerSegmentTest extends TestCase
 
     private function userWithOrdersOn(array $datetimes): User
     {
-        $user = User::factory()->create();
+        $user = $this->shopper();
         foreach ($datetimes as $dt) {
             $order = Order::create([
                 'user_id' => $user->id,
@@ -215,6 +226,84 @@ class CustomerSegmentTest extends TestCase
 
         $this->assertContains($recent->id, $ids);
         $this->assertNotContains($old->id, $ids);
+    }
+
+    /**
+     * The two tests below pin the tenant boundary on segment recalculation.
+     *
+     * The second one is the one that matters, and it is the reason the tenant
+     * predicate cannot simply be added alongside the conditions. Under
+     * `match_type = 'any'` the conditions are OR-ed, and AND binds tighter than
+     * OR — so a top-level `WHERE (customer is this merchant's) OR (condition)`
+     * leaves the right-hand side qualified by nothing and selects every user on
+     * the deployment. The constraint has to sit outside a group the conditions
+     * are inside. A test written only against `match_type = 'all'` passes either
+     * way, which is how this shape keeps surviving test files.
+     */
+    public function test_recalculation_ignores_another_merchants_shoppers(): void
+    {
+        $ours = Team::factory()->create();
+        $theirs = Team::factory()->create();
+
+        $ourShopper = $this->shopperOf($ours, ltv: 2000);
+        $theirShopper = $this->shopperOf($theirs, ltv: 2000);
+
+        $segment = $this->makeSegment(
+            [['field' => 'lifetime_value', 'operator' => '>=', 'value' => 1000]],
+            'all'
+        );
+        $segment->forceFill(['team_id' => $ours->id])->save();
+
+        $segment->calculateMembers();
+
+        $ids = $segment->members()->pluck('users.id')->all();
+        $this->assertContains($ourShopper->id, $ids);
+        $this->assertNotContains(
+            $theirShopper->id,
+            $ids,
+            'a segment must never draw members from another merchant'
+        );
+        $this->assertEquals(1, $segment->fresh()->customer_count);
+    }
+
+    public function test_match_type_any_does_not_widen_past_the_merchant(): void
+    {
+        $ours = Team::factory()->create();
+        $theirs = Team::factory()->create();
+
+        $ourShopper = $this->shopperOf($ours, ltv: 2000);
+        $theirShopper = $this->shopperOf($theirs, ltv: 2000);
+
+        $segment = $this->makeSegment([
+            ['field' => 'lifetime_value', 'operator' => '>=', 'value' => 1000],
+            ['field' => 'lifetime_value', 'operator' => '<=', 'value' => 10],
+        ], 'any');
+        $segment->forceFill(['team_id' => $ours->id])->save();
+
+        $segment->calculateMembers();
+
+        $ids = $segment->members()->pluck('users.id')->all();
+        $this->assertContains($ourShopper->id, $ids);
+        $this->assertNotContains(
+            $theirShopper->id,
+            $ids,
+            'an OR-ed condition must not escape the tenant predicate'
+        );
+    }
+
+    private function shopperOf(Team $team, float $ltv): User
+    {
+        $user = User::factory()->create();
+        $customer = $user->getOrCreateCustomer();
+        $customer->forceFill(['team_id' => $team->id])->save();
+
+        CustomerMetric::create([
+            'user_id' => $user->id,
+            'lifetime_value' => $ltv,
+            'total_orders' => 0,
+        ]);
+
+        return $user;
     }
 
     public function test_unknown_condition_field_matches_no_one(): void


### PR DESCRIPTION
Found while surveying the host for wave 14 (#821), which takes over segments from Commerce Customers.

## The leak

`CustomerSegment::calculateMembers()` built its candidate set from a bare `User::query()` — every user on the deployment — and then `sync()`ed the result onto the segment. One merchant's segment filled with another merchant's shoppers.

It is not a corner case, because of how it is called. `IsTenantModel` writes `team_id` on create and installs **no read scope**, so `segments:calculate`'s `CustomerSegment::active()->get()` returns *every* merchant's segments and recalculates each one against every merchant's users. One run of one command crossed every tenant boundary on the deployment at once.

## The fix

Candidates are drawn through the shopper's `Customer` record — the only place a person's relationship with a merchant is recorded, and the same path the `in_customer_group` condition already takes. A user who is nobody's customer belongs to no merchant's segment, which is why the test helpers now give their users a customer file.

**An unstamped segment sees unstamped customers, and only those.** `team_id` is nullable on both tables and null means nobody could say who owns the row — the ordinary state of a deployment that has not configured tenancy. Matching null to null leaves that deployment working exactly as it did while making a tenanted one correct.

The alternative — an unstamped segment matching nobody — reads as the safer choice and is not. It turns a leak into a silently empty segment, and a merchant reading an empty segment acts on it just as confidently as one reading a wrong one. A control that fails closed has to fail visibly, and there is nowhere here to say so.

## Why the conditions moved inside a group

The tenant predicate could not simply be added alongside the conditions. Under `match_type = 'any'` the conditions are OR-ed, and AND binds tighter than OR — so

```sql
WHERE (customer is this merchant's) OR (lifetime_value >= 1000)
```

leaves the right-hand side qualified by nothing and selects every user on the deployment again. The constraint has to sit outside a group the conditions are inside.

This is the same shape as #1048's ungrouped `or`, two waves running, and the same lesson about which test catches it: **a test written only against `match_type = 'all'` passes either way.** Of the two tests added, the second — `test_match_type_any_does_not_widen_past_the_merchant` — is the one that fails against a naive fix.

## Not fixed here

`IsTenantModel` still has no read scope, which is the reason `segments:calculate` iterates every merchant's segments in the first place. That is a deliberate standing choice in the trait's own docblock and not something to change from inside a segment fix. Neither analytics command is scheduled anywhere either, which is recorded on #821 rather than fixed — the module replaces both.
