### PR TITLE
fix: make loyalty points expire on their date rather than on their label

### DIFF
--- a/app/Models/LoyaltyPoints.php
+++ b/app/Models/LoyaltyPoints.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\DB;
 
 class LoyaltyPoints extends Model
 {
@@ -45,21 +46,26 @@ class LoyaltyPoints extends Model
      */
     public function addPoints(int $points, string $type, ?string $description = null, ?int $orderId = null): void
     {
-        $this->increment('balance', $points);
-        $this->increment('lifetime_earned', $points);
+        // The counters and the ledger row are one write. Unwrapped, a crash
+        // between them leaves a balance with nothing behind it — and since every
+        // reader reads the counter, nothing would ever say so.
+        DB::transaction(function () use ($points, $type, $description, $orderId) {
+            $this->increment('balance', $points);
+            $this->increment('lifetime_earned', $points);
 
-        $expiresAt = null;
-        if ($this->program->points_expiry_days) {
-            $expiresAt = now()->addDays($this->program->points_expiry_days);
-        }
+            $expiresAt = null;
+            if ($this->program->points_expiry_days) {
+                $expiresAt = now()->addDays($this->program->points_expiry_days);
+            }
 
-        $this->transactions()->create([
-            'points' => $points,
-            'type' => $type,
-            'description' => $description,
-            'order_id' => $orderId,
-            'expires_at' => $expiresAt,
-        ]);
+            $this->transactions()->create([
+                'points' => $points,
+                'type' => $type,
+                'description' => $description,
+                'order_id' => $orderId,
+                'expires_at' => $expiresAt,
+            ]);
+        });
     }
 
     /**
@@ -67,21 +73,31 @@ class LoyaltyPoints extends Model
      */
     public function redeemPoints(int $points, ?string $description = null, ?int $orderId = null): bool
     {
-        if ($this->balance < $points) {
-            return false;
-        }
+        // Check-then-act on a row two callers can hold at once: both read the same
+        // balance, both pass, both decrement. The lock makes the read and the
+        // write one step, so the second caller reads the first one's result.
+        return DB::transaction(function () use ($points, $description, $orderId) {
+            $locked = static::query()->whereKey($this->getKey())->lockForUpdate()->first();
 
-        $this->decrement('balance', $points);
-        $this->increment('lifetime_redeemed', $points);
+            if ($locked === null || $locked->balance < $points) {
+                return false;
+            }
 
-        $this->transactions()->create([
-            'points' => -$points,
-            'type' => 'redeemed',
-            'description' => $description,
-            'order_id' => $orderId,
-        ]);
+            $locked->decrement('balance', $points);
+            $locked->increment('lifetime_redeemed', $points);
 
-        return true;
+            $locked->transactions()->create([
+                'points' => -$points,
+                'type' => 'redeemed',
+                'description' => $description,
+                'order_id' => $orderId,
+            ]);
+
+            // The caller holds this instance, not the locked one.
+            $this->refresh();
+
+            return true;
+        });
     }
 
     /**
@@ -89,31 +105,47 @@ class LoyaltyPoints extends Model
      */
     public function expirePoints(): void
     {
+        // Selected by shape, not by label. `addPoints()` takes `$type` from its
+        // caller and writes it unvalidated — the migration's
+        // `// earned, redeemed, expired, adjustment, bonus` is a comment, not a
+        // constraint — so filtering on `type = 'earned'` retired only the lots
+        // whose caller happened to pass that one string. Every other label
+        // ('purchase', 'bonus', 'signup') earned points that could never expire,
+        // and the liability grew without bound.
+        //
+        // A lot is a positive movement carrying an expiry date. That is true of
+        // everything `addPoints()` writes and of nothing else: redemptions and
+        // expiries are negative and carry no `expires_at`.
         $expiredTransactions = $this->transactions()
-            ->where('type', 'earned')
+            ->where('points', '>', 0)
             ->where('expires_at', '<=', now())
             ->where('is_expired', false)
             ->get();
 
         foreach ($expiredTransactions as $transaction) {
-            // Only points still sitting in the balance can expire. A lot that was
-            // already (partly) spent must not drive the balance negative.
-            // ponytail: no per-lot tracking — clamp to the running balance; add FIFO lots only if partial-lot expiry is ever required.
-            $expiring = (int) min($transaction->points, max(0, $this->balance));
+            // One lot, one transaction. Marking the lot expired and taking the
+            // points off the balance are the same act; split, a crash between
+            // them retires a lot whose points are still spendable.
+            DB::transaction(function () use ($transaction) {
+                // Only points still sitting in the balance can expire. A lot that was
+                // already (partly) spent must not drive the balance negative.
+                // ponytail: no per-lot tracking — clamp to the running balance; add FIFO lots only if partial-lot expiry is ever required.
+                $expiring = (int) min($transaction->points, max(0, $this->balance));
 
-            $transaction->update(['is_expired' => true]);
+                $transaction->update(['is_expired' => true]);
 
-            if ($expiring <= 0) {
-                continue;
-            }
+                if ($expiring <= 0) {
+                    return;
+                }
 
-            $this->decrement('balance', $expiring);
+                $this->decrement('balance', $expiring);
 
-            $this->transactions()->create([
-                'points' => -$expiring,
-                'type' => 'expired',
-                'description' => 'Points expired',
-            ]);
+                $this->transactions()->create([
+                    'points' => -$expiring,
+                    'type' => 'expired',
+                    'description' => 'Points expired',
+                ]);
+            });
         }
     }
 }

