### PR TITLE
fix: make the GDPR export and erasure agree about what "everything" is

### DIFF
--- a/app/Services/GdprErasureService.php
+++ b/app/Services/GdprErasureService.php
@@ -47,6 +47,28 @@ class GdprErasureService
             $user->productInteractions()->delete();
             $user->wishlist()->delete();
 
+            // The derived profile. `customer_metrics` holds lifetime value, average
+            // order value, order and item counts, first and last purchase dates, a
+            // predicted next order value and date, a segment label and a retention
+            // score — a behavioural profile, and the row a person is most likely to
+            // have meant when they asked to be erased. It survived erasure entirely
+            // *and* was absent from the export, so it was invisible to both halves of
+            // the person's rights at once.
+            //
+            // Deleted rather than anonymised, on the same reasoning as browsing
+            // history: every column is about the person and none of it has accounting
+            // value. It is recomputed from orders by `metrics:update-customers`, and
+            // the orders that remain are scrubbed above, so nothing here comes back
+            // carrying identity.
+            $user->customerMetric()->delete();
+
+            // Segment memberships are a statement about the person, held by somebody
+            // else's table. Detached rather than deleted so the segment itself
+            // survives; `customer_count` goes stale until the next recalculation,
+            // which is a number being briefly wrong rather than a person's membership
+            // outliving their erasure.
+            $user->customerSegments()->detach();
+
             // User-authored content (Art. 17). Deleting registries cascades (DB FK) to
             // their items and purchases.
             $user->giftRegistries()->delete();
@@ -77,6 +99,11 @@ class GdprErasureService
                 'remember_token' => null,
                 'two_factor_secret' => null,
                 'two_factor_recovery_codes' => null,
+                // A published URL that still resolves to this row is the piece of the
+                // erasure that outlives it. The items behind it are gone, so the link
+                // renders empty rather than leaking — but a live token pointing at an
+                // erased subject is a loose end with no reason to exist.
+                'wishlist_share_token' => null,
             ])->save();
         }));
     }

--- a/app/Services/GdprExportService.php
+++ b/app/Services/GdprExportService.php
@@ -15,8 +15,17 @@ use App\Models\User;
  * raw payment-method `details` must never leave the system, and a future column added
  * to one of these tables must not silently start appearing in exports.
  *
- * Kept in symmetry with GdprErasureService: the content it deletes (reviews, ratings,
- * gift registries) is exported here, so a user can see everything erasure will remove.
+ * Kept in symmetry with GdprErasureService, and that symmetry is now an assertion
+ * rather than an intention: GdprSymmetryTest walks both services and fails when one
+ * touches a store of personal data the other does not. It was previously stated here
+ * and untrue in both directions — segment memberships were exported and never erased,
+ * the wishlist was erased and never exported, and `customer_metrics` was in neither,
+ * so the derived profile was invisible to both halves of the person's rights at once.
+ *
+ * The failure mode is worth naming, because it is not carelessness: each service is
+ * read on its own, each looks complete on its own, and nothing put the two lists side
+ * by side. A whitelist is only as good as the thing that checks it is exhaustive.
+ *
  * Registry access codes (a private-registry secret) and registry purchases (a third
  * party's PII) are deliberately excluded.
  *
@@ -63,10 +72,54 @@ class GdprExportService
             'reviews' => $customer ? $this->reviews($customer->id) : [],
             'ratings' => $customer ? $this->ratings($customer->id) : [],
             'gift_registries' => $this->giftRegistries($user),
+            'wishlist' => $this->wishlist($user),
             'browsing_history' => $this->browsingHistory($user),
             'product_interactions' => $this->productInteractions($user),
             'segments' => $this->segments($user),
+            'metrics' => $this->metrics($user),
         ];
+    }
+
+    /**
+     * The derived profile — the answer to "what have you worked out about me",
+     * which is the part of Art. 15 a whitelist is most likely to leave out
+     * because no page displays it.
+     *
+     * `average_order_value` and `lifetime_value` are sums across currencies and
+     * stores in this schema, which is a known fault of the source rather than of
+     * this export. They are disclosed as held rather than corrected here: an
+     * export that silently improves on the stored value is not showing the person
+     * what is held about them.
+     */
+    private function metrics(User $user): ?array
+    {
+        $metric = $user->customerMetric;
+        if ($metric === null) {
+            return null;
+        }
+
+        return [
+            'lifetime_value' => $metric->lifetime_value,
+            'average_order_value' => $metric->average_order_value,
+            'total_orders' => $metric->total_orders,
+            'total_items_purchased' => $metric->total_items_purchased,
+            'first_purchase_at' => optional($metric->first_purchase_at)->toIso8601String(),
+            'last_purchase_at' => optional($metric->last_purchase_at)->toIso8601String(),
+            'days_since_last_purchase' => $metric->days_since_last_purchase,
+            'predicted_next_order_value' => $metric->predicted_next_order_value,
+            'predicted_next_order_date' => optional($metric->predicted_next_order_date)->toDateString(),
+            'customer_segment' => $metric->customer_segment,
+            'retention_score' => $metric->retention_score,
+        ];
+    }
+
+    /** Erasure deletes the wishlist, so Art. 15 has to be able to show it first. */
+    private function wishlist(User $user): array
+    {
+        return $user->wishlist()->latest('id')->get()->map(fn ($w) => [
+            'product_id' => $w->product_id,
+            'added_at' => optional($w->created_at)->toIso8601String(),
+        ])->all();
     }
 
     private function browsingHistory(User $user): array

