### PR TITLE
Sync listed products into a per-team Meta Commerce Catalog

### DIFF
--- a/app/Console/Commands/ReconcileFacebookCatalog.php
+++ b/app/Console/Commands/ReconcileFacebookCatalog.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\FacebookConnection;
+use App\Models\ProductFacebookListing;
+use Illuminate\Console\Command;
+
+/**
+ * Re-reads Meta-owned Catalog status into local Listings, per connected Team,
+ * so the merchant sees rejections and stock drift Meta applied after upload.
+ */
+class ReconcileFacebookCatalog extends Command
+{
+    protected $signature = 'facebook:reconcile-catalog';
+
+    protected $description = 'Re-read Meta Catalog item status into local Listings (drift reconciliation).';
+
+    public function handle(): int
+    {
+        $updated = 0;
+
+        foreach (FacebookConnection::all() as $connection) {
+            $updated += $this->reconcile($connection);
+        }
+
+        $this->info("Reconciled {$updated} listing(s).");
+
+        return self::SUCCESS;
+    }
+
+    private function reconcile(FacebookConnection $connection): int
+    {
+        $listings = ProductFacebookListing::query()
+            ->where('status', '!=', 'deleted')
+            ->whereHas('product', fn ($query) => $query->where('team_id', $connection->team_id))
+            ->get();
+
+        if ($listings->isEmpty()) {
+            return 0;
+        }
+
+        $statuses = $connection->catalog()->readItemStatuses($listings->pluck('retailer_id')->all());
+        $updated = 0;
+
+        foreach ($listings as $listing) {
+            $item = $statuses[$listing->retailer_id] ?? null;
+
+            if ($item === null) {
+                continue;
+            }
+
+            $listing->update($this->mapStatus($item));
+            $updated++;
+        }
+
+        return $updated;
+    }
+
+    /** Translate Meta's review/availability into a local Listing status. */
+    private function mapStatus(array $item): array
+    {
+        $review = strtolower($item['review_status'] ?? '');
+        $availability = strtolower($item['availability'] ?? '');
+        $errors = $item['errors'] ?? null;
+
+        $status = match (true) {
+            in_array($review, ['rejected', 'disapproved'], true) => 'error',
+            $availability === 'out of stock' => 'out_of_stock',
+            in_array($review, ['approved', 'active'], true) => 'active',
+            default => 'pending',
+        };
+
+        return [
+            'status' => $status,
+            'errors' => $errors ?: null,
+            'catalog_item_id' => $item['id'] ?? null,
+            'last_synced_at' => now(),
+        ];
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -14,6 +14,10 @@ class Kernel extends ConsoleKernel
     {
         // Clear out expired shipping quotes daily so the table doesn't grow unbounded.
         $schedule->command('shipping:prune-quotes')->daily();
+
+        // Meta applies its own review after upload, so local status goes stale
+        // without a read-back.
+        $schedule->command('facebook:reconcile-catalog')->hourly();
     }
 
     /**

--- a/app/Filament/App/Resources/FacebookConnections/FacebookConnectionResource.php
+++ b/app/Filament/App/Resources/FacebookConnections/FacebookConnectionResource.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Filament\App\Resources\FacebookConnections;
+
+use App\Filament\App\Resources\FacebookConnections\Pages\CreateFacebookConnection;
+use App\Filament\App\Resources\FacebookConnections\Pages\EditFacebookConnection;
+use App\Filament\App\Resources\FacebookConnections\Pages\ListFacebookConnections;
+use App\Models\FacebookConnection;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class FacebookConnectionResource extends Resource
+{
+    protected static ?string $model = FacebookConnection::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-share';
+
+    protected static ?string $modelLabel = 'Facebook Catalog';
+
+    protected static ?string $pluralModelLabel = 'Facebook Catalog';
+
+    protected static ?int $navigationSort = 11;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Meta Commerce credentials')
+                    ->description('Listed products sync into this Catalog, which is what Page Shop, Instagram Shopping and Marketplace listings read. Marketplace itself has no public API.')
+                    ->schema([
+                        TextInput::make('access_token')
+                            ->label('System User access token')
+                            ->password()
+                            ->revealable()
+                            ->required()
+                            ->helperText('Stored encrypted at rest.')
+                            ->maxLength(1024),
+                        TextInput::make('catalog_id')
+                            ->label('Catalog ID')
+                            ->required()
+                            ->maxLength(255),
+                        TextInput::make('business_id')
+                            ->label('Business ID')
+                            ->maxLength(255),
+                        Select::make('graph_version')
+                            ->label('Graph API version')
+                            ->options([
+                                'v21.0' => 'v21.0',
+                                'v20.0' => 'v20.0',
+                                'v19.0' => 'v19.0',
+                            ])
+                            ->default('v21.0')
+                            ->required(),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('catalog_id')->label('Catalog ID'),
+                TextColumn::make('business_id')->label('Business ID'),
+                TextColumn::make('graph_version')->label('Graph version'),
+                TextColumn::make('updated_at')->label('Updated')->dateTime(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ]);
+    }
+
+    /** One Catalog per Team — the unique index would refuse a second anyway. */
+    public static function canCreate(): bool
+    {
+        return parent::canCreate() && ! static::getEloquentQuery()->exists();
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListFacebookConnections::route('/'),
+            'create' => CreateFacebookConnection::route('/create'),
+            'edit' => EditFacebookConnection::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/FacebookConnections/Pages/CreateFacebookConnection.php
+++ b/app/Filament/App/Resources/FacebookConnections/Pages/CreateFacebookConnection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\App\Resources\FacebookConnections\Pages;
+
+use App\Filament\App\Resources\FacebookConnections\FacebookConnectionResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateFacebookConnection extends CreateRecord
+{
+    protected static string $resource = FacebookConnectionResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/App/Resources/FacebookConnections/Pages/EditFacebookConnection.php
+++ b/app/Filament/App/Resources/FacebookConnections/Pages/EditFacebookConnection.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Filament\App\Resources\FacebookConnections\Pages;
+
+use App\Filament\App\Resources\FacebookConnections\FacebookConnectionResource;
+use App\Services\Facebook\FacebookCatalog;
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\EditRecord;
+
+class EditFacebookConnection extends EditRecord
+{
+    protected static string $resource = FacebookConnectionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('testConnection')
+                ->label('Test connection')
+                ->icon('heroicon-o-signal')
+                // Tests what is on screen, not what is saved, so a merchant can
+                // check a pasted token before committing it.
+                ->action(function (): void {
+                    $data = $this->form->getState();
+
+                    $result = (new FacebookCatalog(
+                        (string) ($data['access_token'] ?? ''),
+                        (string) ($data['catalog_id'] ?? ''),
+                        (string) ($data['business_id'] ?? ''),
+                        (string) ($data['graph_version'] ?? 'v21.0'),
+                    ))->testConnection();
+
+                    Notification::make()
+                        ->title($result['message'])
+                        ->{$result['success'] ? 'success' : 'danger'}()
+                        ->send();
+                }),
+            DeleteAction::make()
+                ->label('Disconnect')
+                ->modalDescription('Products stay listed in Meta until you unlist them; this only removes the credentials.'),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/FacebookConnections/Pages/ListFacebookConnections.php
+++ b/app/Filament/App/Resources/FacebookConnections/Pages/ListFacebookConnections.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\App\Resources\FacebookConnections\Pages;
+
+use App\Filament\App\Resources\FacebookConnections\FacebookConnectionResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListFacebookConnections extends ListRecords
+{
+    protected static string $resource = FacebookConnectionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/Products/ProductResource.php
+++ b/app/Filament/App/Resources/Products/ProductResource.php
@@ -5,10 +5,12 @@ namespace App\Filament\App\Resources\Products;
 use App\Filament\App\Resources\Products\Pages\CreateProduct;
 use App\Filament\App\Resources\Products\Pages\EditProduct;
 use App\Filament\App\Resources\Products\Pages\ListProducts;
+use App\Models\FacebookConnection;
 use App\Models\Product;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Repeater;
@@ -84,6 +86,11 @@ class ProductResource extends Resource
                     ->directory('products')
                     ->visibility('public')
                     ->label('Featured Image'),
+
+                Toggle::make('list_on_facebook')
+                    ->label('List on Facebook')
+                    ->helperText('Pushes this product into your Meta Catalog. Needs a Facebook Catalog connection.')
+                    ->visible(fn () => FacebookConnection::forTeam(Filament::getTenant()?->id) !== null),
 
                 Repeater::make('images')
                     ->relationship('images')

--- a/app/Jobs/RemoveProductFromFacebookCatalog.php
+++ b/app/Jobs/RemoveProductFromFacebookCatalog.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\FacebookConnection;
+use App\Models\ProductFacebookListing;
+use App\Services\Facebook\CatalogItemMapper;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use RuntimeException;
+
+/**
+ * Removes Catalog items when a Product is unlisted or deleted — a real DELETE,
+ * unlike the sold-out path, which keeps the item and flips availability. Takes
+ * retailer ids and a team so it still works after the Product row is gone.
+ */
+class RemoveProductFromFacebookCatalog implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    /** @param  array<int, string>  $retailerIds */
+    public function __construct(public array $retailerIds, public int $teamId) {}
+
+    public function backoff(): array
+    {
+        return [10, 30, 60];
+    }
+
+    public function handle(): void
+    {
+        if ($this->retailerIds === []) {
+            return;
+        }
+
+        $connection = FacebookConnection::forTeam($this->teamId);
+
+        if ($connection === null) {
+            return;
+        }
+
+        $requests = array_map(
+            fn (string $retailerId) => CatalogItemMapper::deleteRequest($retailerId),
+            $this->retailerIds,
+        );
+
+        $result = $connection->catalog()->itemsBatch($requests);
+
+        // retailer_id is unique across the table, so the ids alone are the scope.
+        $listings = ProductFacebookListing::query()
+            ->whereIn('retailer_id', $this->retailerIds)
+            ->get();
+
+        if (! $result['ok']) {
+            $message = $result['body']['error']['message'] ?? ('HTTP '.$result['status']);
+
+            foreach ($listings as $listing) {
+                $listing->update(['status' => 'error', 'errors' => ['message' => $message]]);
+            }
+
+            throw new RuntimeException('items_batch delete failed: '.$message);
+        }
+
+        foreach ($listings as $listing) {
+            $listing->update([
+                'status' => 'deleted',
+                'errors' => null,
+                'last_synced_at' => now(),
+            ]);
+        }
+    }
+}

--- a/app/Jobs/SyncProductToFacebookCatalog.php
+++ b/app/Jobs/SyncProductToFacebookCatalog.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\FacebookConnection;
+use App\Models\Product;
+use App\Models\ProductFacebookListing;
+use App\Services\Facebook\CatalogItemMapper;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use RuntimeException;
+
+/**
+ * Upserts a listed Product into its Team's Meta Catalog. Idempotent — keyed by
+ * a stable retailer id, so a re-run updates rather than duplicates. Transient
+ * failures throw so the queue retries with backoff.
+ */
+class SyncProductToFacebookCatalog implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function __construct(public int $productId) {}
+
+    public function backoff(): array
+    {
+        return [10, 30, 60];
+    }
+
+    public function handle(): void
+    {
+        $product = Product::find($this->productId);
+
+        if (! $product || ! $product->list_on_facebook) {
+            return;
+        }
+
+        $connection = FacebookConnection::forTeam($product->team_id);
+
+        if ($connection === null) {
+            return;
+        }
+
+        [$requests, $listings] = $product->hasVariants()
+            ? $this->variantRequests($product)
+            : $this->simpleRequest($product);
+
+        $result = $connection->catalog()->itemsBatch($requests);
+
+        if (! $result['ok']) {
+            $message = $result['body']['error']['message'] ?? ('HTTP '.$result['status']);
+
+            foreach ($listings as $listing) {
+                $listing->update(['status' => 'error', 'errors' => ['message' => $message]]);
+            }
+
+            throw new RuntimeException('items_batch failed: '.$message);
+        }
+
+        foreach ($listings as $retailerId => $listing) {
+            $errors = $this->validationErrors($retailerId, $result['body']);
+
+            $listing->update([
+                'status' => $errors ? 'error' : 'active',
+                'errors' => $errors ?: null,
+                'last_synced_at' => now(),
+            ]);
+        }
+    }
+
+    /** @return array{0: array<int, array>, 1: array<string, ProductFacebookListing>} */
+    private function simpleRequest(Product $product): array
+    {
+        $listing = $product->facebookListings()->firstOrCreate(
+            ['product_variant_id' => null],
+            [
+                'retailer_id' => CatalogItemMapper::retailerIdForProduct($product),
+                'status' => 'pending',
+            ],
+        );
+
+        return [
+            [CatalogItemMapper::forProduct($product, $listing->retailer_id)],
+            [$listing->retailer_id => $listing],
+        ];
+    }
+
+    /** @return array{0: array<int, array>, 1: array<string, ProductFacebookListing>} */
+    private function variantRequests(Product $product): array
+    {
+        $groupId = CatalogItemMapper::itemGroupId($product);
+        $requests = [];
+        $listings = [];
+
+        foreach ($product->variants as $variant) {
+            $listing = $product->facebookListings()->firstOrCreate(
+                ['product_variant_id' => $variant->id],
+                [
+                    'retailer_id' => CatalogItemMapper::retailerIdForVariant($variant),
+                    'status' => 'pending',
+                ],
+            );
+
+            $requests[] = CatalogItemMapper::forVariant($product, $variant, $listing->retailer_id, $groupId);
+            $listings[$listing->retailer_id] = $listing;
+        }
+
+        return [$requests, $listings];
+    }
+
+    /** Per-item validation errors Meta returns inline for our retailer id. */
+    private function validationErrors(string $retailerId, array $body): array
+    {
+        return collect($body['validation_status'] ?? [])
+            ->firstWhere('retailer_id', $retailerId)['errors'] ?? [];
+    }
+}

--- a/app/Models/FacebookConnection.php
+++ b/app/Models/FacebookConnection.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use App\Services\Facebook\FacebookCatalog;
+use App\Traits\IsTenantModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * One Team's Meta Commerce Catalog credentials.
+ *
+ * Per Team rather than per installation: a merchant connects their own Meta
+ * Business, and the platform never holds one catalogue everybody publishes into.
+ * The unique index on `team_id` is what makes "the connection" a fair phrase.
+ */
+class FacebookConnection extends Model
+{
+    use HasFactory;
+    use IsTenantModel;
+
+    protected $fillable = [
+        'access_token',
+        'catalog_id',
+        'business_id',
+        'graph_version',
+    ];
+
+    protected $casts = [
+        'access_token' => 'encrypted',
+    ];
+
+    public static function forTeam(?int $teamId): ?self
+    {
+        return $teamId === null
+            ? null
+            : static::query()->where('team_id', $teamId)->first();
+    }
+
+    public function catalog(): FacebookCatalog
+    {
+        return new FacebookCatalog(
+            (string) $this->access_token,
+            (string) $this->catalog_id,
+            (string) ($this->business_id ?? ''),
+            (string) ($this->graph_version ?: 'v21.0'),
+        );
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use App\Interfaces\Orderable;
+use App\Jobs\RemoveProductFromFacebookCatalog;
+use App\Jobs\SyncProductToFacebookCatalog;
 use App\Notifications\ProductBackInStockNotification;
 use App\Services\TaxCalculator;
 use App\Traits\IsStoreScoped;
@@ -49,6 +51,7 @@ class Product extends Model implements Orderable
         'suggested_price',
         'minimum_price',
         'is_featured',
+        'list_on_facebook',
 
         // Fillable so the API write paths can stamp the creating admin's team.
         // No validator accepts it from request input, so it cannot be set by a
@@ -58,6 +61,7 @@ class Product extends Model implements Orderable
 
     protected $casts = [
         'is_downloadable' => 'boolean',
+        'list_on_facebook' => 'boolean',
         'price' => 'decimal:2',
         'weight' => 'decimal:2',
         'suggested_price' => 'decimal:2',
@@ -231,6 +235,35 @@ class Product extends Model implements Orderable
                 $product->notifyBackInStockSubscribers();
             }
         });
+
+        static::saved(function ($product) {
+            if ($product->list_on_facebook) {
+                SyncProductToFacebookCatalog::dispatch($product->id);
+            } elseif ($product->wasChanged('list_on_facebook')) {
+                $product->dispatchFacebookUnlist();
+            }
+        });
+
+        // `deleting`, not `deleted`: the retailer ids have to be read before a
+        // force delete cascades the listing rows away.
+        static::deleting(function ($product) {
+            $product->dispatchFacebookUnlist();
+        });
+    }
+
+    public function facebookListings(): HasMany
+    {
+        return $this->hasMany(ProductFacebookListing::class);
+    }
+
+    /** Queue removal of whatever this Product currently occupies in the Catalog. */
+    public function dispatchFacebookUnlist(): void
+    {
+        $retailerIds = $this->facebookListings()->pluck('retailer_id')->all();
+
+        if ($retailerIds !== [] && $this->team_id !== null) {
+            RemoveProductFromFacebookCatalog::dispatch($retailerIds, (int) $this->team_id);
+        }
     }
 
     /**
@@ -396,7 +429,7 @@ class Product extends Model implements Orderable
      */
     public function adjustInventory(int $delta, string $reason): bool
     {
-        return (bool) DB::transaction(function () use ($delta, $reason) {
+        $adjusted = (bool) DB::transaction(function () use ($delta, $reason) {
             if ($delta < 0) {
                 $affected = static::whereKey($this->getKey())
                     ->where('inventory_count', '>=', abs($delta))
@@ -421,5 +454,14 @@ class Product extends Model implements Orderable
 
             return true;
         });
+
+        // increment()/decrement() bypass `saved`, so the Catalog push that a
+        // plain save() would have queued has to be queued here. Selling out is
+        // an availability flip, never an unlist.
+        if ($adjusted && $this->list_on_facebook) {
+            SyncProductToFacebookCatalog::dispatch($this->id);
+        }
+
+        return $adjusted;
     }
 }

--- a/app/Models/ProductFacebookListing.php
+++ b/app/Models/ProductFacebookListing.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * The sync state of one Product (or one Variant) inside a Team's Meta Catalog.
+ * `status` and `errors` mirror what Meta owns; the application owns the content.
+ *
+ * No `team_id`: the owner is the Product's, the way ProductVariant's is.
+ */
+class ProductFacebookListing extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'product_id',
+        'product_variant_id',
+        'retailer_id',
+        'catalog_item_id',
+        'status',
+        'errors',
+        'last_synced_at',
+    ];
+
+    protected $casts = [
+        'errors' => 'array',
+        'last_synced_at' => 'datetime',
+    ];
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function variant(): BelongsTo
+    {
+        return $this->belongsTo(ProductVariant::class, 'product_variant_id');
+    }
+}

--- a/app/Models/ProductVariant.php
+++ b/app/Models/ProductVariant.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Jobs\SyncProductToFacebookCatalog;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -47,6 +48,19 @@ class ProductVariant extends Model
         'requires_shipping' => 'boolean',
         'position' => 'integer',
     ];
+
+    protected static function booted(): void
+    {
+        // A price or stock edit re-pushes the parent Product's variant items.
+        // Query-level decrements bypass this, same as the Product path.
+        static::saved(function (ProductVariant $variant) {
+            $product = $variant->product;
+
+            if ($product && $product->list_on_facebook) {
+                SyncProductToFacebookCatalog::dispatch($product->id);
+            }
+        });
+    }
 
     public function product(): BelongsTo
     {

--- a/app/Policies/FacebookConnectionPolicy.php
+++ b/app/Policies/FacebookConnectionPolicy.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\FacebookConnection;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+/**
+ * The App panel runs strictAuthorization, so this has to exist for the resource
+ * to be reachable at all. Permission names follow the seeded Shield convention:
+ * FacebookConnection => facebook::connection.
+ */
+class FacebookConnectionPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view_any_facebook::connection');
+    }
+
+    public function view(User $user, FacebookConnection $connection): bool
+    {
+        return $user->can('view_facebook::connection');
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('create_facebook::connection');
+    }
+
+    public function update(User $user, FacebookConnection $connection): bool
+    {
+        return $user->can('update_facebook::connection');
+    }
+
+    public function delete(User $user, FacebookConnection $connection): bool
+    {
+        return $user->can('delete_facebook::connection');
+    }
+
+    public function deleteAny(User $user): bool
+    {
+        return $user->can('delete_any_facebook::connection');
+    }
+}

--- a/app/Services/Facebook/CatalogItemMapper.php
+++ b/app/Services/Facebook/CatalogItemMapper.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Services\Facebook;
+
+use App\Models\Product;
+use App\Models\ProductVariant;
+
+/**
+ * Maps a Product (or its Variants) into Meta Catalog items_batch requests.
+ * Field mapping lives here so the jobs stay thin.
+ */
+class CatalogItemMapper
+{
+    public static function retailerIdForProduct(Product $product): string
+    {
+        return 'product-'.$product->id;
+    }
+
+    public static function retailerIdForVariant(ProductVariant $variant): string
+    {
+        return 'variant-'.$variant->id;
+    }
+
+    /** The Meta grouping that ties a Product's variant items together. */
+    public static function itemGroupId(Product $product): string
+    {
+        return 'product-'.$product->id;
+    }
+
+    /** An idempotent upsert keyed by the stable retailer id. */
+    public static function forProduct(Product $product, string $retailerId): array
+    {
+        return [
+            'method' => 'UPDATE',
+            'data' => [
+                'id' => $retailerId,
+                'title' => $product->name,
+                'description' => self::description($product),
+                'availability' => $product->inventory_count > 0 ? 'in stock' : 'out of stock',
+                'condition' => 'new',
+                'price' => self::money($product->price),
+                'link' => self::link($product),
+                'image_link' => self::image($product),
+                'brand' => config('app.name'),
+            ],
+        ];
+    }
+
+    /**
+     * One item per Variant sharing an item_group_id, so Meta shows them as one
+     * product with selectable variations. Price and stock come from the Variant.
+     */
+    public static function forVariant(Product $product, ProductVariant $variant, string $retailerId, string $itemGroupId): array
+    {
+        return [
+            'method' => 'UPDATE',
+            'data' => [
+                'id' => $retailerId,
+                'item_group_id' => $itemGroupId,
+                'title' => trim($product->name.' - '.($variant->title ?? '')),
+                'description' => self::description($product),
+                'availability' => $variant->inventory_quantity > 0 ? 'in stock' : 'out of stock',
+                'condition' => 'new',
+                'price' => self::money($variant->price ?? $product->price),
+                'link' => self::link($product),
+                'image_link' => self::image($product),
+                'brand' => config('app.name'),
+            ],
+        ];
+    }
+
+    /** A real unlist — the Catalog item goes away, unlike a sold-out flip. */
+    public static function deleteRequest(string $retailerId): array
+    {
+        return [
+            'method' => 'DELETE',
+            'data' => ['id' => $retailerId],
+        ];
+    }
+
+    private static function description(Product $product): string
+    {
+        $text = $product->description
+            ?? $product->short_description
+            ?? $product->long_description
+            ?? $product->name;
+
+        return trim(strip_tags((string) $text)) ?: $product->name;
+    }
+
+    /**
+     * The merchant's own storefront hostname, not APP_URL — a queued job has no
+     * request to resolve a channel from, so the Store answers instead.
+     */
+    private static function link(Product $product): string
+    {
+        $host = $product->store?->channels()->first()?->primaryDomain()?->host;
+
+        return $host
+            ? 'https://'.$host.'/products/'.$product->slug
+            : url('/products/'.$product->slug);
+    }
+
+    private static function image(Product $product): ?string
+    {
+        $image = $product->featured_image;
+
+        if (blank($image)) {
+            return null;
+        }
+
+        return str_starts_with($image, 'http') ? $image : url($image);
+    }
+
+    private static function money(int|float|string $price): string
+    {
+        return number_format((float) $price, 2, '.', '').' '.config('ecommerce.default_currency', 'USD');
+    }
+}

--- a/app/Services/Facebook/FacebookCatalog.php
+++ b/app/Services/Facebook/FacebookCatalog.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Services\Facebook;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * The one HTTP client for the Meta Commerce Catalog. We address the Catalog,
+ * never Marketplace itself, which has no public API.
+ */
+class FacebookCatalog
+{
+    public function __construct(
+        protected string $accessToken,
+        protected string $catalogId,
+        protected string $businessId = '',
+        protected string $graphVersion = 'v21.0',
+    ) {}
+
+    /** Verify credentials by reading the Catalog node. Never throws. */
+    public function testConnection(): array
+    {
+        if (blank($this->accessToken) || blank($this->catalogId)) {
+            return ['success' => false, 'message' => 'Set an access token and Catalog ID before testing.'];
+        }
+
+        try {
+            $response = $this->graph()->get('/'.$this->catalogId, ['fields' => 'id,name']);
+        } catch (Throwable $e) {
+            return ['success' => false, 'message' => 'Could not reach Meta: '.$e->getMessage()];
+        }
+
+        if ($response->successful()) {
+            $name = $response->json('name', $this->catalogId);
+
+            return ['success' => true, 'message' => "Connected to Catalog: {$name}"];
+        }
+
+        $error = $response->json('error.message', $response->body());
+
+        return ['success' => false, 'message' => "Meta rejected the request: {$error}"];
+    }
+
+    /**
+     * Upsert/delete Catalog items in one call. Each request is
+     * ['method' => 'UPDATE'|'DELETE', 'data' => ['id' => retailerId, ...]].
+     *
+     * @return array{ok: bool, status: int, body: array}
+     */
+    public function itemsBatch(array $requests): array
+    {
+        $response = $this->graph()->post('/'.$this->catalogId.'/items_batch', [
+            'item_type' => 'PRODUCT_ITEM',
+            'allow_upsert' => true,
+            'requests' => $requests,
+        ]);
+
+        return [
+            'ok' => $response->successful(),
+            'status' => $response->status(),
+            'body' => $response->json() ?? [],
+        ];
+    }
+
+    /**
+     * Meta-owned item status keyed by retailer id. Read-back only — the
+     * application stays source of truth for content.
+     *
+     * @param  array<int, string>  $retailerIds
+     * @return array<string, array>
+     */
+    public function readItemStatuses(array $retailerIds): array
+    {
+        if ($retailerIds === []) {
+            return [];
+        }
+
+        try {
+            // ponytail: one page of 1000. Follow `paging.next` if a real
+            // catalogue outgrows it.
+            $response = $this->graph()->get('/'.$this->catalogId.'/products', [
+                'fields' => 'id,retailer_id,review_status,errors,availability',
+                'limit' => 1000,
+            ]);
+        } catch (Throwable $e) {
+            return [];
+        }
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        if ($response->json('paging.next')) {
+            Log::warning('FacebookCatalog: catalog exceeds one page; reconciliation covered only the first 1000 items.');
+        }
+
+        $wanted = array_flip($retailerIds);
+        $map = [];
+
+        foreach ($response->json('data', []) as $item) {
+            $retailerId = $item['retailer_id'] ?? null;
+
+            if ($retailerId !== null && isset($wanted[$retailerId])) {
+                $map[$retailerId] = $item;
+            }
+        }
+
+        return $map;
+    }
+
+    /** A Graph request pinned to the configured version and bearer token. */
+    protected function graph(): PendingRequest
+    {
+        return Http::baseUrl('https://graph.facebook.com/'.$this->graphVersion)
+            ->withToken($this->accessToken)
+            ->acceptJson();
+    }
+}

--- a/database/migrations/2026_08_17_000000_create_facebook_connections_table.php
+++ b/database/migrations/2026_08_17_000000_create_facebook_connections_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\Team;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('facebook_connections', function (Blueprint $table) {
+            $table->id();
+            // Unique: one Meta Catalog per merchant, never a shared one.
+            $table->foreignIdFor(Team::class)->unique()->constrained()->cascadeOnDelete();
+            $table->text('access_token');            // encrypted by the model cast
+            $table->string('catalog_id');
+            $table->string('business_id')->nullable();
+            $table->string('graph_version')->default('v21.0');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('facebook_connections');
+    }
+};

--- a/database/migrations/2026_08_17_000001_create_product_facebook_listings_table.php
+++ b/database/migrations/2026_08_17_000001_create_product_facebook_listings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\Product;
+use App\Models\ProductVariant;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_facebook_listings', function (Blueprint $table) {
+            $table->id();
+            // No team_id: the Product's tenancy owns this row, the way
+            // ProductVariant's does.
+            $table->foreignIdFor(Product::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(ProductVariant::class)->nullable()->constrained()->cascadeOnDelete();
+            $table->string('retailer_id')->unique();       // app-side key sent to Meta as data.id
+            $table->string('catalog_item_id')->nullable(); // Meta-generated, filled on reconcile
+            $table->string('status')->default('pending');  // pending|active|error|out_of_stock|deleted
+            $table->json('errors')->nullable();
+            $table->timestamp('last_synced_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_facebook_listings');
+    }
+};