--- a/app/Models/LoyaltyReward.php
+++ b/app/Models/LoyaltyReward.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\DB;
 
 class LoyaltyReward extends Model
 {
@@ -56,7 +57,7 @@ class LoyaltyReward extends Model
      */
     public function isAvailable(?int $userId = null): bool
     {
-        if (!$this->is_active) {
+        if (! $this->is_active) {
             return false;
         }
 
@@ -91,33 +92,45 @@ class LoyaltyReward extends Model
      */
     public function redeem(int $userId, ?int $orderId = null): ?LoyaltyRewardRedemption
     {
-        if (!$this->isAvailable($userId)) {
-            return null;
-        }
+        // Four writes across two tables. Unwrapped and unlocked, `isAvailable()`
+        // is a check-then-act on both limits it enforces: two callers racing for
+        // the last unit both read `stock_quantity = 1`, both pay, both decrement,
+        // and the stock lands at -1 with two redemption rows. `max_redemptions`
+        // has the same window — it is a `count()` compared to a limit with
+        // nothing holding the rows still in between.
+        //
+        // Locking the reward row serialises callers competing for the same
+        // reward and leaves callers of different rewards alone, which is the
+        // narrowest lock that closes both windows.
+        return DB::transaction(function () use ($userId, $orderId) {
+            $reward = static::query()->whereKey($this->getKey())->lockForUpdate()->first();
 
-        // Check user has enough points
-        $loyaltyPoints = LoyaltyPoints::where('user_id', $userId)
-            ->where('loyalty_program_id', $this->loyalty_program_id)
-            ->first();
+            if ($reward === null || ! $reward->isAvailable($userId)) {
+                return null;
+            }
 
-        if (!$loyaltyPoints || $loyaltyPoints->balance < $this->points_cost) {
-            return null;
-        }
+            $loyaltyPoints = LoyaltyPoints::where('user_id', $userId)
+                ->where('loyalty_program_id', $reward->loyalty_program_id)
+                ->first();
 
-        // Redeem points
-        $loyaltyPoints->redeemPoints($this->points_cost, "Redeemed: {$this->name}", $orderId);
+            // The debit reports its own outcome under its own lock, so the
+            // balance is not checked twice from out here. Dropping this boolean
+            // discarded the one answer the caller's own check could not give.
+            if (! $loyaltyPoints || ! $loyaltyPoints->redeemPoints($reward->points_cost, "Redeemed: {$reward->name}", $orderId)) {
+                return null;
+            }
 
-        // Decrement stock
-        if ($this->stock_quantity !== null) {
-            $this->decrement('stock_quantity');
-        }
+            if ($reward->stock_quantity !== null) {
+                $reward->decrement('stock_quantity');
+                $this->refresh();
+            }
 
-        // Create redemption record
-        return $this->redemptions()->create([
-            'user_id' => $userId,
-            'order_id' => $orderId,
-            'points_spent' => $this->points_cost,
-            'status' => 'pending',
-        ]);
+            return $reward->redemptions()->create([
+                'user_id' => $userId,
+                'order_id' => $orderId,
+                'points_spent' => $reward->points_cost,
+                'status' => 'pending',
+            ]);
+        });
     }
 }

--- a/tests/Unit/LoyaltyPointsTest.php
+++ b/tests/Unit/LoyaltyPointsTest.php
@@ -31,6 +31,7 @@ class LoyaltyPointsTest extends TestCase
     private function makePoints(array $overrides = []): LoyaltyPoints
     {
         $user = User::factory()->create();
+
         return LoyaltyPoints::create(array_merge([
             'user_id' => $user->id,
             'loyalty_program_id' => $this->program->id,
@@ -131,6 +132,31 @@ class LoyaltyPointsTest extends TestCase
         $this->assertGreaterThanOrEqual(0, $balance, 'expiry must never make the balance negative');
         $this->assertEquals(0, $balance);
         // Ledger stays consistent: earned +100, redeemed -60, expired -40 => 0.
+        $this->assertEquals(0, $points->transactions()->sum('points'));
+    }
+
+    /**
+     * The regression that mattered: every other expiry test in this file builds its
+     * own `LoyaltyPointTransaction` with `'type' => 'earned'`, which is a row shape
+     * the writer only produces if its caller happens to pass that exact string.
+     * `addPoints()` takes `$type` unvalidated, this file's own tests pass
+     * `'purchase'`, and the old `where('type', 'earned')` therefore skipped them —
+     * points that could never expire, and a liability with no ceiling.
+     *
+     * So this one earns its points through the writer instead of around it, which
+     * is the only arrangement that proves the two agree.
+     */
+    public function test_points_earned_under_any_label_still_expire(): void
+    {
+        $points = $this->makePoints();
+        $points->addPoints(100, 'purchase', 'Order #1');
+
+        $this->assertEquals(100, $points->fresh()->balance);
+
+        $this->travel(366)->days();
+        $points->fresh()->expirePoints();
+
+        $this->assertEquals(0, $points->fresh()->balance, 'a lot expires on its date, not on its label');
         $this->assertEquals(0, $points->transactions()->sum('points'));
     }
 

--- a/tests/Unit/LoyaltyRewardModelTest.php
+++ b/tests/Unit/LoyaltyRewardModelTest.php
@@ -154,6 +154,58 @@ class LoyaltyRewardModelTest extends TestCase
         $this->assertEquals(1500, $points->fresh()->balance);
     }
 
+    /**
+     * A failed redemption leaves nothing behind — no ledger row, no stock movement,
+     * no redemption record.
+     *
+     * The race this guards against is not reproducible in a single-threaded test:
+     * two callers reading `stock_quantity = 1` before either decrements it needs two
+     * connections. What is testable is the property the lock exists to keep — that
+     * the four writes are one act — so this pins the all-or-nothing shape, and a
+     * future edit that pulls a write back out of the transaction fails here.
+     */
+    public function test_a_failed_redemption_moves_nothing(): void
+    {
+        $user = User::factory()->create();
+        $points = LoyaltyPoints::create([
+            'user_id' => $user->id,
+            'loyalty_program_id' => $this->program->id,
+            'balance' => 100,
+        ]);
+        $reward = $this->makeReward(['points_cost' => 500, 'stock_quantity' => 1]);
+
+        $this->assertNull($reward->redeem($user->id));
+
+        $this->assertEquals(100, $points->fresh()->balance);
+        $this->assertEquals(0, $points->transactions()->count(), 'no ledger row for a redemption that did not happen');
+        $this->assertEquals(1, $reward->fresh()->stock_quantity, 'stock is not spent on a failed redemption');
+        $this->assertEquals(0, $reward->redemptions()->count());
+    }
+
+    /**
+     * The last unit is spent once. `isAvailable()` and the decrement used to sit
+     * either side of the points debit with nothing holding the row still between
+     * them; the second call now reads the first one's result.
+     */
+    public function test_the_last_unit_of_stock_is_redeemed_once(): void
+    {
+        $user = User::factory()->create();
+        $points = LoyaltyPoints::create([
+            'user_id' => $user->id,
+            'loyalty_program_id' => $this->program->id,
+            'balance' => 2000,
+            'lifetime_earned' => 2000,
+        ]);
+        $reward = $this->makeReward(['points_cost' => 500, 'stock_quantity' => 1]);
+
+        $this->assertNotNull($reward->redeem($user->id));
+        $this->assertNull($reward->redeem($user->id));
+
+        $this->assertEquals(0, $reward->fresh()->stock_quantity, 'stock never goes negative');
+        $this->assertEquals(1500, $points->fresh()->balance);
+        $this->assertEquals(1, $reward->redemptions()->count());
+    }
+
     public function test_belongs_to_program(): void
     {
         $reward = $this->makeReward();


### PR DESCRIPTION
## The bug

`LoyaltyPoints::expirePoints()` selected expiring lots with `where('type', 'earned')`.

Nothing guarantees that value. `addPoints()` takes `string $type` from its caller and writes it unvalidated — the migration's `// earned, redeemed, expired, adjustment, bonus` is a comment, not a constraint — and this repository's own test file calls `addPoints(50, 'purchase', ...)`.

So a lot earned under any other label never expired. On a programme with `points_expiry_days` set, the outstanding liability had no ceiling.

## Why five test files did not catch it

The three expiry tests build a `LoyaltyPointTransaction` by hand with `'type' => 'earned'` rather than calling `addPoints()`. A test that constructs its own fixture proves the reader, never the pair — the writer and the reader were each tested against a shape the other never produced.

`test_points_earned_under_any_label_still_expire()` earns its points through the writer instead of around it, which is the only arrangement that can see the gap.

## The fix

A lot is selected by **shape** rather than by label: a positive movement carrying an expiry date. That is true of everything `addPoints()` writes and of nothing else — redemptions and expiries are negative and carry no `expires_at`.

## Three unwrapped write paths, one of them racing

| Path | Before | Now |
| --- | --- | --- |
| `addPoints()` | two `increment()`s and a `create()`, unwrapped | one transaction |
| `redeemPoints()` | check-then-act: both callers read the same balance, both pass, both decrement | reads under `lockForUpdate` inside a transaction |
| `LoyaltyReward::redeem()` | four writes across two tables, no transaction, no lock, and `redeemPoints()`'s boolean discarded | reward row locked for the whole redemption |

`redeem()` dropping that boolean is the sharper half: the balance was checked on the line above, so the only way the debit could return `false` was the race — which is to say the one case the check could not cover is the one case the return value would have reported.

Locking the **reward** row serialises callers competing for the same reward and leaves callers of other rewards alone, which is the narrowest lock that closes both the stock and the `max_redemptions` window.

## Tests

Three added. The race is not reproducible single-threaded — two callers reading `stock_quantity = 1` before either decrements needs two connections — so the reward tests pin the property the lock exists to keep: a failed redemption moves nothing, and the last unit is spent once. A future edit that pulls a write back out of the transaction fails there.

## Deliberately not fixed

Decisions rather than defects, all recorded in the wave 16 survey: `min_points_redemption` is enforced nowhere; `qualifiesForTier()` is an `||` over two columns that both default to zero, so a new tier qualifies everybody; a cancelled redemption gives back neither the points nor the stock.

Found while surveying the host for [#866](https://github.com/liberusoftware/ecommerce-laravel/issues/866).