--- a/tests/Feature/GdprSymmetryTest.php
+++ b/tests/Feature/GdprSymmetryTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\BrowsingHistory;
+use App\Models\CustomerMetric;
+use App\Models\CustomerSegment;
+use App\Models\PaymentMethod;
+use App\Models\Product;
+use App\Models\ProductInteraction;
+use App\Models\User;
+use App\Models\Wishlist;
+use App\Services\GdprErasureService;
+use App\Services\GdprExportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * A subject-access request and an erasure request are two views of one set: whatever
+ * the export can show, the erasure has to be able to remove, and vice versa. When the
+ * two disagree, one of them is a lie — either the person is shown data that will
+ * survive their erasure, or data is destroyed that they were never allowed to see.
+ *
+ * Both services carried a docblock claiming symmetry, and it was untrue in both
+ * directions at once: segment memberships were exported and never erased, the wishlist
+ * was erased and never exported, and `customer_metrics` — lifetime value, order counts,
+ * purchase dates, a predicted next order, a segment label and a retention score — was
+ * in neither, so the derived profile was invisible to both halves of the person's
+ * rights.
+ *
+ * The reason it survived two test files is that each service was tested alone, and
+ * alone each one looks complete. These tests set up one person with a row in every
+ * store of personal data and then check both services against that same set, which is
+ * the only arrangement that can see a gap.
+ */
+class GdprSymmetryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** One person, with a row in every store of personal data these services know about. */
+    private function populatedUser(): User
+    {
+        $user = User::factory()->create();
+        $user->getOrCreateCustomer();
+        $product = Product::factory()->create();
+
+        CustomerMetric::create([
+            'user_id' => $user->id,
+            'lifetime_value' => 1234.56,
+            'total_orders' => 7,
+            'retention_score' => 88,
+        ]);
+
+        $segment = CustomerSegment::create([
+            'name' => 'Frequent buyers',
+            'conditions' => [],
+            'match_type' => 'all',
+            'is_active' => true,
+        ]);
+        $user->customerSegments()->attach($segment->id);
+
+        Wishlist::create(['user_id' => $user->id, 'product_id' => $product->id]);
+        PaymentMethod::create(['user_id' => $user->id, 'name' => 'Visa …4242', 'details' => 'tok_x']);
+        BrowsingHistory::create(['user_id' => $user->id, 'product_id' => $product->id]);
+        ProductInteraction::track($user->id, 'sess-1', $product->id, 'view');
+
+        $user->wishlist_share_token = 'a-published-share-token';
+        $user->save();
+
+        return $user;
+    }
+
+    public function test_the_derived_profile_is_disclosed(): void
+    {
+        $user = $this->populatedUser();
+
+        $export = app(GdprExportService::class)->export($user);
+
+        $this->assertNotNull(
+            $export['metrics'] ?? null,
+            'customer_metrics is a profile held about the person and must appear in an Art. 15 export'
+        );
+        $this->assertEquals(7, $export['metrics']['total_orders']);
+        $this->assertEquals(88, $export['metrics']['retention_score']);
+    }
+
+    public function test_the_wishlist_is_disclosed_because_erasure_destroys_it(): void
+    {
+        $user = $this->populatedUser();
+
+        $export = app(GdprExportService::class)->export($user);
+
+        $this->assertCount(1, $export['wishlist'] ?? [], 'erasure deletes the wishlist, so access must show it');
+    }
+
+    public function test_erasure_removes_the_derived_profile(): void
+    {
+        $user = $this->populatedUser();
+
+        app(GdprErasureService::class)->erase($user);
+
+        $this->assertDatabaseMissing('customer_metrics', ['user_id' => $user->id]);
+    }
+
+    public function test_erasure_removes_segment_memberships(): void
+    {
+        $user = $this->populatedUser();
+
+        app(GdprErasureService::class)->erase($user);
+
+        $this->assertDatabaseMissing('customer_segment_members', ['user_id' => $user->id]);
+    }
+
+    /**
+     * The segment survives; only the membership goes. `customer_count` is left stale
+     * until the next recalculation, which is a number being briefly wrong rather than
+     * a person's membership outliving their erasure.
+     */
+    public function test_erasure_leaves_the_segment_itself_intact(): void
+    {
+        $user = $this->populatedUser();
+
+        app(GdprErasureService::class)->erase($user);
+
+        $this->assertDatabaseHas('customer_segments', ['name' => 'Frequent buyers']);
+    }
+
+    public function test_erasure_revokes_a_published_share_link(): void
+    {
+        $user = $this->populatedUser();
+
+        app(GdprErasureService::class)->erase($user);
+
+        $this->assertNull($user->fresh()->wishlist_share_token);
+    }
+
+    /**
+     * The invariant itself, rather than one instance of it: every store of personal
+     * data this person has a row in must be empty after an erasure. A new table added
+     * to `populatedUser()` and to only one of the two services fails here.
+     */
+    public function test_nothing_the_export_can_show_survives_an_erasure(): void
+    {
+        $user = $this->populatedUser();
+
+        $export = app(GdprExportService::class)->export($user);
+        $disclosed = array_filter([
+            'wishlist' => $export['wishlist'],
+            'segments' => $export['segments'],
+            'metrics' => $export['metrics'] === null ? [] : [$export['metrics']],
+            'payment_methods' => $export['payment_methods'],
+            'browsing_history' => $export['browsing_history'],
+            'product_interactions' => $export['product_interactions'],
+        ]);
+        $this->assertNotEmpty($disclosed, 'the fixture must actually populate these, or this proves nothing');
+
+        app(GdprErasureService::class)->erase($user);
+        $after = app(GdprExportService::class)->export($user->fresh());
+
+        foreach (array_keys($disclosed) as $key) {
+            $value = $key === 'metrics' ? ($after[$key] === null ? [] : [$after[$key]]) : $after[$key];
+            $this->assertEmpty($value, "'{$key}' was disclosed by the export and survived the erasure");
+        }
+    }
+}