--- a/database/migrations/2026_08_17_000002_add_list_on_facebook_to_products_table.php
+++ b/database/migrations/2026_08_17_000002_add_list_on_facebook_to_products_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->boolean('list_on_facebook')->default(false)->after('is_featured');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('list_on_facebook');
+        });
+    }
+};

--- a/database/seeders/PermissionsTableSeeder.php
+++ b/database/seeders/PermissionsTableSeeder.php
@@ -1388,6 +1388,50 @@ class PermissionsTableSeeder extends Seeder
                 'created_at' => '2024-09-04 14:20:26',
                 'updated_at' => '2024-09-04 14:20:26',
             ],
+            // FacebookConnection has no soft deletes, so no restore/force-delete
+            // pair, and it is never reordered or replicated.
+            195 => [
+                'id' => 196,
+                'name' => 'view_facebook::connection',
+                'guard_name' => 'web',
+                'created_at' => '2026-08-17 00:00:00',
+                'updated_at' => '2026-08-17 00:00:00',
+            ],
+            196 => [
+                'id' => 197,
+                'name' => 'view_any_facebook::connection',
+                'guard_name' => 'web',
+                'created_at' => '2026-08-17 00:00:00',
+                'updated_at' => '2026-08-17 00:00:00',
+            ],
+            197 => [
+                'id' => 198,
+                'name' => 'create_facebook::connection',
+                'guard_name' => 'web',
+                'created_at' => '2026-08-17 00:00:00',
+                'updated_at' => '2026-08-17 00:00:00',
+            ],
+            198 => [
+                'id' => 199,
+                'name' => 'update_facebook::connection',
+                'guard_name' => 'web',
+                'created_at' => '2026-08-17 00:00:00',
+                'updated_at' => '2026-08-17 00:00:00',
+            ],
+            199 => [
+                'id' => 200,
+                'name' => 'delete_facebook::connection',
+                'guard_name' => 'web',
+                'created_at' => '2026-08-17 00:00:00',
+                'updated_at' => '2026-08-17 00:00:00',
+            ],
+            200 => [
+                'id' => 201,
+                'name' => 'delete_any_facebook::connection',
+                'guard_name' => 'web',
+                'created_at' => '2026-08-17 00:00:00',
+                'updated_at' => '2026-08-17 00:00:00',
+            ],
         ]);
 
         app()[PermissionRegistrar::class]->forgetCachedPermissions();

--- a/tests/Feature/Concerns/ConnectsAFacebookCatalog.php
+++ b/tests/Feature/Concerns/ConnectsAFacebookCatalog.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Concerns;
+
+use App\Models\FacebookConnection;
+use App\Models\Product;
+use App\Models\Team;
+
+/**
+ * A connected merchant. The connection is per Team, so every fixture here has
+ * to say which Team it belongs to — that is the whole difference from the
+ * single-tenant original.
+ */
+trait ConnectsAFacebookCatalog
+{
+    protected Team $team;
+
+    protected function connectTeam(string $catalogId = 'CAT123'): FacebookConnection
+    {
+        $team = Team::factory()->create();
+
+        return FacebookConnection::forceCreate([
+            'team_id' => $team->id,
+            'access_token' => 'test-token',
+            'catalog_id' => $catalogId,
+            'business_id' => 'BIZ1',
+            'graph_version' => 'v21.0',
+        ]);
+    }
+
+    protected function connectedTeam(): Team
+    {
+        return $this->team = $this->connectTeam()->team;
+    }
+
+    /** A Product owned by the Team currently under test. */
+    protected function product(array $overrides = []): Product
+    {
+        return Product::factory()->create(array_merge([
+            'team_id' => $this->team->id,
+            'inventory_count' => 5,
+            'list_on_facebook' => false,
+        ], $overrides));
+    }
+}