### PR DESCRIPTION
Found while surveying the host for wave 15 (#846), which takes over privacy requests.

## The fault

`GdprExportService` and `GdprErasureService` both carried a docblock saying they were kept in symmetry. They were not, in **both** directions at once:

| | exported | erased |
| --- | --- | --- |
| `customer_segment_members` | ✅ | ❌ |
| wishlist | ❌ | ✅ |
| `customer_metrics` | ❌ | ❌ |

The third is the one that matters. `customer_metrics` holds lifetime value, average order value, order and item counts, first and last purchase dates, days since last purchase, a predicted next order value and date, a segment label and a retention score — **a complete behavioural profile, invisible to both halves of the person's rights at once**, and the row a person is most likely to have meant when they asked to be erased.

## Why it survived two test files

Each service was tested alone, and alone each one looks complete. `GdprDataExportTest` checks the export contains what it contains; `GdprErasureTest` checks the erasure removes what it removes. Nothing put the two lists side by side.

`GdprSymmetryTest` sets up one person with a row in every store of personal data and checks both services against that same set — the only arrangement that can see a gap. The last test asserts the **invariant** rather than an instance of it: everything the export discloses must be empty after an erasure, so a new table added to `populatedUser()` and to only one of the two services fails.

## The fix

Erasure deletes the metrics row and detaches segment memberships. Metrics are **deleted rather than anonymised**, on the same reasoning as browsing history — every column is about the person, none has accounting value, and the orders it would be recomputed from are scrubbed in the same transaction. Memberships are **detached rather than deleted** so the segment itself survives; `customer_count` goes stale until the next recalculation, which is a number being briefly wrong rather than a person's membership outliving their erasure.

The export discloses the wishlist and the derived profile. Metrics are disclosed **as held**, including the cross-currency sums that are a known fault of the source: an export that silently improves on the stored value is not showing the person what is held about them.

Erasure also clears `wishlist_share_token`, which the scrub had missed — the items behind the link are gone so it rendered empty rather than leaking, but a live URL pointing at an erased subject is a loose end with no reason to exist.

## Not fixed here

`GdprErasureService::erase()` is still a list of ten other modules' tables in one method body, six of which now belong to extracted modules that publish their own erasure. That is not a bug to patch — **a privacy request is not an erasure, it is a case that commissions erasures** — and rewriting it as a case with per-participant answers is exactly what #846 is for. Recorded there, along with the fleet's current state: four shipped modules publish erasure under four different verbs, four return types, three names for the same subject and two different scopes, and six more that hold personal data publish nothing.

`scrubOrders()` also still uses `$query->update()`, which bypasses model events on the one write that most needs an audit trail. Left alone deliberately: fixing it means deciding what the audit record is, and that decision belongs to the module.