--- a/tests/Feature/FacebookCatalogReconcileTest.php
+++ b/tests/Feature/FacebookCatalogReconcileTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\SyncProductToFacebookCatalog;
+use App\Models\ProductFacebookListing;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Concerns\ConnectsAFacebookCatalog;
+use Tests\TestCase;
+
+class FacebookCatalogReconcileTest extends TestCase
+{
+    use ConnectsAFacebookCatalog;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connectedTeam();
+    }
+
+    private function listing(string $status = 'active'): ProductFacebookListing
+    {
+        $product = $this->product();
+
+        return $product->facebookListings()->create([
+            'retailer_id' => 'product-'.$product->id,
+            'status' => $status,
+        ]);
+    }
+
+    private function fakeProducts(array $items): void
+    {
+        Http::fake(['graph.facebook.com/*' => Http::response(['data' => $items], 200)]);
+    }
+
+    public function test_reconcile_marks_rejection_from_meta(): void
+    {
+        $listing = $this->listing('active');
+        $this->fakeProducts([[
+            'id' => '99887766',
+            'retailer_id' => $listing->retailer_id,
+            'review_status' => 'rejected',
+            'errors' => [['message' => 'Image missing']],
+        ]]);
+
+        $this->artisan('facebook:reconcile-catalog')->assertSuccessful();
+
+        $listing->refresh();
+        $this->assertSame('error', $listing->status);
+        $this->assertSame('99887766', $listing->catalog_item_id);
+        $this->assertNotNull($listing->errors);
+    }
+
+    public function test_reconcile_marks_out_of_stock_drift(): void
+    {
+        $listing = $this->listing('active');
+        $this->fakeProducts([[
+            'id' => '1',
+            'retailer_id' => $listing->retailer_id,
+            'review_status' => 'approved',
+            'availability' => 'out of stock',
+        ]]);
+
+        $this->artisan('facebook:reconcile-catalog')->assertSuccessful();
+
+        $this->assertSame('out_of_stock', $listing->refresh()->status);
+    }
+
+    public function test_reconcile_marks_approved_active(): void
+    {
+        $listing = $this->listing('pending');
+        $this->fakeProducts([[
+            'id' => '1',
+            'retailer_id' => $listing->retailer_id,
+            'review_status' => 'approved',
+            'availability' => 'in stock',
+        ]]);
+
+        $this->artisan('facebook:reconcile-catalog')->assertSuccessful();
+
+        $this->assertSame('active', $listing->refresh()->status);
+    }
+
+    public function test_reconcile_ignores_deleted_listings(): void
+    {
+        $listing = $this->listing('deleted');
+        $this->fakeProducts([[
+            'id' => '1',
+            'retailer_id' => $listing->retailer_id,
+            'review_status' => 'approved',
+        ]]);
+
+        $this->artisan('facebook:reconcile-catalog')->assertSuccessful();
+
+        $this->assertSame('deleted', $listing->refresh()->status);
+    }
+
+    public function test_reconcile_reads_each_teams_own_catalog(): void
+    {
+        $mine = $this->listing('pending');
+
+        $other = $this->connectTeam('CAT-OTHER');
+        $this->team = $other->team;
+        $theirs = $this->listing('pending');
+
+        Http::fake([
+            'graph.facebook.com/*/CAT123/products*' => Http::response(['data' => [
+                ['id' => 'A', 'retailer_id' => $mine->retailer_id, 'review_status' => 'approved'],
+            ]], 200),
+            'graph.facebook.com/*/CAT-OTHER/products*' => Http::response(['data' => [
+                ['id' => 'B', 'retailer_id' => $theirs->retailer_id, 'review_status' => 'rejected'],
+            ]], 200),
+        ]);
+
+        $this->artisan('facebook:reconcile-catalog')->assertSuccessful();
+
+        $this->assertSame('active', $mine->refresh()->status);
+        $this->assertSame('error', $theirs->refresh()->status);
+    }
+
+    public function test_repush_clears_errors_on_success(): void
+    {
+        $product = $this->product(['inventory_count' => 3]);
+        $listing = $product->facebookListings()->create([
+            'retailer_id' => 'product-'.$product->id,
+            'status' => 'error',
+            'errors' => ['message' => 'Image missing'],
+        ]);
+        $product->list_on_facebook = true;
+        $product->saveQuietly();
+
+        Http::fake(['graph.facebook.com/*' => Http::response(['handles' => ['h']], 200)]);
+
+        (new SyncProductToFacebookCatalog($product->id))->handle();
+
+        $listing->refresh();
+        $this->assertSame('active', $listing->status);
+        $this->assertNull($listing->errors);
+    }
+}

--- a/tests/Feature/FacebookCatalogSyncTest.php
+++ b/tests/Feature/FacebookCatalogSyncTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\SyncProductToFacebookCatalog;
+use App\Models\Product;
+use App\Models\ProductFacebookListing;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use RuntimeException;
+use Tests\Feature\Concerns\ConnectsAFacebookCatalog;
+use Tests\TestCase;
+
+class FacebookCatalogSyncTest extends TestCase
+{
+    use ConnectsAFacebookCatalog;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connectedTeam();
+    }
+
+    private function listedProduct(array $overrides = []): Product
+    {
+        return $this->product(array_merge(['list_on_facebook' => true], $overrides));
+    }
+
+    private function runSync(Product $product): void
+    {
+        (new SyncProductToFacebookCatalog($product->id))->handle();
+    }
+
+    public function test_saving_a_listed_product_enqueues_the_sync_job(): void
+    {
+        Queue::fake();
+
+        $product = $this->listedProduct();
+
+        Queue::assertPushed(
+            SyncProductToFacebookCatalog::class,
+            fn (SyncProductToFacebookCatalog $job) => $job->productId === $product->id
+        );
+    }
+
+    public function test_saving_an_unlisted_product_does_not_enqueue(): void
+    {
+        Queue::fake();
+
+        $this->product();
+
+        Queue::assertNotPushed(SyncProductToFacebookCatalog::class);
+    }
+
+    public function test_job_upserts_product_via_items_batch_and_marks_listing_active(): void
+    {
+        Http::fake(['graph.facebook.com/*' => Http::response(['handles' => ['h1']], 200)]);
+        Queue::fake();
+
+        $product = $this->listedProduct(['name' => 'Blue Widget']);
+
+        $this->runSync($product);
+
+        Http::assertSent(function ($request) use ($product) {
+            $body = $request->data();
+
+            return str_contains($request->url(), '/CAT123/items_batch')
+                && $body['item_type'] === 'PRODUCT_ITEM'
+                && $body['allow_upsert'] === true
+                && $body['requests'][0]['method'] === 'UPDATE'
+                && $body['requests'][0]['data']['id'] === 'product-'.$product->id
+                && $body['requests'][0]['data']['title'] === 'Blue Widget'
+                && $body['requests'][0]['data']['availability'] === 'in stock';
+        });
+
+        $listing = ProductFacebookListing::where('product_id', $product->id)->sole();
+        $this->assertNull($listing->product_variant_id);
+        $this->assertSame('active', $listing->status);
+        $this->assertNotNull($listing->last_synced_at);
+    }
+
+    public function test_resaving_updates_the_same_listing_not_a_duplicate(): void
+    {
+        Http::fake(['graph.facebook.com/*' => Http::response(['handles' => ['h1']], 200)]);
+        Queue::fake();
+
+        $product = $this->listedProduct();
+
+        $this->runSync($product);
+        $this->runSync($product);
+
+        $this->assertSame(1, ProductFacebookListing::where('product_id', $product->id)->count());
+    }
+
+    public function test_transient_failure_records_error_and_throws_for_retry(): void
+    {
+        Http::fake(['graph.facebook.com/*' => Http::response('upstream boom', 500)]);
+        Queue::fake();
+
+        $product = $this->listedProduct();
+
+        try {
+            $this->runSync($product);
+            $this->fail('Expected the job to throw so the queue retries.');
+        } catch (RuntimeException $e) {
+            // expected
+        }
+
+        $listing = ProductFacebookListing::where('product_id', $product->id)->sole();
+        $this->assertSame('error', $listing->status);
+        $this->assertNotNull($listing->errors);
+    }
+
+    public function test_out_of_stock_product_maps_to_out_of_stock_availability(): void
+    {
+        Http::fake(['graph.facebook.com/*' => Http::response(['handles' => ['h1']], 200)]);
+        Queue::fake();
+
+        $product = $this->listedProduct(['inventory_count' => 0]);
+
+        $this->runSync($product);
+
+        Http::assertSent(fn ($request) => $request->data()['requests'][0]['data']['availability'] === 'out of stock');
+    }
+
+    public function test_price_is_sent_in_the_configured_currency(): void
+    {
+        config(['ecommerce.default_currency' => 'GBP']);
+        Http::fake(['graph.facebook.com/*' => Http::response(['handles' => ['h1']], 200)]);
+        Queue::fake();
+
+        $product = $this->listedProduct(['price' => 12.5]);
+
+        $this->runSync($product);
+
+        Http::assertSent(fn ($request) => $request->data()['requests'][0]['data']['price'] === '12.50 GBP');
+    }
+}

--- a/tests/Feature/FacebookCatalogTenancyTest.php
+++ b/tests/Feature/FacebookCatalogTenancyTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\SyncProductToFacebookCatalog;
+use App\Models\Product;
+use App\Models\ProductFacebookListing;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Tests\Feature\Concerns\ConnectsAFacebookCatalog;
+use Tests\TestCase;
+
+/**
+ * The connection is per Team. A product reaches its own merchant's Catalog or
+ * none — never the platform's, and never another merchant's.
+ */
+class FacebookCatalogTenancyTest extends TestCase
+{
+    use ConnectsAFacebookCatalog;
+    use RefreshDatabase;
+
+    public function test_a_team_without_a_connection_syncs_nothing(): void
+    {
+        Http::fake();
+        Queue::fake();
+
+        // Another merchant is connected; this product's team is not.
+        $this->connectTeam('SOMEONE-ELSE');
+        $this->team = Team::factory()->create();
+
+        $product = $this->product(['list_on_facebook' => true]);
+
+        (new SyncProductToFacebookCatalog($product->id))->handle();
+
+        Http::assertNothingSent();
+        $this->assertSame(0, ProductFacebookListing::where('product_id', $product->id)->count());
+    }
+
+    public function test_each_team_pushes_into_its_own_catalog(): void
+    {
+        Http::fake(['graph.facebook.com/*' => Http::response(['handles' => ['h']], 200)]);
+        Queue::fake();
+
+        $first = $this->connectTeam('CAT-ONE');
+        $second = $this->connectTeam('CAT-TWO');
+
+        $this->team = $first->team;
+        $productOne = $this->product(['list_on_facebook' => true]);
+
+        $this->team = $second->team;
+        $productTwo = $this->product(['list_on_facebook' => true]);
+
+        (new SyncProductToFacebookCatalog($productOne->id))->handle();
+        (new SyncProductToFacebookCatalog($productTwo->id))->handle();
+
+        Http::assertSent(fn ($request) => str_contains($request->url(), '/CAT-ONE/items_batch')
+            && $request->data()['requests'][0]['data']['id'] === 'product-'.$productOne->id);
+
+        Http::assertSent(fn ($request) => str_contains($request->url(), '/CAT-TWO/items_batch')
+            && $request->data()['requests'][0]['data']['id'] === 'product-'.$productTwo->id);
+
+        $this->assertSame(1, ProductFacebookListing::where('product_id', $productOne->id)->count());
+        $this->assertSame(1, ProductFacebookListing::where('product_id', $productTwo->id)->count());
+    }
+
+    public function test_an_unattributed_product_syncs_nothing(): void
+    {
+        Http::fake();
+        Queue::fake();
+
+        $this->connectTeam();
+
+        // team_id null is the state IsTenantModel leaves a row nothing could
+        // attribute. It belongs to no merchant, so it reaches no catalogue.
+        $product = Product::factory()->create(['list_on_facebook' => true, 'team_id' => null]);
+
+        (new SyncProductToFacebookCatalog($product->id))->handle();
+
+        Http::assertNothingSent();
+        $this->assertSame(0, ProductFacebookListing::where('product_id', $product->id)->count());
+    }
+
+    public function test_the_token_is_encrypted_at_rest(): void
+    {
+        $connection = $this->connectTeam();
+
+        $stored = DB::table('facebook_connections')
+            ->where('id', $connection->id)
+            ->value('access_token');
+
+        $this->assertNotSame('test-token', $stored);
+        $this->assertSame('test-token', $connection->fresh()->access_token);
+    }
+}

--- a/tests/Feature/FacebookCatalogUnlistTest.php
+++ b/tests/Feature/FacebookCatalogUnlistTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\RemoveProductFromFacebookCatalog;
+use App\Jobs\SyncProductToFacebookCatalog;
+use App\Models\Product;
+use App\Models\ProductFacebookListing;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use RuntimeException;
+use Tests\Feature\Concerns\ConnectsAFacebookCatalog;
+use Tests\TestCase;
+
+class FacebookCatalogUnlistTest extends TestCase
+{
+    use ConnectsAFacebookCatalog;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connectedTeam();
+    }
+
+    /** A listed Product with an existing Listing, built without firing sync. */
+    private function listedWithListing(int $inventory = 5): Product
+    {
+        $product = $this->product(['inventory_count' => $inventory]);
+
+        $product->facebookListings()->create([
+            'retailer_id' => 'product-'.$product->id,
+            'status' => 'active',
+        ]);
+
+        $product->list_on_facebook = true;
+        $product->saveQuietly();
+
+        return $product;
+    }
+
+    public function test_toggling_off_enqueues_removal(): void
+    {
+        $product = $this->listedWithListing();
+
+        Queue::fake();
+        $product->update(['list_on_facebook' => false]);
+
+        Queue::assertPushed(
+            RemoveProductFromFacebookCatalog::class,
+            fn (RemoveProductFromFacebookCatalog $job) => $job->retailerIds === ['product-'.$product->id]
+                && $job->teamId === $this->team->id
+        );
+        Queue::assertNotPushed(SyncProductToFacebookCatalog::class);
+    }
+
+    public function test_deleting_a_listed_product_enqueues_removal(): void
+    {
+        $product = $this->listedWithListing();
+
+        Queue::fake();
+        $product->delete();
+
+        Queue::assertPushed(
+            RemoveProductFromFacebookCatalog::class,
+            fn (RemoveProductFromFacebookCatalog $job) => $job->retailerIds === ['product-'.$product->id]
+        );
+    }
+
+    public function test_force_deleting_still_enqueues_removal_before_cascade(): void
+    {
+        $product = $this->listedWithListing();
+
+        Queue::fake();
+        $product->forceDelete();
+
+        // `deleting` fires before the FK cascade wipes the listing rows, so the
+        // retailer ids are still there to capture.
+        Queue::assertPushed(
+            RemoveProductFromFacebookCatalog::class,
+            fn (RemoveProductFromFacebookCatalog $job) => $job->retailerIds === ['product-'.$product->id]
+        );
+    }
+
+    public function test_removal_job_sends_delete_and_marks_listing_deleted(): void
+    {
+        Http::fake(['graph.facebook.com/*' => Http::response(['handles' => ['h1']], 200)]);
+        $product = $this->listedWithListing();
+
+        (new RemoveProductFromFacebookCatalog(['product-'.$product->id], $this->team->id))->handle();
+
+        Http::assertSent(function ($request) use ($product) {
+            $req = $request->data()['requests'][0];
+
+            return str_contains($request->url(), '/CAT123/items_batch')
+                && $req['method'] === 'DELETE'
+                && $req['data']['id'] === 'product-'.$product->id;
+        });
+
+        $this->assertSame('deleted', ProductFacebookListing::where('product_id', $product->id)->sole()->status);
+    }
+
+    public function test_removal_failure_throws_for_retry(): void
+    {
+        Http::fake(['graph.facebook.com/*' => Http::response('boom', 500)]);
+        $product = $this->listedWithListing();
+
+        $this->expectException(RuntimeException::class);
+        (new RemoveProductFromFacebookCatalog(['product-'.$product->id], $this->team->id))->handle();
+    }
+
+    public function test_stock_hitting_zero_syncs_out_of_stock_and_keeps_item(): void
+    {
+        $product = $this->listedWithListing(inventory: 3);
+
+        Queue::fake();
+        $ok = $product->adjustInventory(-3, 'sold out');
+
+        $this->assertTrue($ok);
+        // Selling out is an availability flip, NOT a removal.
+        Queue::assertPushed(
+            SyncProductToFacebookCatalog::class,
+            fn (SyncProductToFacebookCatalog $job) => $job->productId === $product->id
+        );
+        Queue::assertNotPushed(RemoveProductFromFacebookCatalog::class);
+    }
+
+    public function test_sold_out_push_sets_out_of_stock_availability_not_delete(): void
+    {
+        Http::fake(['graph.facebook.com/*' => Http::response(['handles' => ['h1']], 200)]);
+        $product = $this->listedWithListing(inventory: 0);
+
+        (new SyncProductToFacebookCatalog($product->id))->handle();
+
+        Http::assertSent(function ($request) {
+            $req = $request->data()['requests'][0];
+
+            return $req['method'] === 'UPDATE'
+                && $req['data']['availability'] === 'out of stock';
+        });
+    }
+
+    public function test_restock_enqueues_sync(): void
+    {
+        $product = $this->listedWithListing(inventory: 0);
+
+        Queue::fake();
+        $product->adjustInventory(2, 'restock');
+
+        Queue::assertPushed(SyncProductToFacebookCatalog::class);
+    }
+}

--- a/tests/Feature/FacebookCatalogVariantTest.php
+++ b/tests/Feature/FacebookCatalogVariantTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\SyncProductToFacebookCatalog;
+use App\Models\Product;
+use App\Models\ProductFacebookListing;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Tests\Feature\Concerns\ConnectsAFacebookCatalog;
+use Tests\TestCase;
+
+class FacebookCatalogVariantTest extends TestCase
+{
+    use ConnectsAFacebookCatalog;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connectedTeam();
+    }
+
+    /** A listed Product with two Variants, built without firing sync. */
+    private function variantProduct(int $stockA = 5, int $stockB = 5): Product
+    {
+        $product = $this->product(['price' => 20]);
+
+        $product->variants()->create(['sku' => 'A-'.$product->id, 'title' => 'Small', 'price' => 10, 'inventory_quantity' => $stockA, 'position' => 1]);
+        $product->variants()->create(['sku' => 'B-'.$product->id, 'title' => 'Large', 'price' => 15, 'inventory_quantity' => $stockB, 'position' => 2]);
+
+        $product->list_on_facebook = true;
+        $product->saveQuietly();
+
+        return $product->fresh();
+    }
+
+    private function runSync(Product $product): void
+    {
+        (new SyncProductToFacebookCatalog($product->id))->handle();
+    }
+
+    public function test_each_variant_is_its_own_item_sharing_one_item_group(): void
+    {
+        Http::fake(['graph.facebook.com/*' => Http::response(['handles' => ['h']], 200)]);
+        $product = $this->variantProduct();
+        [$v1, $v2] = $product->variants->all();
+
+        $this->runSync($product);
+
+        Http::assertSent(function ($request) use ($product, $v1, $v2) {
+            $requests = $request->data()['requests'];
+            $ids = array_column(array_column($requests, 'data'), 'id');
+            $groups = array_column(array_column($requests, 'data'), 'item_group_id');
+
+            return count($requests) === 2
+                && in_array('variant-'.$v1->id, $ids, true)
+                && in_array('variant-'.$v2->id, $ids, true)
+                && $groups === ['product-'.$product->id, 'product-'.$product->id];
+        });
+
+        $this->assertSame(2, ProductFacebookListing::where('product_id', $product->id)->whereNotNull('product_variant_id')->count());
+        $this->assertSame('active', ProductFacebookListing::where('product_variant_id', $v1->id)->sole()->status);
+    }
+
+    public function test_per_variant_status_is_recorded_independently(): void
+    {
+        $product = $this->variantProduct();
+        [$v1, $v2] = $product->variants->all();
+
+        Http::fake(['graph.facebook.com/*' => Http::response([
+            'validation_status' => [
+                ['retailer_id' => 'variant-'.$v2->id, 'errors' => [['message' => 'missing image']]],
+            ],
+        ], 200)]);
+
+        $this->runSync($product);
+
+        $this->assertSame('active', ProductFacebookListing::where('product_variant_id', $v1->id)->sole()->status);
+        $errored = ProductFacebookListing::where('product_variant_id', $v2->id)->sole();
+        $this->assertSame('error', $errored->status);
+        $this->assertNotNull($errored->errors);
+    }
+
+    public function test_a_variant_change_enqueues_a_sync(): void
+    {
+        $product = $this->variantProduct();
+
+        Queue::fake();
+        $product->variants->first()->update(['price' => 12]);
+
+        Queue::assertPushed(
+            SyncProductToFacebookCatalog::class,
+            fn (SyncProductToFacebookCatalog $job) => $job->productId === $product->id
+        );
+    }
+
+    public function test_sold_out_is_per_variant(): void
+    {
+        Http::fake(['graph.facebook.com/*' => Http::response(['handles' => ['h']], 200)]);
+        $product = $this->variantProduct(stockA: 0, stockB: 4);
+        [$v1, $v2] = $product->variants->all();
+
+        $this->runSync($product);
+
+        Http::assertSent(function ($request) use ($v1, $v2) {
+            $byId = [];
+
+            foreach ($request->data()['requests'] as $r) {
+                $byId[$r['data']['id']] = $r['data']['availability'];
+            }
+
+            return $byId['variant-'.$v1->id] === 'out of stock'
+                && $byId['variant-'.$v2->id] === 'in stock';
+        });
+    }
+}

--- a/tests/Feature/StoreBackfillTest.php
+++ b/tests/Feature/StoreBackfillTest.php
@@ -57,6 +57,13 @@ class StoreBackfillTest extends TestCase
         // rest of this wave followed.
         'ab_tests', 'cart_recovery_campaigns', 'customer_groups', 'customer_segments',
         'inventory_locations', 'recommendation_rules', 'seo_settings', 'taxonomy_categories',
+
+        // A Meta Business belongs to the merchant, not to one of their
+        // shopfronts, and #808 asked for a connection per team. Nothing on a
+        // storefront reads it — the catalogue push is a queued job — so a store
+        // scope here would control a path nobody walks. It gets a store grain
+        // if a merchant ever needs two Catalogs.
+        'facebook_connections',
     ];
 
     public function test_every_team_scoped_table_has_a_store_id(): void

--- a/tests/Unit/FacebookCatalogTest.php
+++ b/tests/Unit/FacebookCatalogTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\Facebook\FacebookCatalog;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class FacebookCatalogTest extends TestCase
+{
+    private function client(string $token = 'test-token', string $catalog = '123456', string $version = 'v21.0'): FacebookCatalog
+    {
+        return new FacebookCatalog($token, $catalog, 'biz-1', $version);
+    }
+
+    public function test_connection_succeeds_and_reports_catalog_name(): void
+    {
+        Http::fake([
+            'graph.facebook.com/*' => Http::response(['id' => '123456', 'name' => 'My Store Catalog'], 200),
+        ]);
+
+        $result = $this->client()->testConnection();
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('My Store Catalog', $result['message']);
+    }
+
+    public function test_connection_sends_bearer_token_to_versioned_catalog_node(): void
+    {
+        Http::fake([
+            'graph.facebook.com/*' => Http::response(['id' => '123456', 'name' => 'C'], 200),
+        ]);
+
+        $this->client(version: 'v20.0')->testConnection();
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('Authorization', 'Bearer test-token')
+                && str_contains($request->url(), '/v20.0/123456')
+                && str_contains($request->url(), 'fields=id%2Cname');
+        });
+    }
+
+    public function test_connection_reports_meta_error_message_on_failure(): void
+    {
+        Http::fake([
+            'graph.facebook.com/*' => Http::response(
+                ['error' => ['message' => 'Invalid OAuth access token.']],
+                400
+            ),
+        ]);
+
+        $result = $this->client()->testConnection();
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('Invalid OAuth access token.', $result['message']);
+    }
+
+    public function test_connection_requires_credentials_before_calling_meta(): void
+    {
+        Http::fake();
+
+        $result = $this->client(token: '')->testConnection();
+
+        $this->assertFalse($result['success']);
+        Http::assertNothingSent();
+    }
+}


### PR DESCRIPTION
Ports the Facebook Catalog sync from the private `phonexchange` prototype, which is what issue #808 asks for, and re-shapes it for this tenancy.

Marketplace itself has no public API. The Meta Commerce Catalog does, and it is what a Page Shop, Instagram Shopping and Marketplace listings all read, so the Catalog is what this addresses.

## What changed from the prototype

The prototype was single-tenant and kept the credentials in a spatie settings group. Here that would mean one Meta Business for the whole deployment — every merchant publishing into the platform's catalogue. So:

- `FacebookConnection` is a model with `IsTenantModel` and a unique index on `team_id`. One Catalog per merchant.
- A Product whose Team has no connection syncs nothing. It never falls back to another merchant's catalogue, and an unattributed Product (`team_id` null) reaches none.
- `ProductFacebookListing` has no `team_id`: its owner is its Product's, the way `ProductVariant`'s is.
- Prices go out in `ecommerce.default_currency`, and product links use the Store's own primary channel host rather than `APP_URL` — a queued job has no request to resolve a channel from.

## Behaviour

- Saving a Product with `list_on_facebook` queues an idempotent `items_batch` upsert keyed by a stable retailer id, so a re-push updates rather than duplicates.
- A Product with Variants pushes one item per Variant sharing an `item_group_id`; a simple Product pushes one item.
- Selling out flips availability and keeps the item. Unlisting or deleting sends a real DELETE — `deleting`, not `deleted`, so the retailer ids are read before a force delete cascades them away.
- `increment()`/`decrement()` bypass `saved`, so `adjustInventory()` queues the push itself.
- Transient failures record the error on the Listing and throw, so the queue retries with backoff.
- `facebook:reconcile-catalog` runs hourly, per connection, reading Meta-owned status back — Meta reviews items after upload and the local status otherwise goes stale.

## Panel

`FacebookConnectionResource` on the merchant panel, with a "Test connection" action that checks what is on screen rather than what is saved. It has a policy, because the App panel runs `strictAuthorization`, and the six permissions it needs are in `PermissionsTableSeeder`. The `List on Facebook` toggle on `ProductResource` is hidden until the Team has a connection.

## Tests

`FacebookCatalogTenancyTest` covers the part that is new here — own catalogue or none, and the token encrypted at rest. The rest port the prototype's suite: sync, variants, unlist/sold-out, reconcile.

Nothing runs locally (no PHP or Composer on the machine this was written on), so this PR is the first run of the suite.
